### PR TITLE
fix: leader schedule slot card grid styling

### DIFF
--- a/src/features/LeaderSchedule/Slots/slotCardGrid.module.css
+++ b/src/features/LeaderSchedule/Slots/slotCardGrid.module.css
@@ -11,6 +11,9 @@
   & * {
     touch-action: pan-x;
   }
+  scrollbar-width: thin;
+  scrollbar-color: #cbcbcb20 #cbcbcb01;
+  width: 100%;
 }
 
 .header-text {


### PR DESCRIPTION
# fix: leader schedule slot card grid styling

For narrow screens where the grid has not yet wrapped, the scrollbar appeared too chunky, so its width has been reduced. Additionally, on narrow screens, when the slots grid wraps to the next line, it has been fixed to occupy the full width of the card.