### PR TITLE
fix: consistent line height

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -6,7 +6,7 @@
   font-display: optional;
   --scaling: 0.875;
   --cursor-button: pointer;
-  --line-height: normal;
+  --line-height: 1.2;
 
   /* custom tokens */
   --white-heading: #f7f8f8;


### PR DESCRIPTION
# fix: consistent line height

We noticed some discrepancies in text container heights due to using line-height: normal, which can result in different heights for certain characters and emojis, so we're using a constant instead.