### PR TITLE
chore: use dev and prod .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+# Env files
+.env
+.env.*
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@
 
 # Running locally
 
-- Run `cp .env.example .env.local`
+- Run `cp .env.example .env.development`
 - Run `npm run dev`
 
 ## Build
 
+- Run `cp .env.example .env.production`
 - Run `npm ci`
 - Run `npm run build`
 - Serve static assets in `./dist` with preferred tool. Ex. `npx run serve`

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:dev": "tsc && vite build --mode development",
     "test": "vitest",
     "lint": "prettier --check . && eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "prettier --write .",

--- a/src/api/ws/ConnectionProvider.tsx
+++ b/src/api/ws/ConnectionProvider.tsx
@@ -12,12 +12,13 @@ import {
   messageEventType,
 } from "./ConnectionContext";
 
-const VITE_WEBSOCKET_URL = (
-  import.meta.env.VITE_WEBSOCKET_URL as string
-)?.trim();
+const VITE_WEBSOCKET_URL = import.meta.env.PROD
+  ? null
+  : (import.meta.env.VITE_WEBSOCKET_URL as string)?.trim();
 
 export function ConnectionProvider({ children }: PropsWithChildren) {
   const [ctxValue, _setCtxValue] = useState(defaultCtxValue);
+
   // connect to current host via websocket
   const websocketUrl = VITE_WEBSOCKET_URL
     ? VITE_WEBSOCKET_URL


### PR DESCRIPTION
- use `.env.production` and `.env.development` instead of `.env.local`.
- add `build:dev` script.