### PR TITLE
feat: interactively filter bank chart

### DIFF
--- a/src/colors.ts
+++ b/src/colors.ts
@@ -265,6 +265,7 @@ export const slotDetailsDisabledSlotBorderColor = "#484D53B2";
 export const slotDetailsStatsPrimary = "var(--gray-11)";
 export const slotDetailsStatsSecondary = "var(--gray-10)";
 export const slotDetailsStatsTertiary = "var(--gray-12)";
+export const slotDetailsChartControlsTriggered = "#70B8FF";
 
 // slots list
 export const slotsListSlotBackgroundColor = "#070A13";

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChart.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChart.tsx
@@ -33,6 +33,7 @@ interface BarsChartProps {
   isLastChart?: boolean;
   hide?: boolean;
   isSelected?: boolean;
+  isFocused?: boolean;
 }
 
 export default function BarsChart({
@@ -41,9 +42,10 @@ export default function BarsChart({
   isLastChart,
   hide,
   isSelected,
+  isFocused,
 }: BarsChartProps) {
-  const { transactions, maxTs, focusedBankIdx } =
-    useContext(ChartControlsContext);
+  const { transactions, maxTs } = useContext(ChartControlsContext);
+
   const isFirstOrLastChart = isFirstChart || isLastChart;
   const leftAxisSize = useAtomValue(leftAxisSizeAtom) - xBuffer;
   const rightAxisSize = useAtomValue(rightAxisSizeAtom) - xBuffer;
@@ -196,7 +198,7 @@ export default function BarsChart({
             <>
               <UplotReact
                 id={getUplotId(bankIdx)}
-                className={clsx(bankIdx === focusedBankIdx && styles.focused)}
+                className={clsx(isFocused && styles.focused)}
                 options={options}
                 data={chartData}
                 onCreate={handleCreate}

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChart.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChart.tsx
@@ -1,5 +1,5 @@
 import styles from "./barsChart.module.css";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useContext, useMemo, useRef } from "react";
 import type uPlot from "uplot";
 import "uplot/dist/uPlot.min.css";
 import { txnBarsPlugin } from "./txnBarsPlugin";
@@ -21,14 +21,14 @@ import { chartAxisColor, chartGridStrokeColor } from "../../../../colors";
 import { banksXScaleKey } from "../ComputeUnitsCard/consts";
 import { clientAtom } from "../../../../atoms";
 import { getTxnBundleStats } from "../../../../transactionUtils";
+import clsx from "clsx";
+import { ChartControlsContext } from "../../../SlotDetails/ChartControlsContext";
 
 /** Buffer of the canvas past the axes of the chart to prevent the first and last tick labels from being cut off */
 const xBuffer = 20;
 
 interface BarsChartProps {
   bankIdx: number;
-  transactions: SlotTransactions;
-  maxTs: number;
   isFirstChart?: boolean;
   isLastChart?: boolean;
   hide?: boolean;
@@ -37,13 +37,13 @@ interface BarsChartProps {
 
 export default function BarsChart({
   bankIdx,
-  transactions,
-  maxTs,
   isFirstChart,
   isLastChart,
   hide,
   isSelected,
 }: BarsChartProps) {
+  const { transactions, maxTs, focusedBankIdx } =
+    useContext(ChartControlsContext);
   const isFirstOrLastChart = isFirstChart || isLastChart;
   const leftAxisSize = useAtomValue(leftAxisSizeAtom) - xBuffer;
   const rightAxisSize = useAtomValue(rightAxisSizeAtom) - xBuffer;
@@ -196,6 +196,7 @@ export default function BarsChart({
             <>
               <UplotReact
                 id={getUplotId(bankIdx)}
+                className={clsx(bankIdx === focusedBankIdx && styles.focused)}
                 options={options}
                 data={chartData}
                 onCreate={handleCreate}

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChartContainer.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChartContainer.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 import type uPlot from "uplot";
 import "uplot/dist/uPlot.min.css";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
@@ -22,7 +22,14 @@ const navigationTop = clusterIndicatorHeight + headerHeight;
 export const txnBarsControlsStickyTop = navigationTop + slotNavHeight;
 
 export default function BarsChartContainer() {
-  const { hasData, transactions, maxTs } = useContext(ChartControlsContext);
+  const [focusedBankIdx, setFocusedBankIdx] = useState<number>();
+
+  const { hasData, transactions, maxTs, registerChart } =
+    useContext(ChartControlsContext);
+
+  useEffect(() => {
+    registerChart((bankIdx?: number) => setFocusedBankIdx(bankIdx));
+  }, [registerChart]);
 
   const tileCount = useAtomValue(tileCountAtom);
   const bankTileCount = tileCount["execle"];
@@ -87,6 +94,7 @@ export default function BarsChartContainer() {
               }
               isSelected={selected === bankIdx}
               hide={selected !== undefined && selected !== bankIdx}
+              isFocused={focusedBankIdx === bankIdx}
             />
           </div>
         );

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/SearchCommand.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/SearchCommand.tsx
@@ -434,8 +434,10 @@ export default function SearchCommand({ size = "lg" }: SearchCommandProps) {
                     styles.inputContainer,
                     "rt-TextFieldRoot",
                     "rt-variant-surface",
-                    size === "sm" && styles.sm,
-                    triggeredChartControl === "Search" && styles.triggered,
+                    {
+                      [styles.sm]: size === "sm",
+                      [styles.triggered]: triggeredChartControl === "Search",
+                    },
                   )}
                 >
                   <Command.Input

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/SearchCommand.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/SearchCommand.tsx
@@ -94,7 +94,7 @@ export default function SearchCommand({ size = "lg" }: SearchCommandProps) {
     focusTxn,
     resetTxnFocus,
     triggeredChartControl,
-    setTriggeredChartControl,
+    resetTriggeredChartControl,
   } = useContext(ChartControlsContext);
   const [dInputValue, setDInputValue] = useDebounce(search.text, 500);
   const [searchIdx, setSearchIdx] = useState<{
@@ -453,7 +453,7 @@ export default function SearchCommand({ size = "lg" }: SearchCommandProps) {
                       // To re-open dialog after selection if input stays focused
                       setIsOpen(true);
                     }}
-                    onBlur={() => setTriggeredChartControl(undefined)}
+                    onBlur={resetTriggeredChartControl}
                     readOnly={isInputDisabled}
                     ref={inputRef}
                   />

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/ToggleGroupControl.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/ToggleGroupControl.tsx
@@ -1,13 +1,12 @@
 import { ToggleGroup } from "radix-ui";
 import { Flex, Text } from "@radix-ui/themes";
 import styles from "./toggleGroupControl.module.css";
-import { useState } from "react";
 import clsx from "clsx";
 
 interface ToggleGroupControlProps<T extends string> {
   label?: string;
   options: T[];
-  defaultValue?: T;
+  value: T;
   onChange: (value: T) => void;
   optionColors?: Partial<Record<T, string>>;
   hasMinTextWidth?: boolean;
@@ -16,13 +15,11 @@ interface ToggleGroupControlProps<T extends string> {
 export default function ToggleGroupControl<T extends string>({
   label,
   options,
-  defaultValue,
+  value,
   onChange,
   optionColors,
   hasMinTextWidth,
 }: ToggleGroupControlProps<T>) {
-  const [value, setValue] = useState(defaultValue);
-
   return (
     <Flex align="center">
       {label && (
@@ -39,12 +36,7 @@ export default function ToggleGroupControl<T extends string>({
         type="single"
         value={value}
         aria-label={label}
-        onValueChange={(value) => {
-          if (value) {
-            setValue(value as T);
-            onChange(value as T);
-          }
-        }}
+        onValueChange={onChange}
       >
         {options.map((option) => (
           <ToggleGroup.Item

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/ToggleGroupControl.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/ToggleGroupControl.tsx
@@ -1,6 +1,7 @@
 import { ToggleGroup } from "radix-ui";
-import { Flex, Text } from "@radix-ui/themes";
+import { Flex, Text, Tooltip } from "@radix-ui/themes";
 import styles from "./toggleGroupControl.module.css";
+import chartControlStyles from "./chartControl.module.css";
 import clsx from "clsx";
 
 interface ToggleGroupControlProps<T extends string> {
@@ -8,6 +9,8 @@ interface ToggleGroupControlProps<T extends string> {
   options: T[];
   value: T;
   onChange: (value: T) => void;
+  triggered?: boolean;
+  onBlur?: (e: React.FocusEvent) => void;
   optionColors?: Partial<Record<T, string>>;
   hasMinTextWidth?: boolean;
 }
@@ -17,6 +20,8 @@ export default function ToggleGroupControl<T extends string>({
   options,
   value,
   onChange,
+  triggered,
+  onBlur,
   optionColors,
   hasMinTextWidth,
 }: ToggleGroupControlProps<T>) {
@@ -31,30 +36,39 @@ export default function ToggleGroupControl<T extends string>({
           {label}
         </Text>
       )}
-      <ToggleGroup.Root
-        className={styles.group}
-        type="single"
-        value={value}
-        aria-label={label}
-        onValueChange={onChange}
+      <Tooltip
+        className={chartControlStyles.chartControlTooltip}
+        content={`Applied "${value}"`}
+        open={!!triggered}
+        side="bottom"
       >
-        {options.map((option) => (
-          <ToggleGroup.Item
-            key={option}
-            className={styles.item}
-            value={option}
-            aria-label={option}
-          >
-            {optionColors?.[option] && (
-              <div
-                className={styles.itemColor}
-                style={{ background: optionColors[option] }}
-              />
-            )}
-            {option}
-          </ToggleGroup.Item>
-        ))}
-      </ToggleGroup.Root>
+        <ToggleGroup.Root
+          id={`${label?.toLowerCase()}-toggle-group`}
+          className={clsx(styles.group, triggered && styles.triggered)}
+          type="single"
+          value={value}
+          aria-label={label}
+          onValueChange={onChange}
+          onBlur={onBlur}
+        >
+          {options.map((option) => (
+            <ToggleGroup.Item
+              key={option}
+              className={styles.item}
+              value={option}
+              aria-label={option}
+            >
+              {optionColors?.[option] && (
+                <div
+                  className={styles.itemColor}
+                  style={{ background: optionColors[option] }}
+                />
+              )}
+              {option}
+            </ToggleGroup.Item>
+          ))}
+        </ToggleGroup.Root>
+      </Tooltip>
     </Flex>
   );
 }

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/ToggleGroupControl.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/ToggleGroupControl.tsx
@@ -5,6 +5,7 @@ import chartControlStyles from "./chartControl.module.css";
 import clsx from "clsx";
 
 interface ToggleGroupControlProps<T extends string> {
+  toggleGroupId?: string;
   label?: string;
   options: readonly T[];
   value: T;
@@ -16,6 +17,7 @@ interface ToggleGroupControlProps<T extends string> {
 }
 
 export default function ToggleGroupControl<T extends string>({
+  toggleGroupId,
   label,
   options,
   value,
@@ -43,7 +45,7 @@ export default function ToggleGroupControl<T extends string>({
         side="bottom"
       >
         <ToggleGroup.Root
-          id={`${label?.toLowerCase()}-toggle-group`}
+          id={toggleGroupId}
           className={clsx(styles.group, triggered && styles.triggered)}
           type="single"
           value={value}

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/ToggleGroupControl.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/ToggleGroupControl.tsx
@@ -5,25 +5,25 @@ import chartControlStyles from "./chartControl.module.css";
 import clsx from "clsx";
 
 interface ToggleGroupControlProps<T extends string> {
-  toggleGroupId?: string;
   label?: string;
   options: readonly T[];
   value: T;
   onChange: (value: T) => void;
-  triggered?: boolean;
-  onBlur?: (e: React.FocusEvent) => void;
+  registerOptionRef?: (value: T, element: HTMLButtonElement | null) => void;
+  isTooltipOpen?: boolean;
+  closeTooltip?: (e: React.FocusEvent) => void;
   optionColors?: Partial<Record<T, string>>;
   hasMinTextWidth?: boolean;
 }
 
 export default function ToggleGroupControl<T extends string>({
-  toggleGroupId,
   label,
   options,
   value,
   onChange,
-  triggered,
-  onBlur,
+  registerOptionRef,
+  isTooltipOpen,
+  closeTooltip,
   optionColors,
   hasMinTextWidth,
 }: ToggleGroupControlProps<T>) {
@@ -41,24 +41,24 @@ export default function ToggleGroupControl<T extends string>({
       <Tooltip
         className={chartControlStyles.chartControlTooltip}
         content={`Applied "${value}"`}
-        open={!!triggered}
+        open={!!isTooltipOpen}
         side="bottom"
       >
         <ToggleGroup.Root
-          id={toggleGroupId}
-          className={clsx(styles.group, triggered && styles.triggered)}
+          className={clsx(styles.group, isTooltipOpen && styles.tooltipOpen)}
           type="single"
           value={value}
           aria-label={label}
           onValueChange={onChange}
-          onBlur={onBlur}
         >
           {options.map((option) => (
             <ToggleGroup.Item
               key={option}
+              ref={(el) => registerOptionRef?.(option, el)}
               className={styles.item}
               value={option}
               aria-label={option}
+              onBlur={closeTooltip}
             >
               {optionColors?.[option] && (
                 <div

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/ToggleGroupControl.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/ToggleGroupControl.tsx
@@ -6,7 +6,7 @@ import clsx from "clsx";
 
 interface ToggleGroupControlProps<T extends string> {
   label?: string;
-  options: T[];
+  options: readonly T[];
   value: T;
   onChange: (value: T) => void;
   triggered?: boolean;

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/chartControl.module.css
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/chartControl.module.css
@@ -86,7 +86,7 @@
 
   :global(.rt-TooltipText) {
     font-size: 12px;
-    word-break: break-all;
+    overflow-wrap: break-word;
   }
 
   :global(.rt-TooltipArrow) {

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/chartControl.module.css
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/chartControl.module.css
@@ -79,3 +79,17 @@
   top: 4px;
   right: 4px;
 }
+
+.chart-control-tooltip {
+  background: var(--blue-11);
+  color: #111113;
+
+  :global(.rt-TooltipText) {
+    font-size: 12px;
+    word-break: break-all;
+  }
+
+  :global(.rt-TooltipArrow) {
+    fill: var(--blue-11);
+  }
+}

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/index.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/index.tsx
@@ -63,6 +63,7 @@ import { txnErrorCodeMap } from "../../../../../consts";
 import { useThrottledCallback } from "use-debounce";
 import {
   ChartControlsContext,
+  INCLUSION_FILTER_OPTIONS,
   type InclusionFilterOptions,
 } from "../../../../SlotDetails/ChartControlsContext";
 
@@ -310,7 +311,7 @@ function BundleControl({ isMobileView }: ToggleGroupControlProps) {
   return (
     <ToggleGroupControl
       label="Bundle"
-      options={["All", "Yes", "No"]}
+      options={INCLUSION_FILTER_OPTIONS}
       value={bundleFilter}
       onChange={(value) => value && updateBundleFilter(value)}
       triggered={triggeredChartControl === "Bundle"}
@@ -330,7 +331,7 @@ function LandedControl({ isMobileView }: ToggleGroupControlProps) {
   return (
     <ToggleGroupControl
       label="Landed"
-      options={["All", "Yes", "No"]}
+      options={INCLUSION_FILTER_OPTIONS}
       value={value}
       onChange={(value) => {
         if (!value) return;
@@ -353,7 +354,7 @@ function SimpleControl({ isMobileView }: ToggleGroupControlProps) {
   return (
     <ToggleGroupControl
       label="Vote"
-      options={["All", "Yes", "No"]}
+      options={INCLUSION_FILTER_OPTIONS}
       value={value}
       onChange={(value) => {
         if (!value) return;

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/index.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/index.tsx
@@ -304,7 +304,7 @@ function BundleControl({ isMobileView }: ToggleGroupControlProps) {
     bundleFilter,
     updateBundleFilter,
     triggeredChartControl,
-    setTriggeredChartControl,
+    resetTriggeredChartControl,
   } = useContext(ChartControlsContext);
 
   return (
@@ -314,7 +314,7 @@ function BundleControl({ isMobileView }: ToggleGroupControlProps) {
       value={bundleFilter}
       onChange={(value) => value && updateBundleFilter(value)}
       triggered={triggeredChartControl === "Bundle"}
-      onBlur={() => setTriggeredChartControl(undefined)}
+      onBlur={resetTriggeredChartControl}
       hasMinTextWidth={isMobileView}
     />
   );

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/index.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/index.tsx
@@ -66,6 +66,7 @@ import {
   INCLUSION_FILTER_OPTIONS,
   type InclusionFilterOptions,
 } from "../../../../SlotDetails/ChartControlsContext";
+import { bundleToggleGroupId } from "../../../../SlotDetails/DetailedSlotStats/consts";
 
 export default function ChartControls() {
   const [isMinimized, setIsMinimized] = useState(false);
@@ -310,6 +311,7 @@ function BundleControl({ isMobileView }: ToggleGroupControlProps) {
 
   return (
     <ToggleGroupControl
+      toggleGroupId={bundleToggleGroupId}
       label="Bundle"
       options={INCLUSION_FILTER_OPTIONS}
       value={bundleFilter}

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/index.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/index.tsx
@@ -300,7 +300,12 @@ function TpuControl() {
 }
 
 function BundleControl({ isMobileView }: ToggleGroupControlProps) {
-  const { bundleFilter, updateBundleFilter } = useContext(ChartControlsContext);
+  const {
+    bundleFilter,
+    updateBundleFilter,
+    triggeredChartControl,
+    setTriggeredChartControl,
+  } = useContext(ChartControlsContext);
 
   return (
     <ToggleGroupControl
@@ -308,6 +313,8 @@ function BundleControl({ isMobileView }: ToggleGroupControlProps) {
       options={["All", "Yes", "No"]}
       value={bundleFilter}
       onChange={(value) => value && updateBundleFilter(value)}
+      triggered={triggeredChartControl === "Bundle"}
+      onBlur={() => setTriggeredChartControl(undefined)}
       hasMinTextWidth={isMobileView}
     />
   );

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/searchCommand.module.css
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/searchCommand.module.css
@@ -131,3 +131,8 @@
     }
   }
 }
+
+.triggered {
+  outline-offset: -1px;
+  outline: 2px solid var(--slot-details-chart-controls-triggered) !important;
+}

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/searchCommand.module.css
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/searchCommand.module.css
@@ -132,7 +132,7 @@
   }
 }
 
-.triggered {
+.tooltip-open {
   outline-offset: -1px;
   outline: 2px solid var(--slot-details-chart-controls-triggered) !important;
 }

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/toggleGroupControl.module.css
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/toggleGroupControl.module.css
@@ -11,6 +11,14 @@
   background-color: var(--mauve-6);
   border-radius: 4px;
   box-shadow: 0 2px 10px var(--black-a7);
+
+  &.triggered {
+    box-shadow: 0 0 0 2px var(--slot-details-chart-controls-triggered);
+
+    .item:focus-visible {
+      box-shadow: unset;
+    }
+  }
 }
 
 .item {
@@ -49,9 +57,9 @@
     font-weight: 510;
   }
 
-  &:focus {
+  &:focus-visible {
     position: relative;
-    box-shadow: 0 0 0 2px black;
+    box-shadow: 0 0 0 2px var(--focus-8);
   }
 
   .item-color {

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/toggleGroupControl.module.css
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/toggleGroupControl.module.css
@@ -12,7 +12,7 @@
   border-radius: 4px;
   box-shadow: 0 2px 10px var(--black-a7);
 
-  &.triggered {
+  &.tooltip-open {
     box-shadow: 0 0 0 2px var(--slot-details-chart-controls-triggered);
 
     .item:focus-visible {

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/useChartControl.ts
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/useChartControl.ts
@@ -1,0 +1,37 @@
+import { useCallback, useContext, useEffect, useState } from "react";
+import {
+  ChartControlsContext,
+  type ChartControlProps,
+} from "../../../../SlotDetails/ChartControlsContext";
+
+export default function useChartControl({
+  chartControl,
+  handleExternalValueUpdate,
+}: ChartControlProps) {
+  const { registerChartControl } = useContext(ChartControlsContext);
+
+  const [isTooltipOpen, setIsTooltipOpen] = useState<boolean>(false);
+  const closeTooltip = useCallback(() => setIsTooltipOpen(false), []);
+
+  /**
+   * `handleExternalValueUpdate`'s argument type depends on `chartControl`,
+   * but Typescript loses that relationship when we destructure props,
+   * so we need to cast it to accept `value`
+   */
+  const handleUpdateAndShowTooltip = useCallback(
+    (value: Parameters<typeof handleExternalValueUpdate>[0]) => {
+      (handleExternalValueUpdate as (v: typeof value) => void)(value);
+      setIsTooltipOpen(true);
+    },
+    [handleExternalValueUpdate],
+  );
+
+  useEffect(() => {
+    registerChartControl({
+      chartControl,
+      handleExternalValueUpdate: handleUpdateAndShowTooltip,
+    });
+  }, [chartControl, registerChartControl, handleUpdateAndShowTooltip]);
+
+  return { isTooltipOpen, closeTooltip };
+}

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/barsChart.module.css
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/barsChart.module.css
@@ -28,3 +28,9 @@
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
   }
 }
+
+.focused {
+  :global(.u-over) {
+    border: 1px solid var(--focused-border-color);
+  }
+}

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/consts.ts
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/consts.ts
@@ -52,3 +52,11 @@ export const enum FilterEnum {
 }
 
 export const txnBarsUplotIdPrefix = "bank-";
+
+export const enum SearchMode {
+  TxnSignature = "Txn Sig",
+  Error = "Error",
+  Income = "Income",
+  Ip = "IPv4",
+  Tpu = "TPU",
+}

--- a/src/features/SlotDetails/ChartControlsContext.tsx
+++ b/src/features/SlotDetails/ChartControlsContext.tsx
@@ -12,15 +12,20 @@ export type ChartControls = {
   updateBundleFilter: (
     value: ChartControls["bundleFilter"],
     scroll?: boolean,
+    externalTrigger?: boolean,
   ) => void;
   search: { mode: SearchMode; text: string };
   updateSearch: (
     value: { mode?: SearchMode; text?: string },
-    bankIdx?: number,
+    externalTrigger?: boolean,
   ) => void;
   focusTxn: (txnIdx: number) => void;
   resetTxnFocus: () => void;
   focusedBankIdx?: number;
+  triggeredChartControl?: "Bundle" | "Search";
+  setTriggeredChartControl: (
+    value: ChartControls["triggeredChartControl"],
+  ) => void;
 };
 
 export const DEFAULT_CHART_CONTROLS_CONTEXT: ChartControls = {
@@ -57,6 +62,7 @@ export const DEFAULT_CHART_CONTROLS_CONTEXT: ChartControls = {
   updateSearch: () => {},
   focusTxn: () => {},
   resetTxnFocus: () => {},
+  setTriggeredChartControl: () => {},
 };
 
 export const ChartControlsContext = createContext<ChartControls>(

--- a/src/features/SlotDetails/ChartControlsContext.tsx
+++ b/src/features/SlotDetails/ChartControlsContext.tsx
@@ -2,7 +2,8 @@ import { createContext } from "react";
 import { SearchMode } from "../Overview/SlotPerformance/TransactionBarsCard/consts";
 import type { SlotTransactions } from "../../api/types";
 
-export type InclusionFilterOptions = "All" | "Yes" | "No";
+export const INCLUSION_FILTER_OPTIONS = ["All", "Yes", "No"] as const;
+export type InclusionFilterOptions = (typeof INCLUSION_FILTER_OPTIONS)[number];
 
 export type ChartControls = {
   hasData: boolean;

--- a/src/features/SlotDetails/ChartControlsContext.tsx
+++ b/src/features/SlotDetails/ChartControlsContext.tsx
@@ -12,13 +12,12 @@ export type ChartControls = {
   bundleFilter: InclusionFilterOptions;
   updateBundleFilter: (
     value: ChartControls["bundleFilter"],
-    scroll?: boolean,
-    externalTrigger?: boolean,
+    options?: { scroll?: boolean; externalTrigger?: boolean },
   ) => void;
   search: { mode: SearchMode; text: string };
   updateSearch: (
     value: { mode?: SearchMode; text?: string },
-    externalTrigger?: boolean,
+    options?: { externalTrigger?: boolean },
   ) => void;
   focusTxn: (txnIdx: number) => void;
   resetTxnFocus: () => void;

--- a/src/features/SlotDetails/ChartControlsContext.tsx
+++ b/src/features/SlotDetails/ChartControlsContext.tsx
@@ -23,9 +23,7 @@ export type ChartControls = {
   resetTxnFocus: () => void;
   focusedBankIdx?: number;
   triggeredChartControl?: "Bundle" | "Search";
-  setTriggeredChartControl: (
-    value: ChartControls["triggeredChartControl"],
-  ) => void;
+  resetTriggeredChartControl: () => void;
 };
 
 export const DEFAULT_CHART_CONTROLS_CONTEXT: ChartControls = {
@@ -62,7 +60,7 @@ export const DEFAULT_CHART_CONTROLS_CONTEXT: ChartControls = {
   updateSearch: () => {},
   focusTxn: () => {},
   resetTxnFocus: () => {},
-  setTriggeredChartControl: () => {},
+  resetTriggeredChartControl: () => {},
 };
 
 export const ChartControlsContext = createContext<ChartControls>(

--- a/src/features/SlotDetails/ChartControlsContext.tsx
+++ b/src/features/SlotDetails/ChartControlsContext.tsx
@@ -1,0 +1,64 @@
+import { createContext } from "react";
+import { SearchMode } from "../Overview/SlotPerformance/TransactionBarsCard/consts";
+import type { SlotTransactions } from "../../api/types";
+
+export type InclusionFilterOptions = "All" | "Yes" | "No";
+
+export type ChartControls = {
+  hasData: boolean;
+  transactions: SlotTransactions;
+  maxTs: number;
+  bundleFilter: InclusionFilterOptions;
+  updateBundleFilter: (
+    value: ChartControls["bundleFilter"],
+    scroll?: boolean,
+  ) => void;
+  search: { mode: SearchMode; text: string };
+  updateSearch: (
+    value: { mode?: SearchMode; text?: string },
+    bankIdx?: number,
+  ) => void;
+  focusTxn: (txnIdx: number) => void;
+  resetTxnFocus: () => void;
+  focusedBankIdx?: number;
+};
+
+export const DEFAULT_CHART_CONTROLS_CONTEXT: ChartControls = {
+  hasData: false,
+  transactions: {
+    start_timestamp_nanos: 0n,
+    target_end_timestamp_nanos: 0n,
+    txn_mb_start_timestamps_nanos: [],
+    txn_mb_end_timestamps_nanos: [],
+    txn_compute_units_requested: [],
+    txn_compute_units_consumed: [],
+    txn_transaction_fee: [],
+    txn_priority_fee: [],
+    txn_tips: [],
+    txn_error_code: [],
+    txn_from_bundle: [],
+    txn_is_simple_vote: [],
+    txn_bank_idx: [],
+    txn_preload_end_timestamps_nanos: [],
+    txn_start_timestamps_nanos: [],
+    txn_load_end_timestamps_nanos: [],
+    txn_end_timestamps_nanos: [],
+    txn_arrival_timestamps_nanos: [],
+    txn_microblock_id: [],
+    txn_landed: [],
+    txn_signature: [],
+    txn_source_ipv4: [],
+    txn_source_tpu: [],
+  },
+  maxTs: 0,
+  bundleFilter: "All",
+  updateBundleFilter: () => {},
+  search: { mode: SearchMode.TxnSignature, text: "" },
+  updateSearch: () => {},
+  focusTxn: () => {},
+  resetTxnFocus: () => {},
+};
+
+export const ChartControlsContext = createContext<ChartControls>(
+  DEFAULT_CHART_CONTROLS_CONTEXT,
+);

--- a/src/features/SlotDetails/ChartControlsContext.tsx
+++ b/src/features/SlotDetails/ChartControlsContext.tsx
@@ -1,29 +1,35 @@
 import { createContext } from "react";
-import { SearchMode } from "../Overview/SlotPerformance/TransactionBarsCard/consts";
+import type { SearchMode } from "../Overview/SlotPerformance/TransactionBarsCard/consts";
 import type { SlotTransactions } from "../../api/types";
 
 export const INCLUSION_FILTER_OPTIONS = ["All", "Yes", "No"] as const;
 export type InclusionFilterOptions = (typeof INCLUSION_FILTER_OPTIONS)[number];
 
+export type Search = { mode: SearchMode; text: string };
+
+export type FocusBankCallback = (bankIdx?: number) => void;
+export type UpdateBundleCallback = (value: InclusionFilterOptions) => void;
+export type UpdateSeachCallback = (value: Search) => void;
+
+export type ChartControlProps =
+  | {
+      chartControl: "Bundle";
+      handleExternalValueUpdate: UpdateBundleCallback;
+    }
+  | {
+      chartControl: "Search";
+      handleExternalValueUpdate: UpdateSeachCallback;
+    };
+
 export type ChartControls = {
   hasData: boolean;
   transactions: SlotTransactions;
   maxTs: number;
-  bundleFilter: InclusionFilterOptions;
-  updateBundleFilter: (
-    value: ChartControls["bundleFilter"],
-    options?: { scroll?: boolean; externalTrigger?: boolean },
-  ) => void;
-  search: { mode: SearchMode; text: string };
-  updateSearch: (
-    value: { mode?: SearchMode; text?: string },
-    options?: { externalTrigger?: boolean },
-  ) => void;
-  focusTxn: (txnIdx: number) => void;
-  resetTxnFocus: () => void;
-  focusedBankIdx?: number;
-  triggeredChartControl?: "Bundle" | "Search";
-  resetTriggeredChartControl: () => void;
+  updateBundleFilter: UpdateBundleCallback;
+  updateSearch: UpdateSeachCallback;
+  focusBank?: FocusBankCallback;
+  registerChartControl: (props: ChartControlProps) => void;
+  registerChart: (focusBank: FocusBankCallback) => void;
 };
 
 export const DEFAULT_CHART_CONTROLS_CONTEXT: ChartControls = {
@@ -54,13 +60,10 @@ export const DEFAULT_CHART_CONTROLS_CONTEXT: ChartControls = {
     txn_source_tpu: [],
   },
   maxTs: 0,
-  bundleFilter: "All",
   updateBundleFilter: () => {},
-  search: { mode: SearchMode.TxnSignature, text: "" },
   updateSearch: () => {},
-  focusTxn: () => {},
-  resetTxnFocus: () => {},
-  resetTriggeredChartControl: () => {},
+  registerChartControl: () => {},
+  registerChart: () => {},
 };
 
 export const ChartControlsContext = createContext<ChartControls>(

--- a/src/features/SlotDetails/ChartControlsProvider.tsx
+++ b/src/features/SlotDetails/ChartControlsProvider.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useMemo, useState, type PropsWithChildren } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from "react";
 import {
   ChartControlsContext,
   DEFAULT_CHART_CONTROLS_CONTEXT,
@@ -21,6 +27,12 @@ import { txnBarsControlsStickyTop } from "../Overview/SlotPerformance/Transactio
 const desiredScaleRangeMultiplierMax = 30;
 const desiredScaleRangeMultiplierMin = 20;
 
+const DEFAULT_BUNDLE_FILTER = "All";
+const DEFAULT_SEARCH = {
+  mode: SearchMode.TxnSignature,
+  text: "",
+};
+
 export default function ChartControlsProvider({
   children,
 }: PropsWithChildren<unknown>) {
@@ -33,12 +45,10 @@ export default function ChartControlsProvider({
     selectedSlotTransactions ?? DEFAULT_CHART_CONTROLS_CONTEXT.transactions;
   const filterBundle = useSetAtom(filterBundleDataAtom);
 
-  const [bundleFilter, setBundleFilter] =
-    useState<ChartControls["bundleFilter"]>("All");
-  const [search, setSearch] = useState<ChartControls["search"]>({
-    mode: SearchMode.TxnSignature,
-    text: "",
-  });
+  const [bundleFilter, setBundleFilter] = useState<
+    ChartControls["bundleFilter"]
+  >(DEFAULT_BUNDLE_FILTER);
+  const [search, setSearch] = useState<ChartControls["search"]>(DEFAULT_SEARCH);
   const [focusedBankIdx, setFocusedBankIdx] = useState<number | undefined>();
   const [triggeredChartControl, setTriggeredChartControl] =
     useState<ChartControls["triggeredChartControl"]>();
@@ -227,6 +237,18 @@ export default function ChartControlsProvider({
     [focusTxn, ipToTxnIdx, txnSigToTxnIdx],
   );
 
+  const resetTriggeredChartControl = useCallback(() => {
+    setTriggeredChartControl(undefined);
+  }, []);
+
+  // Reset state when navigating to a different slot
+  useEffect(() => {
+    setBundleFilter(DEFAULT_BUNDLE_FILTER);
+    setSearch(DEFAULT_SEARCH);
+    setFocusedBankIdx(undefined);
+    setTriggeredChartControl(undefined);
+  }, [selectedSlot]);
+
   return (
     <ChartControlsContext.Provider
       value={
@@ -243,7 +265,7 @@ export default function ChartControlsProvider({
               resetTxnFocus,
               focusedBankIdx,
               triggeredChartControl,
-              setTriggeredChartControl,
+              resetTriggeredChartControl,
             }
           : DEFAULT_CHART_CONTROLS_CONTEXT
       }

--- a/src/features/SlotDetails/ChartControlsProvider.tsx
+++ b/src/features/SlotDetails/ChartControlsProvider.tsx
@@ -1,0 +1,227 @@
+import { useCallback, useMemo, useState, type PropsWithChildren } from "react";
+import {
+  ChartControlsContext,
+  DEFAULT_CHART_CONTROLS_CONTEXT,
+  type ChartControls,
+} from "./ChartControlsContext";
+import { SearchMode } from "../Overview/SlotPerformance/TransactionBarsCard/consts";
+import { getUplotId } from "../Overview/SlotPerformance/TransactionBarsCard/chartUtils";
+import { useAtomValue, useSetAtom } from "jotai";
+import { selectedSlotAtom } from "../Overview/SlotPerformance/atoms";
+import { useSlotQueryResponseTransactions } from "../../hooks/useSlotQuery";
+import { txnBarsUplotActionAtom } from "../Overview/SlotPerformance/TransactionBarsCard/uplotAtoms";
+import { filterBundleDataAtom } from "../Overview/SlotPerformance/TransactionBarsCard/atoms";
+import { getMaxTsWithBuffer } from "../../transactionUtils";
+import { highlightTxnIdx } from "../Overview/SlotPerformance/TransactionBarsCard/txnBarsPlugin";
+import { banksXScaleKey } from "../Overview/SlotPerformance/ComputeUnitsCard/consts";
+import { isElementFullyInView } from "../../utils";
+import { txnBarsControlsStickyTop } from "../Overview/SlotPerformance/TransactionBarsCard/BarsChartContainer";
+
+/** Multiplier to determine the desired scale zoom range for the txn (ex. scale range of 30x txn duration length) */
+const desiredScaleRangeMultiplierMax = 30;
+const desiredScaleRangeMultiplierMin = 20;
+
+export default function ChartControlsProvider({
+  children,
+}: PropsWithChildren<unknown>) {
+  const uplotAction = useSetAtom(txnBarsUplotActionAtom);
+
+  const selectedSlot = useAtomValue(selectedSlotAtom);
+  const selectedSlotTransactions =
+    useSlotQueryResponseTransactions(selectedSlot).response?.transactions;
+  const transactions =
+    selectedSlotTransactions ?? DEFAULT_CHART_CONTROLS_CONTEXT.transactions;
+  const filterBundle = useSetAtom(filterBundleDataAtom);
+
+  const [bundleFilter, setBundleFilter] =
+    useState<ChartControls["bundleFilter"]>("All");
+  const [search, setSearch] = useState<ChartControls["search"]>({
+    mode: SearchMode.TxnSignature,
+    text: "",
+  });
+  const [focusedBankIdx, setFocusedBankIdx] = useState<number | undefined>();
+
+  const maxTs = useMemo(
+    () => (transactions ? getMaxTsWithBuffer(transactions) : 0),
+    [transactions],
+  );
+
+  const updateBundleFilter = useCallback(
+    (value: ChartControls["bundleFilter"], scroll?: boolean) => {
+      setBundleFilter(value);
+      if (!transactions) return;
+      uplotAction((u, bankIdx) => {
+        filterBundle(u, transactions, bankIdx, maxTs, value);
+      });
+      if (scroll) {
+        // Targets the first bank tile since bundle filter affects all tiles
+        document
+          .getElementById(getUplotId(0))
+          ?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    },
+    [filterBundle, maxTs, transactions, uplotAction],
+  );
+
+  const focusTxn = useCallback(
+    (txnIdx: number) => {
+      if (!transactions) return;
+      const bankIdx = transactions.txn_bank_idx[txnIdx];
+
+      const chartEl = document.getElementById(getUplotId(bankIdx));
+      const canvasEl = chartEl?.getElementsByTagName("canvas")?.[0] as
+        | HTMLElement
+        | undefined;
+      if (chartEl && canvasEl) {
+        if (!isElementFullyInView(canvasEl)) {
+          canvasEl.scrollIntoView({ block: "nearest" });
+          const canvasRect = canvasEl.getBoundingClientRect();
+          const headerRect = document
+            .getElementById("transaction-bars-controls")
+            ?.getBoundingClientRect();
+          if (
+            headerRect &&
+            // Check if header is stickied
+            headerRect.top - txnBarsControlsStickyTop <= 0 &&
+            // Check if the element is hidden behind the sticky header
+            canvasRect.top < headerRect.bottom
+          ) {
+            document.getElementById("scroll-container")?.scrollBy({
+              top: -headerRect.bottom - canvasRect.top,
+            });
+          }
+        }
+        setFocusedBankIdx(bankIdx);
+      }
+
+      uplotAction((u, _bankIdx) => {
+        if (bankIdx !== _bankIdx) {
+          // To redraw non-focused banks without focus
+          u.redraw();
+          return;
+        }
+
+        const scale = u.scales[banksXScaleKey];
+        const scaleMin = scale.min ?? -Infinity;
+        const scaleMax = scale.max ?? Infinity;
+        const currentScaleRange = scaleMax - scaleMin;
+
+        const isFirstTxnInBundle =
+          transactions.txn_from_bundle[txnIdx] &&
+          transactions.txn_microblock_id[txnIdx - 1] !==
+            transactions.txn_microblock_id[txnIdx];
+        const isLastTxnInBundle =
+          transactions.txn_from_bundle[txnIdx] &&
+          transactions.txn_microblock_id[txnIdx + 1] !==
+            transactions.txn_microblock_id[txnIdx];
+
+        const startTs = Number(
+          (isFirstTxnInBundle || !transactions.txn_from_bundle[txnIdx]
+            ? transactions.txn_mb_start_timestamps_nanos[txnIdx]
+            : transactions.txn_preload_end_timestamps_nanos[txnIdx]) -
+            transactions.start_timestamp_nanos,
+        );
+        const endTs = Number(
+          (isLastTxnInBundle || !transactions.txn_from_bundle[txnIdx]
+            ? transactions.txn_mb_end_timestamps_nanos[txnIdx]
+            : transactions.txn_end_timestamps_nanos[txnIdx]) -
+            transactions.start_timestamp_nanos,
+        );
+        const desiredScaleRangeMax =
+          (endTs - startTs) * desiredScaleRangeMultiplierMax;
+        const desiredScaleRangeMin =
+          (endTs - startTs) * desiredScaleRangeMultiplierMin;
+
+        // If txn is already fully out of view, adjust the scale to include it
+        const notWithinScale = endTs < scaleMin || startTs > scaleMax;
+        // If the current scale is too large, zoom in to the desired scale
+        const scaleRangeTooLarge = currentScaleRange > desiredScaleRangeMax;
+        // If the current scale is too small, zoom out to the desired scale
+        const scaleRangeTooSmall = currentScaleRange < desiredScaleRangeMin;
+
+        // Zooms the charts into the desired scale, taking into account min/max range bounds of the data
+        // Then sets the color highlighting for that txn
+        u.batch(() => {
+          if (notWithinScale || scaleRangeTooLarge || scaleRangeTooSmall) {
+            let min = Math.max(
+              u.data[0][0],
+              startTs - desiredScaleRangeMax / 2,
+            );
+            const max = min + desiredScaleRangeMax;
+            if (max > u.data[0][u.data[0].length - 1]) {
+              min = max - desiredScaleRangeMax;
+            }
+
+            u.setScale(banksXScaleKey, { min, max });
+          }
+
+          highlightTxnIdx(txnIdx);
+        });
+      });
+    },
+    [transactions, uplotAction],
+  );
+
+  const resetTxnFocus = useCallback(() => {
+    setFocusedBankIdx(undefined);
+    highlightTxnIdx(undefined);
+  }, []);
+
+  const txnSigToTxnIdx = useCallback(
+    (txnSig: string) => {
+      if (!transactions?.txn_signature) return -1;
+      return transactions.txn_signature.indexOf(txnSig);
+    },
+    [transactions?.txn_signature],
+  );
+
+  const ipToTxnIdx = useCallback(
+    (ip: string) => {
+      if (!transactions?.txn_source_ipv4) return -1;
+      return transactions.txn_source_ipv4.indexOf(ip);
+    },
+    [transactions?.txn_source_ipv4],
+  );
+
+  const updateSearch = useCallback(
+    (value: { mode?: SearchMode; text?: string }) => {
+      setSearch((prev) => {
+        const newSearch = { ...prev, ...value };
+
+        let txnIdx = -1;
+        if (newSearch.mode === SearchMode.TxnSignature) {
+          txnIdx = txnSigToTxnIdx(newSearch.text);
+        } else if (newSearch.mode === SearchMode.Ip) {
+          txnIdx = ipToTxnIdx(newSearch.text);
+        }
+        if (txnIdx !== -1) focusTxn(txnIdx);
+
+        return newSearch;
+      });
+    },
+    [focusTxn, ipToTxnIdx, txnSigToTxnIdx],
+  );
+
+  return (
+    <ChartControlsContext.Provider
+      value={
+        selectedSlotTransactions
+          ? {
+              hasData: true,
+              transactions,
+              maxTs,
+              bundleFilter,
+              updateBundleFilter,
+              search,
+              updateSearch,
+              focusTxn,
+              resetTxnFocus,
+              focusedBankIdx,
+            }
+          : DEFAULT_CHART_CONTROLS_CONTEXT
+      }
+    >
+      {children}
+    </ChartControlsContext.Provider>
+  );
+}

--- a/src/features/SlotDetails/ChartControlsProvider.tsx
+++ b/src/features/SlotDetails/ChartControlsProvider.tsx
@@ -1,278 +1,88 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type PropsWithChildren,
-} from "react";
+import { useCallback, useMemo, useRef, type PropsWithChildren } from "react";
 import {
   ChartControlsContext,
   DEFAULT_CHART_CONTROLS_CONTEXT,
-  type ChartControls,
   type InclusionFilterOptions,
+  type Search,
+  type FocusBankCallback,
+  type UpdateBundleCallback,
+  type UpdateSeachCallback,
+  type ChartControlProps,
 } from "./ChartControlsContext";
-import { SearchMode } from "../Overview/SlotPerformance/TransactionBarsCard/consts";
-import { getUplotId } from "../Overview/SlotPerformance/TransactionBarsCard/chartUtils";
-import { useAtomValue, useSetAtom } from "jotai";
+import { useAtomValue } from "jotai";
 import { selectedSlotAtom } from "../Overview/SlotPerformance/atoms";
 import { useSlotQueryResponseTransactions } from "../../hooks/useSlotQuery";
-import { txnBarsUplotActionAtom } from "../Overview/SlotPerformance/TransactionBarsCard/uplotAtoms";
-import { filterBundleDataAtom } from "../Overview/SlotPerformance/TransactionBarsCard/atoms";
 import { getMaxTsWithBuffer } from "../../transactionUtils";
-import { highlightTxnIdx } from "../Overview/SlotPerformance/TransactionBarsCard/txnBarsPlugin";
-import { banksXScaleKey } from "../Overview/SlotPerformance/ComputeUnitsCard/consts";
-import { isElementFullyInView } from "../../utils";
-import { txnBarsControlsStickyTop } from "../Overview/SlotPerformance/TransactionBarsCard/BarsChartContainer";
-import { bundleToggleGroupId } from "./DetailedSlotStats/consts";
-
-/** Multiplier to determine the desired scale zoom range for the txn (ex. scale range of 30x txn duration length) */
-const desiredScaleRangeMultiplierMax = 30;
-const desiredScaleRangeMultiplierMin = 20;
-
-const DEFAULT_BUNDLE_FILTER: InclusionFilterOptions = "All";
-const DEFAULT_SEARCH: ChartControls["search"] = {
-  mode: SearchMode.TxnSignature,
-  text: "",
-};
 
 export default function ChartControlsProvider({ children }: PropsWithChildren) {
-  const uplotAction = useSetAtom(txnBarsUplotActionAtom);
-
   const selectedSlot = useAtomValue(selectedSlotAtom);
   const selectedSlotTransactions =
     useSlotQueryResponseTransactions(selectedSlot).response?.transactions;
   const transactions =
     selectedSlotTransactions ?? DEFAULT_CHART_CONTROLS_CONTEXT.transactions;
-  const filterBundle = useSetAtom(filterBundleDataAtom);
 
-  const [bundleFilter, setBundleFilter] = useState<InclusionFilterOptions>(
-    DEFAULT_BUNDLE_FILTER,
-  );
-  const [search, setSearch] = useState(DEFAULT_SEARCH);
-  const [focusedBankIdx, setFocusedBankIdx] = useState<number | undefined>();
-  const [triggeredChartControl, setTriggeredChartControl] =
-    useState<ChartControls["triggeredChartControl"]>();
+  const bundleUpdaterRef = useRef<UpdateBundleCallback>();
+  const searchUpdaterRef = useRef<UpdateSeachCallback>();
+  const focusBankCallbackRef = useRef<FocusBankCallback>();
 
   const maxTs = useMemo(
     () => (transactions ? getMaxTsWithBuffer(transactions) : 0),
     [transactions],
   );
 
-  const updateBundleFilter = useCallback(
-    (
-      value: ChartControls["bundleFilter"],
-      options?: { scroll?: boolean; externalTrigger?: boolean },
-    ) => {
-      setBundleFilter(value);
-      if (!transactions) return;
-
-      uplotAction((u, bankIdx) => {
-        filterBundle(u, transactions, bankIdx, maxTs, value);
-      });
-
-      if (options?.scroll) {
-        // Targets the first bank tile since bundle filter affects all tiles
-        document
-          .getElementById(getUplotId(0))
-          ?.scrollIntoView({ behavior: "smooth", block: "start" });
-      }
-
-      if (options?.externalTrigger) {
-        const bundleFilterItemEl = document
-          .getElementById(bundleToggleGroupId)
-          ?.querySelector<HTMLElement>(`button[aria-label="${value}"]`);
-        bundleFilterItemEl?.focus();
-        setTriggeredChartControl("Bundle");
-      }
-    },
-    [filterBundle, maxTs, transactions, uplotAction],
-  );
-
-  const focusTxn = useCallback(
-    (txnIdx: number) => {
-      if (!transactions) return;
-      const bankIdx = transactions.txn_bank_idx[txnIdx];
-      const chartEl = document.getElementById(getUplotId(bankIdx));
-      const canvasEl = chartEl?.getElementsByTagName("canvas")?.[0] as
-        | HTMLElement
-        | undefined;
-
-      if (chartEl && canvasEl) {
-        if (!isElementFullyInView(canvasEl)) {
-          canvasEl.scrollIntoView({ block: "nearest" });
-          const canvasRect = canvasEl.getBoundingClientRect();
-          const headerRect = document
-            .getElementById("transaction-bars-controls")
-            ?.getBoundingClientRect();
-          if (
-            headerRect &&
-            // Check if header is stickied
-            headerRect.top - txnBarsControlsStickyTop <= 0 &&
-            // Check if the element is hidden behind the sticky header
-            canvasRect.top < headerRect.bottom
-          ) {
-            document.getElementById("scroll-container")?.scrollBy({
-              top: -headerRect.bottom - canvasRect.top,
-            });
-          }
-        }
-        setFocusedBankIdx(bankIdx);
-      }
-
-      uplotAction((u, _bankIdx) => {
-        if (bankIdx !== _bankIdx) {
-          // To redraw non-focused banks without focus
-          u.redraw();
-          return;
-        }
-
-        const scale = u.scales[banksXScaleKey];
-        const scaleMin = scale.min ?? -Infinity;
-        const scaleMax = scale.max ?? Infinity;
-        const currentScaleRange = scaleMax - scaleMin;
-
-        const isFirstTxnInBundle =
-          transactions.txn_from_bundle[txnIdx] &&
-          transactions.txn_microblock_id[txnIdx - 1] !==
-            transactions.txn_microblock_id[txnIdx];
-        const isLastTxnInBundle =
-          transactions.txn_from_bundle[txnIdx] &&
-          transactions.txn_microblock_id[txnIdx + 1] !==
-            transactions.txn_microblock_id[txnIdx];
-
-        const startTs = Number(
-          (isFirstTxnInBundle || !transactions.txn_from_bundle[txnIdx]
-            ? transactions.txn_mb_start_timestamps_nanos[txnIdx]
-            : transactions.txn_preload_end_timestamps_nanos[txnIdx]) -
-            transactions.start_timestamp_nanos,
-        );
-        const endTs = Number(
-          (isLastTxnInBundle || !transactions.txn_from_bundle[txnIdx]
-            ? transactions.txn_mb_end_timestamps_nanos[txnIdx]
-            : transactions.txn_end_timestamps_nanos[txnIdx]) -
-            transactions.start_timestamp_nanos,
-        );
-        const desiredScaleRangeMax =
-          (endTs - startTs) * desiredScaleRangeMultiplierMax;
-        const desiredScaleRangeMin =
-          (endTs - startTs) * desiredScaleRangeMultiplierMin;
-
-        // If txn is already fully out of view, adjust the scale to include it
-        const notWithinScale = endTs < scaleMin || startTs > scaleMax;
-        // If the current scale is too large, zoom in to the desired scale
-        const scaleRangeTooLarge = currentScaleRange > desiredScaleRangeMax;
-        // If the current scale is too small, zoom out to the desired scale
-        const scaleRangeTooSmall = currentScaleRange < desiredScaleRangeMin;
-
-        // Zooms the charts into the desired scale, taking into account min/max range bounds of the data
-        // Then sets the color highlighting for that txn
-        u.batch(() => {
-          if (notWithinScale || scaleRangeTooLarge || scaleRangeTooSmall) {
-            let min = Math.max(
-              u.data[0][0],
-              startTs - desiredScaleRangeMax / 2,
-            );
-            const max = min + desiredScaleRangeMax;
-            if (max > u.data[0][u.data[0].length - 1]) {
-              min = max - desiredScaleRangeMax;
-            }
-
-            u.setScale(banksXScaleKey, { min, max });
-          }
-
-          highlightTxnIdx(txnIdx);
-        });
-      });
-    },
-    [transactions, uplotAction],
-  );
-
-  const resetTxnFocus = useCallback(() => {
-    setFocusedBankIdx(undefined);
-    highlightTxnIdx(undefined);
+  const updateBundleFilter = useCallback((value: InclusionFilterOptions) => {
+    bundleUpdaterRef.current?.(value);
   }, []);
 
-  const txnSigToTxnIdx = useCallback(
-    (txnSig: string) => {
-      if (!transactions?.txn_signature) return -1;
-      return transactions.txn_signature.indexOf(txnSig);
-    },
-    [transactions?.txn_signature],
-  );
-
-  const ipToTxnIdx = useCallback(
-    (ip: string) => {
-      if (!transactions?.txn_source_ipv4) return -1;
-      return transactions.txn_source_ipv4.indexOf(ip);
-    },
-    [transactions?.txn_source_ipv4],
-  );
-
-  const updateSearch = useCallback(
-    (
-      value: { mode?: SearchMode; text?: string },
-      options?: { externalTrigger?: boolean },
-    ) => {
-      setSearch((prev) => {
-        const newSearch = { ...prev, ...value };
-
-        let txnIdx = -1;
-        if (newSearch.mode === SearchMode.TxnSignature) {
-          txnIdx = txnSigToTxnIdx(newSearch.text);
-        } else if (newSearch.mode === SearchMode.Ip) {
-          txnIdx = ipToTxnIdx(newSearch.text);
-        }
-
-        if (txnIdx !== -1) {
-          focusTxn(txnIdx);
-          if (options?.externalTrigger) {
-            const searchInputEl = document
-              .getElementById("search-command-text-field")
-              ?.querySelector<HTMLElement>("input");
-            searchInputEl?.focus();
-            setTriggeredChartControl("Search");
-          }
-        }
-
-        return newSearch;
-      });
-    },
-    [focusTxn, ipToTxnIdx, txnSigToTxnIdx],
-  );
-
-  const resetTriggeredChartControl = useCallback(() => {
-    setTriggeredChartControl(undefined);
+  const updateSearch = useCallback((value: Search) => {
+    searchUpdaterRef.current?.(value);
   }, []);
 
-  // Reset state when navigating to a different slot
-  useEffect(() => {
-    setBundleFilter(DEFAULT_BUNDLE_FILTER);
-    setSearch(DEFAULT_SEARCH);
-    setFocusedBankIdx(undefined);
-    setTriggeredChartControl(undefined);
-  }, [selectedSlot]);
+  const focusBank = useCallback((bankIdx?: number) => {
+    focusBankCallbackRef.current?.(bankIdx);
+  }, []);
+
+  const registerChartControl = useCallback(
+    ({ chartControl, handleExternalValueUpdate }: ChartControlProps) => {
+      if (chartControl === "Bundle") {
+        bundleUpdaterRef.current = handleExternalValueUpdate;
+      } else if (chartControl === "Search") {
+        searchUpdaterRef.current = handleExternalValueUpdate;
+      }
+    },
+    [],
+  );
+
+  const registerChart = useCallback((focusBankCallback: FocusBankCallback) => {
+    focusBankCallbackRef.current = focusBankCallback;
+  }, []);
+
+  const value = useMemo(() => {
+    return selectedSlotTransactions
+      ? {
+          hasData: true,
+          transactions,
+          maxTs,
+          updateBundleFilter,
+          updateSearch,
+          focusBank,
+          registerChartControl,
+          registerChart,
+        }
+      : DEFAULT_CHART_CONTROLS_CONTEXT;
+  }, [
+    selectedSlotTransactions,
+    transactions,
+    maxTs,
+    updateBundleFilter,
+    updateSearch,
+    focusBank,
+    registerChartControl,
+    registerChart,
+  ]);
 
   return (
-    <ChartControlsContext.Provider
-      value={
-        selectedSlotTransactions
-          ? {
-              hasData: true,
-              transactions,
-              maxTs,
-              bundleFilter,
-              updateBundleFilter,
-              search,
-              updateSearch,
-              focusTxn,
-              resetTxnFocus,
-              focusedBankIdx,
-              triggeredChartControl,
-              resetTriggeredChartControl,
-            }
-          : DEFAULT_CHART_CONTROLS_CONTEXT
-      }
-    >
+    <ChartControlsContext.Provider value={value}>
       {children}
     </ChartControlsContext.Provider>
   );

--- a/src/features/SlotDetails/ChartControlsProvider.tsx
+++ b/src/features/SlotDetails/ChartControlsProvider.tsx
@@ -9,6 +9,7 @@ import {
   ChartControlsContext,
   DEFAULT_CHART_CONTROLS_CONTEXT,
   type ChartControls,
+  type InclusionFilterOptions,
 } from "./ChartControlsContext";
 import { SearchMode } from "../Overview/SlotPerformance/TransactionBarsCard/consts";
 import { getUplotId } from "../Overview/SlotPerformance/TransactionBarsCard/chartUtils";
@@ -27,8 +28,8 @@ import { txnBarsControlsStickyTop } from "../Overview/SlotPerformance/Transactio
 const desiredScaleRangeMultiplierMax = 30;
 const desiredScaleRangeMultiplierMin = 20;
 
-const DEFAULT_BUNDLE_FILTER = "All";
-const DEFAULT_SEARCH = {
+const DEFAULT_BUNDLE_FILTER: InclusionFilterOptions = "All";
+const DEFAULT_SEARCH: ChartControls["search"] = {
   mode: SearchMode.TxnSignature,
   text: "",
 };
@@ -45,10 +46,10 @@ export default function ChartControlsProvider({
     selectedSlotTransactions ?? DEFAULT_CHART_CONTROLS_CONTEXT.transactions;
   const filterBundle = useSetAtom(filterBundleDataAtom);
 
-  const [bundleFilter, setBundleFilter] = useState<
-    ChartControls["bundleFilter"]
-  >(DEFAULT_BUNDLE_FILTER);
-  const [search, setSearch] = useState<ChartControls["search"]>(DEFAULT_SEARCH);
+  const [bundleFilter, setBundleFilter] = useState<InclusionFilterOptions>(
+    DEFAULT_BUNDLE_FILTER,
+  );
+  const [search, setSearch] = useState(DEFAULT_SEARCH);
   const [focusedBankIdx, setFocusedBankIdx] = useState<number | undefined>();
   const [triggeredChartControl, setTriggeredChartControl] =
     useState<ChartControls["triggeredChartControl"]>();

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/DistributionBars.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/DistributionBars.tsx
@@ -55,7 +55,7 @@ export default function DistributionBar({
                       <>
                         <Text weight="bold">{label}</Text>
                         <br />
-                        <Text>{`Income: ${value} (${formattedPct})`}</Text>
+                        <Text>{`Income: ${value} SOL (${formattedPct})`}</Text>
                       </>
                     }
                     side="bottom"
@@ -71,9 +71,7 @@ export default function DistributionBar({
                         background: color,
                         flexGrow: value,
                       }}
-                      onClick={
-                        onItemClick && (() => onItemClick({ label, value }))
-                      }
+                      onClick={() => onItemClick?.({ label, value })}
                     >
                       {showLabel && (
                         <Text mx="2" className={styles.label} truncate>

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/DistributionBars.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/DistributionBars.tsx
@@ -13,6 +13,7 @@ interface DistributionBarProps {
   data: DistributionBarData[];
   showPct?: boolean;
   sort?: boolean;
+  onItemClick?: (item: { label: string; value: number }) => void;
 }
 
 const nodeLimit = 5_000;
@@ -21,6 +22,7 @@ export default function DistributionBar({
   data,
   showPct,
   sort,
+  onItemClick,
 }: DistributionBarProps) {
   const total = data.reduce((sum, { value }) => sum + value, 0);
   let barData = sort ? data.toSorted((a, b) => b.value - a.value) : data;
@@ -54,6 +56,9 @@ export default function DistributionBar({
                       background: color,
                       flexGrow: value,
                     }}
+                    onClick={
+                      onItemClick && (() => onItemClick({ label, value }))
+                    }
                   >
                     {showLabel && (
                       <Text mx="2" className={styles.label} truncate>

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/DistributionBars.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/DistributionBars.tsx
@@ -1,6 +1,7 @@
-import { Flex, Text } from "@radix-ui/themes";
+import { Flex, Text, Tooltip } from "@radix-ui/themes";
 import AutoSizer from "react-virtualized-auto-sizer";
 import styles from "./distributionBars.module.css";
+import clsx from "clsx";
 
 const barColors = ["#003362", "#113B29", "#3F2700", "#202248", "#33255B"];
 
@@ -44,29 +45,44 @@ export default function DistributionBar({
               {barData.map(({ value, label }, i) => {
                 const color = barColors[i % barColors.length];
                 const pct = value / total;
+                const formattedPct = `${Math.round(pct * 100)}%`;
                 const showLabel = pct * width > 30;
                 return (
-                  <Flex
+                  <Tooltip
+                    className={styles.distributionTooltip}
                     key={label}
-                    minWidth="0"
-                    align="center"
-                    justify="center"
-                    flexBasis="0"
-                    style={{
-                      background: color,
-                      flexGrow: value,
-                    }}
-                    onClick={
-                      onItemClick && (() => onItemClick({ label, value }))
+                    content={
+                      <>
+                        <Text weight="bold">{label}</Text>
+                        <br />
+                        <Text>{`Income: ${value} (${formattedPct})`}</Text>
+                      </>
                     }
+                    side="bottom"
+                    disableHoverableContent
                   >
-                    {showLabel && (
-                      <Text mx="2" className={styles.label} truncate>
-                        {label}
-                        {showPct && ` ${Math.round(pct * 100)}%`}
-                      </Text>
-                    )}
-                  </Flex>
+                    <Flex
+                      className={clsx(onItemClick && styles.clickable)}
+                      minWidth="0"
+                      align="center"
+                      justify="center"
+                      flexBasis="0"
+                      style={{
+                        background: color,
+                        flexGrow: value,
+                      }}
+                      onClick={
+                        onItemClick && (() => onItemClick({ label, value }))
+                      }
+                    >
+                      {showLabel && (
+                        <Text mx="2" className={styles.label} truncate>
+                          {label}
+                          {showPct && ` ${formattedPct}`}
+                        </Text>
+                      )}
+                    </Flex>
+                  </Tooltip>
                 );
               })}
             </Flex>

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByBundle.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByBundle.tsx
@@ -1,14 +1,13 @@
-import type { SlotTransactions } from "../../../../api/types";
 import DistributionBar from "./DistributionBars";
-import { useMemo } from "react";
+import { useCallback, useContext, useMemo } from "react";
 import { getTxnIncome } from "../../../../utils";
 import { groupBy, sum } from "lodash";
 import { SlotDetailsSubSection } from "../SlotDetailsSubSection";
+import { ChartControlsContext } from "../../ChartControlsContext";
 
-interface IncomeByTxnProps {
-  transactions: SlotTransactions;
-}
-export default function IncomeByBundle({ transactions }: IncomeByTxnProps) {
+export default function IncomeByBundle() {
+  const { transactions, updateBundleFilter } = useContext(ChartControlsContext);
+
   const data = useMemo(() => {
     const bundleValues = transactions.txn_from_bundle.map((fromBundle, i) => {
       return {
@@ -25,9 +24,15 @@ export default function IncomeByBundle({ transactions }: IncomeByTxnProps) {
       .sort((a, b) => (a.label === "Bundle" ? -1 : 1));
   }, [transactions]);
 
+  const onItemClick = useCallback(
+    ({ label }: { label: string; value: number }) =>
+      updateBundleFilter(label === "Bundle" ? "Yes" : "No", true),
+    [updateBundleFilter],
+  );
+
   return (
     <SlotDetailsSubSection title="Income Distribution by Bundle">
-      <DistributionBar data={data} showPct />
+      <DistributionBar data={data} showPct onItemClick={onItemClick} />
     </SlotDetailsSubSection>
   );
 }

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByBundle.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByBundle.tsx
@@ -26,7 +26,7 @@ export default function IncomeByBundle() {
 
   const onItemClick = useCallback(
     ({ label }: { label: string; value: number }) =>
-      updateBundleFilter(label === "Bundle" ? "Yes" : "No", true),
+      updateBundleFilter(label === "Bundle" ? "Yes" : "No", true, true),
     [updateBundleFilter],
   );
 

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByBundle.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByBundle.tsx
@@ -26,7 +26,10 @@ export default function IncomeByBundle() {
 
   const onItemClick = useCallback(
     ({ label }: { label: string; value: number }) =>
-      updateBundleFilter(label === "Bundle" ? "Yes" : "No", true, true),
+      updateBundleFilter(label === "Bundle" ? "Yes" : "No", {
+        scroll: true,
+        externalTrigger: true,
+      }),
     [updateBundleFilter],
   );
 

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByBundle.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByBundle.tsx
@@ -26,10 +26,7 @@ export default function IncomeByBundle() {
 
   const onItemClick = useCallback(
     ({ label }: { label: string; value: number }) =>
-      updateBundleFilter(label === "Bundle" ? "Yes" : "No", {
-        scroll: true,
-        externalTrigger: true,
-      }),
+      updateBundleFilter(label === "Bundle" ? "Yes" : "No"),
     [updateBundleFilter],
   );
 

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByIp.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByIp.tsx
@@ -26,7 +26,10 @@ export default function IncomeByIp() {
 
   const onItemClick = useCallback(
     ({ label }: { label: string; value: number }) => {
-      updateSearch({ mode: SearchMode.Ip, text: label }, true);
+      updateSearch(
+        { mode: SearchMode.Ip, text: label },
+        { externalTrigger: true },
+      );
     },
     [updateSearch],
   );

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByIp.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByIp.tsx
@@ -26,7 +26,7 @@ export default function IncomeByIp() {
 
   const onItemClick = useCallback(
     ({ label }: { label: string; value: number }) => {
-      updateSearch({ mode: SearchMode.Ip, text: label });
+      updateSearch({ mode: SearchMode.Ip, text: label }, true);
     },
     [updateSearch],
   );

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByIp.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByIp.tsx
@@ -1,14 +1,14 @@
-import type { SlotTransactions } from "../../../../api/types";
 import DistributionBar from "./DistributionBars";
-import { useMemo } from "react";
+import { useCallback, useContext, useMemo } from "react";
 import { getTxnIncome } from "../../../../utils";
 import { groupBy, sum } from "lodash";
 import { SlotDetailsSubSection } from "../SlotDetailsSubSection";
+import { ChartControlsContext } from "../../ChartControlsContext";
+import { SearchMode } from "../../../Overview/SlotPerformance/TransactionBarsCard/consts";
 
-interface IncomeByTxnProps {
-  transactions: SlotTransactions;
-}
-export default function IncomeByIp({ transactions }: IncomeByTxnProps) {
+export default function IncomeByIp() {
+  const { transactions, updateSearch } = useContext(ChartControlsContext);
+
   const data = useMemo(() => {
     const ipValues = transactions.txn_source_ipv4.map((ip, i) => {
       return {
@@ -24,9 +24,16 @@ export default function IncomeByIp({ transactions }: IncomeByTxnProps) {
     );
   }, [transactions]);
 
+  const onItemClick = useCallback(
+    ({ label }: { label: string; value: number }) => {
+      updateSearch({ mode: SearchMode.Ip, text: label });
+    },
+    [updateSearch],
+  );
+
   return (
     <SlotDetailsSubSection title="Income Distribution by IP Address">
-      <DistributionBar data={data} sort />
+      <DistributionBar data={data} sort onItemClick={onItemClick} />
     </SlotDetailsSubSection>
   );
 }

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByIp.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByIp.tsx
@@ -26,10 +26,7 @@ export default function IncomeByIp() {
 
   const onItemClick = useCallback(
     ({ label }: { label: string; value: number }) => {
-      updateSearch(
-        { mode: SearchMode.Ip, text: label },
-        { externalTrigger: true },
-      );
+      updateSearch({ mode: SearchMode.Ip, text: label });
     },
     [updateSearch],
   );

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByPctTxns.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByPctTxns.tsx
@@ -1,9 +1,10 @@
 import type { SlotTransactions } from "../../../../api/types";
 import DistributionBar from "./DistributionBars";
-import { useMemo } from "react";
+import { useContext, useMemo } from "react";
 import { getTxnIncome } from "../../../../utils";
 import { SlotDetailsSubSection } from "../SlotDetailsSubSection";
 import { clamp } from "lodash";
+import { ChartControlsContext } from "../../ChartControlsContext";
 
 function percentileSpread(values: number[], percentiles: number[] = [1, 10]) {
   const n = values.length;
@@ -63,10 +64,9 @@ function getIncomeChartData(transactions: SlotTransactions) {
   });
 }
 
-interface IncomeByTxnProps {
-  transactions: SlotTransactions;
-}
-export default function IncomeByPctTxns({ transactions }: IncomeByTxnProps) {
+export default function IncomeByPctTxns() {
+  const { transactions } = useContext(ChartControlsContext);
+
   const data = useMemo(() => getIncomeChartData(transactions), [transactions]);
 
   if (!data) return;

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByTxn.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByTxn.tsx
@@ -27,7 +27,10 @@ export default function IncomeByTxn() {
 
   const onItemClick = useCallback(
     ({ label }: { label: string; value: number }) => {
-      updateSearch({ mode: SearchMode.TxnSignature, text: label }, true);
+      updateSearch(
+        { mode: SearchMode.TxnSignature, text: label },
+        { externalTrigger: true },
+      );
     },
     [updateSearch],
   );

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByTxn.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByTxn.tsx
@@ -27,10 +27,7 @@ export default function IncomeByTxn() {
 
   const onItemClick = useCallback(
     ({ label }: { label: string; value: number }) => {
-      updateSearch(
-        { mode: SearchMode.TxnSignature, text: label },
-        { externalTrigger: true },
-      );
+      updateSearch({ mode: SearchMode.TxnSignature, text: label });
     },
     [updateSearch],
   );

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByTxn.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByTxn.tsx
@@ -27,7 +27,7 @@ export default function IncomeByTxn() {
 
   const onItemClick = useCallback(
     ({ label }: { label: string; value: number }) => {
-      updateSearch({ mode: SearchMode.TxnSignature, text: label });
+      updateSearch({ mode: SearchMode.TxnSignature, text: label }, true);
     },
     [updateSearch],
   );

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByTxn.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByTxn.tsx
@@ -1,14 +1,14 @@
-import type { SlotTransactions } from "../../../../api/types";
 import DistributionBar from "./DistributionBars";
-import { useMemo } from "react";
+import { useCallback, useContext, useMemo } from "react";
 import { getTxnIncome } from "../../../../utils";
 import { groupBy, sum } from "lodash";
 import { SlotDetailsSubSection } from "../SlotDetailsSubSection";
+import { ChartControlsContext } from "../../ChartControlsContext";
+import { SearchMode } from "../../../Overview/SlotPerformance/TransactionBarsCard/consts";
 
-interface IncomeByTxnProps {
-  transactions: SlotTransactions;
-}
-export default function IncomeByTxn({ transactions }: IncomeByTxnProps) {
+export default function IncomeByTxn() {
+  const { transactions, updateSearch } = useContext(ChartControlsContext);
+
   const data = useMemo(() => {
     const signatureValues = transactions.txn_signature.map((signature, i) => {
       return {
@@ -25,9 +25,16 @@ export default function IncomeByTxn({ transactions }: IncomeByTxnProps) {
     );
   }, [transactions]);
 
+  const onItemClick = useCallback(
+    ({ label }: { label: string; value: number }) => {
+      updateSearch({ mode: SearchMode.TxnSignature, text: label });
+    },
+    [updateSearch],
+  );
+
   return (
     <SlotDetailsSubSection title="Income Distribution by Txn">
-      <DistributionBar data={data} sort />
+      <DistributionBar data={data} sort onItemClick={onItemClick} />
     </SlotDetailsSubSection>
   );
 }

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeDistributionCharts.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeDistributionCharts.tsx
@@ -15,10 +15,10 @@ export default function IncomeDistributionCharts() {
 
   return (
     <>
-      <IncomeByPctTxns transactions={transactions} />
-      <IncomeByBundle transactions={transactions} />
-      <IncomeByTxn transactions={transactions} />
-      <IncomeByIp transactions={transactions} />
+      <IncomeByPctTxns />
+      <IncomeByBundle />
+      <IncomeByTxn />
+      <IncomeByIp />
     </>
   );
 }

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/distributionBars.module.css
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/distributionBars.module.css
@@ -18,6 +18,7 @@
   transition: all 0.3s ease;
 
   &:hover {
+    height: 15px;
     transform: translateY(-2px);
     filter: brightness(1.2);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/distributionBars.module.css
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/distributionBars.module.css
@@ -1,12 +1,27 @@
 .container {
   height: 13px;
   border-radius: 4px;
-  /*  TODO: fix overflow that occurs on some chart's data */
-  overflow: hidden;
 
   .label {
     font-size: 10px;
     color: var(--slot-details-stats-primary);
     pointer-events: none;
+  }
+}
+
+.distribution-tooltip :global(.rt-TooltipContent) {
+  white-space: pre-wrap;
+}
+
+.clickable {
+  cursor: pointer;
+  transition: all 0.3s ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    filter: brightness(1.2);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+    outline: 0.5px solid #e5e7eb;
+    z-index: 1;
   }
 }

--- a/src/features/SlotDetails/DetailedSlotStats/PerformanceSection/TxnExecutionDurationCharts/index.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/PerformanceSection/TxnExecutionDurationCharts/index.tsx
@@ -1,15 +1,15 @@
 import { Box } from "@radix-ui/themes";
-import { useMemo } from "react";
+import { useContext, useMemo } from "react";
 import AutoSizer from "react-virtualized-auto-sizer";
 import uPlot, { type AlignedData, type Options } from "uplot";
 import UplotReact from "../../../../../uplotReact/UplotReact";
 import { useAtomValue } from "jotai";
 import { selectedSlotAtom } from "../../../../Overview/SlotPerformance/atoms";
 import { useSlotQueryResponseTransactions } from "../../../../../hooks/useSlotQuery";
-import type { SlotTransactions } from "../../../../../api/types";
 import { getMax, isDefined } from "../../../../../utils";
 import { getDurationWithUnits } from "../../../../Overview/SlotPerformance/TransactionBarsCard/chartUtils";
 import { SlotDetailsSubSection } from "../../SlotDetailsSubSection";
+import { ChartControlsContext } from "../../../ChartControlsContext";
 
 export default function TxnExecutionDurationCharts() {
   const selectedSlot = useAtomValue(selectedSlotAtom);
@@ -26,7 +26,7 @@ export default function TxnExecutionDurationCharts() {
         minHeight="100px"
         flexGrow="1"
       >
-        <CuChart transactions={transactions} />
+        <CuChart />
       </SlotDetailsSubSection>
       <SlotDetailsSubSection
         title="Transaction Count vs Txn Execution Duration"
@@ -34,7 +34,7 @@ export default function TxnExecutionDurationCharts() {
         minHeight="100px"
         flexGrow="1"
       >
-        <CountChart transactions={transactions} />
+        <CountChart />
       </SlotDetailsSubSection>
     </>
   );
@@ -138,11 +138,9 @@ function Chart({ data, log, id }: ChartProps) {
   );
 }
 
-interface ChartContainerProps {
-  transactions: SlotTransactions;
-}
+function CountChart() {
+  const { transactions } = useContext(ChartControlsContext);
 
-function CountChart({ transactions }: ChartContainerProps) {
   //   TODO fix for bundles
   const data = useMemo<AlignedData>(() => {
     const txnDurations = transactions.txn_landed
@@ -171,7 +169,9 @@ function CountChart({ transactions }: ChartContainerProps) {
   return <Chart data={data} id="txnExecutionDurationCount" log />;
 }
 
-function CuChart({ transactions }: ChartContainerProps) {
+function CuChart() {
+  const { transactions } = useContext(ChartControlsContext);
+
   const data = useMemo<AlignedData>(() => {
     const txnDurations = transactions.txn_landed
       .map((isLanded, i) => {

--- a/src/features/SlotDetails/DetailedSlotStats/consts.ts
+++ b/src/features/SlotDetails/DetailedSlotStats/consts.ts
@@ -3,3 +3,5 @@ export const sectionGapY = "15px";
 export const subsectionGapX = "15px";
 export const gridGapX = "5px";
 export const gridGapY = "1";
+
+export const bundleToggleGroupId = "bundle-toggle-group";

--- a/src/features/SlotDetails/DetailedSlotStats/consts.ts
+++ b/src/features/SlotDetails/DetailedSlotStats/consts.ts
@@ -3,5 +3,3 @@ export const sectionGapY = "15px";
 export const subsectionGapX = "15px";
 export const gridGapX = "5px";
 export const gridGapY = "1";
-
-export const bundleToggleGroupId = "bundle-toggle-group";

--- a/src/features/SlotDetails/index.tsx
+++ b/src/features/SlotDetails/index.tsx
@@ -12,6 +12,7 @@ import { SlotSearch } from "./SlotSearch";
 import SlotNavigation from "./SlotNavigation";
 import DetailedSlotStats from "./DetailedSlotStats";
 import { useEffect, useState } from "react";
+import ChartControlsProvider from "./ChartControlsProvider";
 
 export default function SlotDetails() {
   const selectedSlot = useAtomValue(selectedSlotAtom);
@@ -39,11 +40,13 @@ function SlotContent() {
 
   return (
     <Flex direction="column" gap="2" flexGrow="1">
-      <SlotNavigation />
-      <DetailedSlotStats />
-      <SlotPerformance />
-      <ComputeUnitsCard />
-      <TransactionBarsCard />
+      <ChartControlsProvider>
+        <SlotNavigation />
+        <DetailedSlotStats />
+        <SlotPerformance />
+        <ComputeUnitsCard />
+        <TransactionBarsCard />
+      </ChartControlsProvider>
     </Flex>
   );
 }


### PR DESCRIPTION
Added interactivity to the distribution bars in the Fees section of the slot detail stats
- distribution by bundle toggles yes/no bundles filter
- distribution by txn updates search
- distribution by ip updates search

Added affordances to indicate which distribution bars are interactable (y-axis transform, brightness filter, outline)

Added tooltip and outline to chart control that got updated by an external trigger (clicking on the distribution bars)