### PR TITLE
only transmit requested and consumed cus

### DIFF
--- a/src/api/entities.ts
+++ b/src/api/entities.ts
@@ -215,7 +215,6 @@ export const slotTransactionsSchema = z.object({
   txn_mb_start_timestamps_nanos: z.coerce.bigint().array(),
   txn_mb_end_timestamps_nanos: z.coerce.bigint().array(),
   txn_compute_units_requested: z.number().array(),
-  txn_max_compute_units: z.number().array(),
   txn_compute_units_consumed: z.number().array(),
   txn_priority_fee: z.coerce.bigint().array(),
   txn_tips: z.coerce.bigint().array(),

--- a/src/features/Overview/SlotPerformance/ComputeUnitsCard/Chart.tsx
+++ b/src/features/Overview/SlotPerformance/ComputeUnitsCard/Chart.tsx
@@ -99,8 +99,8 @@ function getChartData(computeUnits: ComputeUnits): ChartData[] {
       const txn_idx = event.txn_idx;
       const cus_delta = computeUnits.txn_landed[txn_idx]
         ? event.start
-          ? computeUnits.txn_max_compute_units[txn_idx]
-          : -computeUnits.txn_max_compute_units[txn_idx] +
+          ? computeUnits.txn_compute_units_requested[txn_idx]
+          : -computeUnits.txn_compute_units_requested[txn_idx] +
             computeUnits.txn_compute_units_consumed[txn_idx]
         : 0;
       const priority_fee =


### PR DESCRIPTION
Doesn't break the frontend, but the slot progression chart will have slightly wrong CUs until the correct backend commit is deployed.