### PR TITLE
feat: add tooltips to income scatter charts

### DIFF
--- a/src/features/SlotDetails/DetailedSlotStats/ChartTooltipRow.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/ChartTooltipRow.tsx
@@ -1,0 +1,32 @@
+import { Text } from "@radix-ui/themes";
+import styles from "./detailedSlotStats.module.css";
+
+interface ChartTooltipRowProps {
+  label: string;
+  value: number;
+  color?: string;
+  formatter?: (x: number) => string;
+}
+
+export function ChartTooltipRow({
+  label,
+  value,
+  color,
+  formatter,
+}: ChartTooltipRowProps) {
+  return (
+    <>
+      <Text wrap="nowrap" className={styles.label}>
+        {label}
+      </Text>
+      <Text
+        wrap="nowrap"
+        className={styles.value}
+        align="right"
+        style={{ color }}
+      >
+        {formatter ? formatter(value) : value.toLocaleString()}
+      </Text>
+    </>
+  );
+}

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeScatterCharts/IncomeScatterChart.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeScatterCharts/IncomeScatterChart.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import AutoSizer from "react-virtualized-auto-sizer";
 import {
   chartAxisColor,
@@ -11,6 +11,9 @@ import { Box } from "@radix-ui/themes";
 import type uPlot from "uplot";
 import { compactZeroDecimalFormatter } from "../../../../../numUtils";
 import { lamportsPerSol } from "../../../../../consts";
+import { incomeScatterTooltipPlugin } from "./incomeScatterTooltipPlugin";
+import IncomeScatterChartTooltip from "./IncomeScatterChartTooltip";
+import { incomeChartPointRadius } from "../../consts";
 
 interface CuIncomeScatterChartProps {
   data: uPlot.AlignedData;
@@ -21,6 +24,9 @@ interface CuIncomeScatterChartProps {
     negMin: number;
     posMax: number;
   };
+  xLabel: string;
+  xColor?: string;
+  formatX: (x: number) => string;
 }
 
 const xScaleKey = "cuX";
@@ -30,7 +36,13 @@ export default function IncomeScatterChart({
   id,
   xLogScale = false,
   xScaleOptions,
+  xLabel,
+  xColor,
+  formatX,
 }: CuIncomeScatterChartProps) {
+  const tooltipElId = `${id}-tooltip`;
+  const [tooltipData, setTooltipData] = useState<{ x: number; y: number }>();
+
   const options = useMemo(() => {
     return {
       width: 0,
@@ -100,7 +112,7 @@ export default function IncomeScatterChart({
           stroke: undefined,
           points: {
             show: true,
-            size: 5,
+            size: incomeChartPointRadius * 2,
             fill: hexToRgba(incomePerCuToggleControlColor, 0.3),
             space: 0,
           },
@@ -124,18 +136,35 @@ export default function IncomeScatterChart({
           },
         ],
       },
+      plugins: [
+        incomeScatterTooltipPlugin(
+          tooltipElId,
+          xScaleKey,
+          lamportsScaleKey,
+          setTooltipData,
+        ),
+      ],
     } satisfies uPlot.Options;
-  }, [xLogScale, xScaleOptions]);
+  }, [tooltipElId, xLogScale, xScaleOptions]);
 
   return (
-    <Box flexGrow="1">
-      <AutoSizer>
-        {({ height, width }) => {
-          options.width = width;
-          options.height = height;
-          return <UplotReact id={id} options={options} data={data} />;
-        }}
-      </AutoSizer>
-    </Box>
+    <>
+      <Box flexGrow="1">
+        <AutoSizer>
+          {({ height, width }) => {
+            options.width = width;
+            options.height = height;
+            return <UplotReact id={id} options={options} data={data} />;
+          }}
+        </AutoSizer>
+      </Box>
+      <IncomeScatterChartTooltip
+        elId={tooltipElId}
+        data={tooltipData}
+        xLabel={xLabel}
+        xColor={xColor}
+        tooltipFormatX={formatX}
+      />
+    </>
   );
 }

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeScatterCharts/IncomeScatterChartTooltip.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeScatterCharts/IncomeScatterChartTooltip.tsx
@@ -1,0 +1,43 @@
+import { Grid } from "@radix-ui/themes";
+import UplotTooltip from "../../../../../uplotReact/UplotTooltip";
+import { incomePerCuToggleControlColor } from "../../../../../colors";
+import { formatNumberLamports } from "../../../../Overview/ValidatorsCard/formatAmt";
+import { maxSolDecimals } from "../../../../../consts";
+import { ChartTooltipRow } from "../../ChartTooltipRow";
+
+interface IncomeScatterChartTooltipProps {
+  elId: string;
+  data?: { x: number; y: number };
+  xLabel: string;
+  xColor?: string;
+  tooltipFormatX: (x: number) => string;
+}
+
+export default function IncomeScatterChartTooltip({
+  elId,
+  data,
+  xLabel,
+  xColor,
+  tooltipFormatX,
+}: IncomeScatterChartTooltipProps) {
+  return (
+    <UplotTooltip elId={elId}>
+      {data !== undefined && (
+        <Grid columns="auto auto" gapX="2">
+          <ChartTooltipRow
+            label={xLabel}
+            value={data.x}
+            color={xColor}
+            formatter={tooltipFormatX}
+          />
+          <ChartTooltipRow
+            label="Income"
+            value={data.y}
+            color={incomePerCuToggleControlColor}
+            formatter={(v) => `${formatNumberLamports(v, maxSolDecimals)} SOL`}
+          />
+        </Grid>
+      )}
+    </UplotTooltip>
+  );
+}

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeScatterCharts/incomeScatterTooltipPlugin.ts
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeScatterCharts/incomeScatterTooltipPlugin.ts
@@ -1,0 +1,52 @@
+import type uPlot from "uplot";
+import { baseTooltipPlugin } from "../../../../../uplotReact/baseTooltipPlugin";
+import { incomeChartPointRadius } from "../../consts";
+
+const HOVER_RADIUS_SQ = (incomeChartPointRadius + 2) ** 2; // slightly larger point for easier hover
+
+export function incomeScatterTooltipPlugin(
+  elId: string,
+  xScaleKey: string,
+  yScaleKey: string,
+  setTooltipData: (data: { x: number; y: number }) => void,
+): uPlot.Plugin {
+  function getClosestIdx(u: uPlot): number | null {
+    const { left, top } = u.cursor;
+    if (left == null || top == null) return null;
+
+    const xData = u.data[0];
+    const yData = u.data[1];
+    let minIdx: number | null = null;
+    let minDistSq = Infinity;
+
+    for (let i = 0; i < yData.length; i++) {
+      const xVal = xData[i];
+      const yVal = yData[i];
+      if (xVal == null || yVal == null) continue;
+      const xPos = u.valToPos(xVal, xScaleKey);
+      const yPos = u.valToPos(yVal, yScaleKey);
+      const distSq = (left - xPos) ** 2 + (top - yPos) ** 2;
+      if (distSq < minDistSq && distSq <= HOVER_RADIUS_SQ) {
+        minDistSq = distSq;
+        minIdx = i;
+      }
+    }
+
+    return minIdx;
+  }
+
+  function showOnCursor(u: uPlot, _xVal: number, idx: number) {
+    const x = u.data[0][idx];
+    const y = u.data[1][idx];
+    if (x == null || y == null) return false;
+
+    setTooltipData({ x, y });
+    return true;
+  }
+
+  return baseTooltipPlugin({
+    elId,
+    getClosestIdx,
+    showOnCursor,
+  });
+}

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeScatterCharts/index.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeScatterCharts/index.tsx
@@ -9,6 +9,8 @@ import { useMemo } from "react";
 import IncomeScatterChart from "./IncomeScatterChart.tsx";
 import type uPlot from "uplot";
 import { subsectionGapX } from "../../consts.ts";
