### PR TITLE
fix: overview card resizing on narrow screens

### DIFF
--- a/src/features/Overview/StatusCard/index.tsx
+++ b/src/features/Overview/StatusCard/index.tsx
@@ -10,8 +10,8 @@ import { voteDistanceAtom, voteStateAtom } from "../../../api/atoms";
 
 export default function SlotStatusCard() {
   return (
-    <Card>
-      <Flex direction="column" height="100%" gap="2">
+    <Card style={{ flexGrow: 1 }}>
+      <Flex direction="column" height="100%" gap="2" align="start">
         <CardHeader text="Status" />
         <div className={styles.statRow}>
           <CurrentSlotText />

--- a/src/features/Overview/TransactionsCard/index.tsx
+++ b/src/features/Overview/TransactionsCard/index.tsx
@@ -7,7 +7,7 @@ import TransactionStats from "./TransactionStats";
 
 export default function TransactionsCard() {
   return (
-    <Card style={{ flex: 1 }}>
+    <Card style={{ flex: 100 }}>
       <Flex direction="column" height="100%" gap="2">
         <CardHeader text="Transactions" />
         <Flex gap="4" flexGrow="1">

--- a/src/features/Overview/ValidatorsCard/index.tsx
+++ b/src/features/Overview/ValidatorsCard/index.tsx
@@ -15,7 +15,7 @@ export default function ValidatorsCard() {
   const delinquentLabel = formatNumberLamports(peerStats.delinquentStake);
 
   return (
-    <Card>
+    <Card style={{ flexGrow: 1 }}>
       <Flex direction="column" height="100%" gap="2">
         <CardHeader text="Validators" />
         <Flex gap="2" flexGrow="1">
@@ -49,7 +49,7 @@ export default function ValidatorsCard() {
               />
             </div>
           </Flex>
-          <Box flexGrow="1" style={{ minWidth: "200px" }}>
+          <Box style={{ minWidth: "200px" }}>
             <Chart
               activeStake={peerStats.activeStake}
               delinquentStake={peerStats.delinquentStake}


### PR DESCRIPTION
# fix: overview card resizing on narrow screens

On wide screens, `SlotStatusCard`, `TransactionCard`, and `ValidatorsCard` should be displayed side-by-side. Among these, only TransactionCard should expand as the screen width increases.

If the screen is narrower, `SlotStatusCard` should appear first in the row. It can shrink down to its minimum width if necessary but won't grow beyond a certain size. `TransactionCard` should stretch to fill the remaining space in the row. `ValidatorsCard` should move to the second row, where it can also shrink to its minimum width but won't grow beyond a certain size.

On very narrow screens, when all three cards are stacked vertically, they should all stretch to fit the width of the container.

We added support for the third behavior in this PR