### PR TITLE
change color of upcoming slot text in leader schedule

### DIFF
--- a/src/features/LeaderSchedule/Slots/UpcomingSlotCard.tsx
+++ b/src/features/LeaderSchedule/Slots/UpcomingSlotCard.tsx
@@ -91,7 +91,7 @@ function UpcomingSlotBody({
       </Flex>
       <Text className={styles.pubkeyText}>{pubkey}</Text>
       <Flex flexGrow="1" justify="center">
-        <Text className={styles.slot}>{slot}</Text>
+        <Text>{slot}</Text>
       </Flex>
       <TimeTillText slot={slot} />
     </Flex>
@@ -116,7 +116,7 @@ function MobileUpcomingSlotBody({
         </Text>
       </Flex>
       <Flex justify="between">
-        <Text className={styles.slot}>{slot}</Text>
+        <Text>{slot}</Text>
         <TimeTillText slot={slot} isNarrowScreen />
       </Flex>
     </Flex>

--- a/src/features/LeaderSchedule/Slots/upcomingSlot.module.css
+++ b/src/features/LeaderSchedule/Slots/upcomingSlot.module.css
@@ -3,9 +3,9 @@
   border-radius: 8px;
   border: 1px solid #1c1e2b;
   background: #101123;
+  color: #b2bcc9;
 
   .name-text {
-    color: #b2bcc9;
     width: 240px;
     overflow: hidden;
     white-space: nowrap;
@@ -13,7 +13,6 @@
   }
 
   .pubkey-text {
-    color: #b2bcc9;
     min-width: 390px;
     overflow: hidden;
     white-space: nowrap;
@@ -33,19 +32,9 @@
   &.one-away {
     border: 1px solid #295060;
     background: #142432;
-    /* opacity: 1.2 */
-  }
-
-  .next-leader {
-    color: #41b9d3;
-  }
-
-  .slot {
-    color: #72aff6;
   }
 
   .time-till {
-    color: #b2bcc9;
     min-width: 250px;
 
     &.narrow-screen {


### PR DESCRIPTION
In leader schedule, changed the text color from blue to grey to not have the upcoming card slot text be confused with the clickable linked blue past card slot text