+import { compactZeroDecimalFormatter } from "../../../../../numUtils.ts";
+import { computeUnitsColor } from "../../../../../colors.ts";
 
 function getCuChartData(transactions?: SlotTransactions | null) {
   return transactions?.txn_compute_units_consumed
@@ -109,6 +111,9 @@ export default function IncomeScatterCharts() {
           id="cuIncomeScatterChart"
           data={cuChartData}
           xLogScale
+          xLabel="CU"
+          xColor={computeUnitsColor}
+          formatX={(x) => compactZeroDecimalFormatter.format(x)}
         />
       </SlotDetailsSubSection>
       <SlotDetailsSubSection title="Arrival Time vs Income" flexGrow="1">
@@ -116,6 +121,10 @@ export default function IncomeScatterCharts() {
           id="arrivalIncomeScatterChart"
           data={arrivalChartData.chartData}
           xScaleOptions={arrivalXScaleOptions}
+          xLabel="Arrival"
+          formatX={(x) =>
+            `${Math.round(scaledToX(x, arrivalChartData.min, arrivalChartData.max)).toLocaleString()}ms`
+          }
         />
       </SlotDetailsSubSection>
     </Flex>

--- a/src/features/SlotDetails/DetailedSlotStats/PerformanceSection/PackBufferChart/PackBufferChartTooltip.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/PerformanceSection/PackBufferChart/PackBufferChartTooltip.tsx
@@ -1,4 +1,4 @@
-import { Grid, Text } from "@radix-ui/themes";
+import { Grid } from "@radix-ui/themes";
 import UplotTooltip from "../../../../../uplotReact/UplotTooltip";
 import type { SchedulerCounts } from "../../../../../api/types";
 import {
@@ -7,7 +7,7 @@ import {
   tipsColor,
   votesColor,
 } from "../../../../../colors";
-import styles from "../../detailedSlotStats.module.css";
+import { ChartTooltipRow } from "../../ChartTooltipRow";
 
 interface PackBufferChartProps {
   data?: SchedulerCounts;
@@ -18,33 +18,28 @@ export default function PackBufferChartTooltip({ data }: PackBufferChartProps) {
     <UplotTooltip elId="pack-buffer-chart-tooltip">
       {data && (
         <Grid columns="auto auto" gapX="2">
-          <Row label="Regular" value={data.regular} color={nonVoteColor} />
-          <Row label="Votes" value={data.votes} color={votesColor} />
-          <Row
+          <ChartTooltipRow
+            label="Regular"
+            value={data.regular}
+            color={nonVoteColor}
+          />
+          <ChartTooltipRow
+            label="Votes"
+            value={data.votes}
+            color={votesColor}
+          />
+          <ChartTooltipRow
             label="Conflicting"
             value={data.conflicting}
             color={slotStatusRed}
           />
-          <Row label="Bundles" value={data.bundles} color={tipsColor} />
+          <ChartTooltipRow
+            label="Bundles"
+            value={data.bundles}
+            color={tipsColor}
+          />
         </Grid>
       )}
     </UplotTooltip>
-  );
-}
-
-interface RowProps {
-  label: string;
-  value: number;
-  color: string;
-}
-
-function Row({ label, value, color }: RowProps) {
-  return (
-    <>
-      <Text className={styles.label}>{label}</Text>
-      <Text className={styles.value} style={{ color }}>
-        {value.toLocaleString()}
-      </Text>
-    </>
   );
 }

--- a/src/features/SlotDetails/DetailedSlotStats/consts.ts
+++ b/src/features/SlotDetails/DetailedSlotStats/consts.ts
@@ -3,3 +3,5 @@ export const sectionGapY = "15px";
 export const subsectionGapX = "15px";
 export const gridGapX = "5px";
 export const gridGapY = "1";
+
+export const incomeChartPointRadius = 2.5;

--- a/src/uplotReact/baseTooltipPlugin.ts
+++ b/src/uplotReact/baseTooltipPlugin.ts
@@ -2,6 +2,8 @@ import type uPlot from "uplot";
 import placement from "../uplot/placement";
 import { throttle } from "lodash";
 
+const CLOSEST_IDX_SERIES = 1;
+
 // Persisted tooltip function should persist across charts, only 1 shown tooltip at a time
 let persistTooltip = false;
 
@@ -9,17 +11,21 @@ function getScrollContainer() {
   return document.getElementById("scroll-container") ?? document.body;
 }
 
+interface BaseTooltipPluginProps {
+  elId: string;
+  showOnCursor: (u: uPlot, val: number, idx: number) => boolean;
+  showPointer?: boolean;
+  closeTooltipElId?: string;
+  getClosestIdx?: (u: uPlot) => number | null;
+}
+
 export function baseTooltipPlugin({
   elId,
   showOnCursor,
   showPointer,
   closeTooltipElId,
-}: {
-  elId: string;
-  showOnCursor: (u: uPlot, val: number, idx: number) => boolean;
-  showPointer?: boolean;
-  closeTooltipElId?: string;
-}): uPlot.Plugin {
+  getClosestIdx,
+}: BaseTooltipPluginProps): uPlot.Plugin {
   let over: HTMLDivElement;
   let bound: HTMLElement;
   let bLeft: number;
@@ -89,9 +95,19 @@ export function baseTooltipPlugin({
 
   let overlay: HTMLElement;
 
-  // setTimeout(() => syncBounds(), 10_000);
-
   return {
+    opts: (_u, opts) => {
+      if (!getClosestIdx) return;
+      opts.cursor ??= {};
+      /* uPlot uses dataIdx to set the active index per series for highlighting.
+       * If multiple non-x series are added, getClosestIdx would need to accept
+       * seriesIdx and return a value based on the series.
+       */
+      opts.cursor.dataIdx = (u, seriesIdx, closestIdx) => {
+        if (seriesIdx === CLOSEST_IDX_SERIES) return getClosestIdx(u);
+        return closestIdx;
+      };
+    },
     hooks: {
       init: (u) => {
         const tooltipEl = document.getElementById(elId);
@@ -147,16 +163,26 @@ export function baseTooltipPlugin({
         if (!isCurrentlyHovered) return;
         if (persistTooltip) return;
 
-        const { idx, left, top } = u.cursor;
+        const { left, top } = u.cursor;
+        /* This idx is used to determine whether and what to show in the tooltip.
+         * uPlot's convention is for series 0 to be the x-axis and closestIdx
+         * to be calculated by closest x value.
+         * When getClosestIdx exists, we read from CLOSEST_IDX_SERIES instead,
+         * which has the custom idx set via dataIdx above. */
+        const idx = u.cursor.idxs?.[getClosestIdx ? CLOSEST_IDX_SERIES : 0];
 
-        if (left === undefined || top === undefined || idx == null) return;
-        const xVal = u.posToVal(left ?? 0, u.series[0].scale ?? "x");
-        const anchor = {
-          left: left + bLeft + 5,
-          top: top + bTop,
-        };
-        const showTooltip = showOnCursor(u, xVal, idx);
+        /* idx is undefined when the cursor not yet initialized and
+         * null when no data is in range (and we should hide the tooltip) */
+        if (left === undefined || top === undefined || idx === undefined)
+          return;
+
+        const xVal = u.posToVal(left, u.series[0].scale ?? "x");
+        const showTooltip = idx !== null && showOnCursor(u, xVal, idx);
         if (showTooltip) {
+          const anchor = {
+            left: left + bLeft + 5,
+            top: top + bTop,
+          };
           overlay.style.display = "block";
           overlay.style.pointerEvents = "none";
           setCursorPointer();


### PR DESCRIPTION
Add tooltip to income scatter charts that calculate the closest data idx via Euclidean distance instead of closest x value