### PR TITLE
fix: first startup slot

### DIFF
--- a/src/features/StartupProgress/Firedancer/CatchingUp/atoms.ts
+++ b/src/features/StartupProgress/Firedancer/CatchingUp/atoms.ts
@@ -16,10 +16,13 @@ export interface CatchingUpData {
 
 export const catchingUpStartSlotAtom = atom<number | null | undefined>(
   (get) => {
-    return (
-      get(bootProgressAtom)?.loading_incremental_snapshot_slot ??
-      get(bootProgressAtom)?.loading_full_snapshot_slot
-    );
+    /* Snapshots represent end-of-slot state; the first slot we replay 
+       from live shreds is (incr or full)+1 */
+    const incr = get(bootProgressAtom)?.loading_incremental_snapshot_slot;
+    if (incr != null) return incr + 1;
+    const full = get(bootProgressAtom)?.loading_full_snapshot_slot;
+    if (full != null) return full + 1;
+    return undefined;
   },
 );
 


### PR DESCRIPTION
snapshots represent end-of-slot state; the first slot we replay from live shreds is (incr or full)+1