### PR TITLE
chore: update slot progression chart start line color

### DIFF
--- a/src/colors.ts
+++ b/src/colors.ts
@@ -89,7 +89,7 @@ export const computeUnitsColor = "#D19DFF";
 export const feesColor = "#4CCCE6";
 export const tipsColor = "#1FD8A4";
 export const elapsedTimeColor = "#6A6A6E";
-export const revenueStartLineColor = "#FFFFFF";
+export const startLineColor = secondaryTextColor;
 
 // transaction bars
 export const successToggleColor = "#30A46C";

--- a/src/features/Overview/SlotPerformance/ComputeUnitsCard/CuChart.tsx
+++ b/src/features/Overview/SlotPerformance/ComputeUnitsCard/CuChart.tsx
@@ -364,12 +364,12 @@ export default function CuChart({
       ],
       legend: { show: false },
       plugins: [
+        startLinePlugin(),
         cuRefAreaPlugin({
           slotTransactionsRef,
           maxComputeUnitsRef,
           bankTileCountRef,
         }),
-        startLinePlugin(),
         timeScaleDragPlugin(),
         wheelZoomPlugin({ factor: 0.75 }),
         cuTooltipPlugin(setTooltipData),

--- a/src/features/Overview/SlotPerformance/ComputeUnitsCard/CuChartInfoIcon.tsx
+++ b/src/features/Overview/SlotPerformance/ComputeUnitsCard/CuChartInfoIcon.tsx
@@ -1,6 +1,7 @@
 import { InfoCircledIcon } from "@radix-ui/react-icons";
 import { Tooltip } from "@radix-ui/themes";
 import styles from "./cuChartIcon.module.css";
+import { startLineColor } from "../../../../colors";
 
 export const infoIconId = "cu-chart-info-icon";
 
@@ -10,7 +11,11 @@ export default function CuChartInfoIcon() {
   return (
     <div id={infoIconId} className={styles.iconContainer}>
       <Tooltip content="The 'revenue' scheduler strategy waits until 50ms remain in the block to schedule non-bundle user transactions">
-        <InfoCircledIcon width={iconSize} height={iconSize} />
+        <InfoCircledIcon
+          width={iconSize}
+          height={iconSize}
+          color={startLineColor}
+        />
       </Tooltip>
     </div>
   );

--- a/src/features/Overview/SlotPerformance/ComputeUnitsCard/startLinePlugin.ts
+++ b/src/features/Overview/SlotPerformance/ComputeUnitsCard/startLinePlugin.ts
@@ -1,7 +1,7 @@
 import uPlot from "uplot";
 
 import { xScaleKey } from "./consts";
-import { revenueStartLineColor } from "../../../../colors";
+import { startLineColor } from "../../../../colors";
 import { getDefaultStore } from "jotai";
 import { ScheduleStrategyEnum } from "../../../../api/entities";
 import { scheduleStrategyAtom } from "../../../../api/atoms";
@@ -50,7 +50,7 @@ export function startLinePlugin(): uPlot.Plugin {
 
           ctx.beginPath();
 
-          ctx.strokeStyle = revenueStartLineColor;
+          ctx.strokeStyle = startLineColor;
           ctx.lineWidth = 5 / uPlot.pxRatio;
           ctx.setLineDash([5, 5]);
 


### PR DESCRIPTION
- Update Slot Progression chart start line color
- Draw start line before drawing bank ref area lines