### PR TITLE
fix: clear filters when trigger chart controls from distribution bars

### DIFF
--- a/src/features/Overview/SlotPerformance/ComputeUnitsCard/CuChart.tsx
+++ b/src/features/Overview/SlotPerformance/ComputeUnitsCard/CuChart.tsx
@@ -23,10 +23,7 @@ import {
 import { cuTooltipPlugin } from "./cuTooltipPlugin";
 import { wheelZoomPlugin } from "../../../../uplotReact/wheelZoomPlugin";
 import { syncXScalePlugin } from "../../../../uplotReact/syncXScalePlugin";
-import {
-  chartBufferMs,
-  getMaxTsWithBuffer,
-} from "../../../../transactionUtils";
+import { chartBufferMs, getMaxTs } from "../../../../transactionUtils";
 import { cuIsFullXRangePlugin } from "./cuIsFullXRangePlugin";
 import { touchPlugin } from "../../../../uplotReact/touchPlugin";
 import {
@@ -103,7 +100,7 @@ function getChartData(transactions: SlotTransactions) {
     [[-chartBufferMs], [0], [0], [0], [0]],
   );
 
-  const maxTs = getMaxTsWithBuffer(transactions);
+  const maxTs = getMaxTs(transactions, true);
 
   chartData.forEach((series) => {
     series.push(null);

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChartContainer.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChartContainer.tsx
@@ -12,7 +12,7 @@ import { baseChartDataAtom, selectedBankAtom } from "./atoms";
 import { getChartData } from "./chartUtils";
 import BarChartFloatingAction from "./BarChartFloatingAction";
 import CardHeader from "../../../../components/CardHeader";
-import { getMaxTsWithBuffer } from "../../../../transactionUtils";
+import { getMaxTs } from "../../../../transactionUtils";
 import { cardBackgroundColor } from "../../../../colors";
 import {
   clusterIndicatorHeight,
@@ -29,8 +29,10 @@ export const txnBarsControlsStickyTop = navigationTop + slotNavHeight;
 export default function BarsChartContainer() {
   const [focusedBankIdx, setFocusedBankIdx] = useState<number>();
 
-  useChartControl(FOCUS_BANK_KEY, (bankIdx?: number) =>
-    setFocusedBankIdx(bankIdx),
+  useChartControl(
+    FOCUS_BANK_KEY,
+    (bankIdx) => setFocusedBankIdx(bankIdx),
+    () => setFocusedBankIdx(undefined),
   );
 
   const slot = useAtomValue(selectedSlotAtom);
@@ -49,7 +51,7 @@ export default function BarsChartContainer() {
   const maxTs = useMemo(() => {
     if (!query.response?.transactions) return 0;
 
-    return getMaxTsWithBuffer(query.response.transactions);
+    return getMaxTs(query.response.transactions, true);
   }, [query.response?.transactions]);
 
   useMemo(() => {

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/SearchCommand.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/SearchCommand.tsx
@@ -48,6 +48,7 @@ import {
 } from "./searchCommandUtils";
 import { txnBarsControlsStickyTop } from "../BarsChartContainer";
 import {
+  ARRIVAL_CONTROL_KEY,
   ChartControlsContext,
   FOCUS_BANK_KEY,
   SEARCH_KEY,
@@ -127,7 +128,7 @@ export default function SearchCommand({
   const commandListRef = useRef<HTMLDivElement>(null);
   const suppressOpenOnFocusRef = useRef<boolean>(false);
 
-  const { triggerControl } = useContext(ChartControlsContext);
+  const { triggerControl, resetControl } = useContext(ChartControlsContext);
 
   const getTxnIdxs = useCallback(
     (value: Search) => {
@@ -278,18 +279,14 @@ export default function SearchCommand({
     [getTxnIdxs, setSearchIdxAndFocus],
   );
 
-  const { isTooltipOpen, closeTooltip } = useChartControl(
-    SEARCH_KEY,
-    handleExternalValueUpdate,
-  );
-
   // For resetting focus when user starts typing in input
   const resetChartElFocus = useCallback(() => {
-    triggerControl(FOCUS_BANK_KEY, undefined);
+    resetControl(FOCUS_BANK_KEY);
+    resetControl(ARRIVAL_CONTROL_KEY);
     highlightTxnIdx(undefined);
     setSearchIdx(undefined);
     setIsCurrentlySelected(false);
-  }, [triggerControl]);
+  }, [resetControl]);
 
   const resetFocus = useCallback(() => {
     resetChartElFocus();
@@ -302,6 +299,12 @@ export default function SearchCommand({
       });
     });
   }, [resetChartElFocus, setDInputValue, uplotAction]);
+
+  const { isTooltipOpen, closeTooltip } = useChartControl(
+    SEARCH_KEY,
+    handleExternalValueUpdate,
+    resetFocus,
+  );
 
   useEffect(() => {
     if (

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/index.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/index.tsx
@@ -36,20 +36,15 @@ import {
 } from "../atoms";
 import { groupBy, max } from "lodash";
 import type { CSSProperties } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import ToggleGroupControl, {
-  type ToggleGroupControlRef,
-} from "./ToggleGroupControl";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import ToggleGroupControl from "./ToggleGroupControl";
 import { useMeasure, useMedia, useUnmount } from "react-use";
 import { FilterEnum, TxnState } from "../consts";
 import ToggleControl from "./ToggleControl";
 import toggleControlStyles from "./toggleControl.module.css";
 import styles from "./chartControl.module.css";
 import { txnBarsUplotActionAtom } from "../uplotAtoms";
-import {
-  chartBufferMs,
-  getMaxTsWithBuffer,
-} from "../../../../../transactionUtils";
+import { getMaxTs } from "../../../../../transactionUtils";
 import { banksXScaleKey } from "../../ComputeUnitsCard/consts";
 import { tooltipTxnIdxAtom, tooltipTxnStateAtom } from "../chartTooltipAtoms";
 import SearchCommand from "./SearchCommand";
@@ -66,12 +61,18 @@ import { uplotActionAtom } from "../../../../../uplotReact/uplotAtoms";
 import { txnErrorCodeMap } from "../../../../../consts";
 import { useThrottledCallback } from "use-debounce";
 import {
+  ARRIVAL_CONTROL_KEY,
   BUNDLE_CONTROL_KEY,
+  ERROR_STATE_CONTROL_KEY,
+  ERROR_STATE_FILTER_OPTIONS,
   INCLUSION_FILTER_OPTIONS,
+  LANDED_CONTROL_KEY,
+  VOTE_CONTROL_KEY,
+  type ErrorStateFilterOption,
   type InclusionFilterOption,
 } from "../../../../SlotDetails/ChartControlsContext";
+import useToggleGroupChartControl from "./useToggleGroupChartControl";
 import useChartControl from "./useChartControl";
-import { getUplotId } from "../chartUtils";
 
 interface ChartControlsProps {
   transactions: SlotTransactions;
@@ -169,23 +170,38 @@ interface ToggleGroupControlProps {
 function ErrorControl({ transactions, maxTs }: ToggleGroupControlProps) {
   const uplotAction = useSetAtom(txnBarsUplotActionAtom);
   const filterError = useSetAtom(filterErrorDataAtom);
-  const [value, setValue] = useState<"All" | "Success" | "Errors">("All");
+  const [value, setValue] = useState<ErrorStateFilterOption>("All");
+
+  const updateErrorStateFilter = useCallback(
+    (value: ErrorStateFilterOption) => {
+      if (!transactions) return;
+      setValue(value);
+      const filterValue =
+        value === "Success" ? "No" : value === "Errors" ? "Yes" : "All";
+      uplotAction((u, bankIdx) =>
+        filterError(u, transactions, bankIdx, maxTs, filterValue),
+      );
+    },
+    [filterError, maxTs, transactions, uplotAction],
+  );
+
+  const { isTooltipOpen, closeTooltip, toggleGroupRef } =
+    useToggleGroupChartControl(
+      ERROR_STATE_CONTROL_KEY,
+      updateErrorStateFilter,
+      () => updateErrorStateFilter("All"),
+    );
 
   return (
     <Flex gap="2">
       <ToggleGroupControl
-        options={["All", "Success", "Errors"]}
+        ref={toggleGroupRef}
+        options={ERROR_STATE_FILTER_OPTIONS}
         optionColors={{ Success: successToggleColor, Errors: errorToggleColor }}
         value={value}
-        onChange={(value) => {
-          if (!value) return;
-          setValue(value);
-          const filterValue =
-            value === "Success" ? "No" : value === "Errors" ? "Yes" : "All";
-          uplotAction((u, bankIdx) =>
-            filterError(u, transactions, bankIdx, maxTs, filterValue),
-          );
-        }}
+        onChange={(value) => value && updateErrorStateFilter(value)}
+        isTooltipOpen={isTooltipOpen}
+        closeTooltip={closeTooltip}
       />
       <HighlightErrorControl
         transactions={transactions}
@@ -326,36 +342,21 @@ function BundleControl({
   const uplotAction = useSetAtom(txnBarsUplotActionAtom);
   const filterBundle = useSetAtom(filterBundleDataAtom);
 
-  const toggleGroupRef =
-    useRef<ToggleGroupControlRef<InclusionFilterOption>>(null);
-
   const updateBundleFilter = useCallback(
     (value: InclusionFilterOption) => {
       if (!transactions) return;
       setValue(value);
-      uplotAction((u, bankIdx) => {
-        filterBundle(u, transactions, bankIdx, maxTs, value);
-      });
+      uplotAction((u, bankIdx) =>
+        filterBundle(u, transactions, bankIdx, maxTs, value),
+      );
     },
     [filterBundle, maxTs, transactions, uplotAction],
   );
 
-  const handleUpdate = useCallback(
-    (value: InclusionFilterOption) => {
-      updateBundleFilter(value);
-      toggleGroupRef.current?.focus(value);
-      // Targets the first bank tile since bundle filter affects all tiles
-      document
-        .getElementById(getUplotId(0))
-        ?.scrollIntoView({ behavior: "smooth", block: "nearest" });
-    },
-    [updateBundleFilter],
-  );
-
-  const { isTooltipOpen, closeTooltip } = useChartControl(
-    BUNDLE_CONTROL_KEY,
-    handleUpdate,
-  );
+  const { isTooltipOpen, closeTooltip, toggleGroupRef } =
+    useToggleGroupChartControl(BUNDLE_CONTROL_KEY, updateBundleFilter, () =>
+      updateBundleFilter("All"),
+    );
 
   return (
     <ToggleGroupControl
@@ -380,18 +381,31 @@ function LandedControl({
   const filterLanded = useSetAtom(filterLandedDataAtom);
   const [value, setValue] = useState<InclusionFilterOption>("All");
 
+  const updateLandedFilter = useCallback(
+    (value: InclusionFilterOption) => {
+      if (!transactions) return;
+      setValue(value);
+      uplotAction((u, bankIdx) =>
+        filterLanded(u, transactions, bankIdx, maxTs, value),
+      );
+    },
+    [filterLanded, maxTs, transactions, uplotAction],
+  );
+
+  const { isTooltipOpen, closeTooltip, toggleGroupRef } =
+    useToggleGroupChartControl(LANDED_CONTROL_KEY, updateLandedFilter, () =>
+      updateLandedFilter("All"),
+    );
+
   return (
     <ToggleGroupControl
+      ref={toggleGroupRef}
       label="Landed"
       options={INCLUSION_FILTER_OPTIONS}
       value={value}
-      onChange={(value) => {
-        if (!value) return;
-        setValue(value);
-        uplotAction((u, bankIdx) =>
-          filterLanded(u, transactions, bankIdx, maxTs, value),
-        );
-      }}
+      onChange={(value) => value && updateLandedFilter(value)}
+      isTooltipOpen={isTooltipOpen}
+      closeTooltip={closeTooltip}
       hasMinTextWidth={isMobileView}
     />
   );
@@ -406,18 +420,31 @@ function SimpleControl({
   const filterSimple = useSetAtom(filterSimpleDataAtom);
   const [value, setValue] = useState<InclusionFilterOption>("All");
 
+  const updateVoteFilter = useCallback(
+    (value: InclusionFilterOption) => {
+      if (!transactions) return;
+      setValue(value);
+      uplotAction((u, bankIdx) =>
+        filterSimple(u, transactions, bankIdx, maxTs, value),
+      );
+    },
+    [filterSimple, maxTs, transactions, uplotAction],
+  );
+
+  const { isTooltipOpen, closeTooltip, toggleGroupRef } =
+    useToggleGroupChartControl(VOTE_CONTROL_KEY, updateVoteFilter, () =>
+      updateVoteFilter("All"),
+    );
+
   return (
     <ToggleGroupControl
+      ref={toggleGroupRef}
       label="Vote"
       options={INCLUSION_FILTER_OPTIONS}
       value={value}
-      onChange={(value) => {
-        if (!value) return;
-        setValue(value);
-        uplotAction((u, bankIdx) =>
-          filterSimple(u, transactions, bankIdx, maxTs, value),
-        );
-      }}
+      onChange={(value) => value && updateVoteFilter(value)}
+      isTooltipOpen={isTooltipOpen}
+      closeTooltip={closeTooltip}
       hasMinTextWidth={isMobileView}
     />
   );
@@ -664,36 +691,22 @@ const beforeZeroMinToMaxRatio = 0.3;
 const snapToZeroRangePct = 0.025;
 
 function ArrivalControl({ transactions }: WithTransactionsProps) {
-  // Max value includes the chart buffer to have the entire chart range be represented
-  const sliderMaxValue = useMemo(
-    () => getMaxTsWithBuffer(transactions) - chartBufferMs,
-    [transactions],
+  const sliderMaxValue = useMemo(() => getMaxTs(transactions), [transactions]);
+  // Scaled from ms value to slider value
+  const sliderMinValue = useMemo(
+    () => -Math.ceil(sliderMaxValue * beforeZeroMinToMaxRatio),
+    [sliderMaxValue],
   );
-  const [rangeValue, setRangeValue] = useState(() => {
-    const maxTs = getMaxTsWithBuffer(transactions);
-    const minValue = -Math.ceil(maxTs * beforeZeroMinToMaxRatio);
-    // default max value does not include chart buffer since there should be no actual transactions arriving past maxTs without buffer
-    const maxValue = maxTs - chartBufferMs;
-    return [minValue, maxValue];
-  });
+
+  const [rangeValue, setRangeValue] = useState<number[]>([
+    sliderMinValue,
+    sliderMaxValue,
+  ]);
 
   const uplotAction = useSetAtom(txnBarsUplotActionAtom);
   const filterArrival = useSetAtom(filterArrivalDataAtom);
 
   const [sliderMeasureRef, { width }] = useMeasure<HTMLDivElement>();
-
-  function getTsToSliderValue(tsNanos: number) {
-    return tsNanos < 0 ? beforeZeroSliderMulti * tsNanos : tsNanos;
-  }
-
-  function getRangeMinMaxValues(range: number[]) {
-    if (range.length < 2) return;
-
-    return {
-      min: getTsToSliderValue(range[0]),
-      max: getTsToSliderValue(range[1]),
-    };
-  }
 
   const zeroValueSliderPct = `${Math.ceil((beforeZeroMinToMaxRatio / (1 + beforeZeroMinToMaxRatio)) * 100)}%`;
 
@@ -710,35 +723,82 @@ function ArrivalControl({ transactions }: WithTransactionsProps) {
     return Number(minArrival - transactions.start_timestamp_nanos);
   }, [transactions]);
 
-  /** Scaled from ms value to slider value */
-  const scaledMinValue = Math.ceil(sliderMaxValue * beforeZeroMinToMaxRatio);
   const snapToZeroRange = Math.ceil(sliderMaxValue * snapToZeroRangePct);
-  const beforeZeroSliderMulti = Math.abs(minValueNanos / scaledMinValue);
-  const sliderMinValue = -scaledMinValue;
+  const beforeZeroSliderMulti =
+    minValueNanos && sliderMinValue
+      ? Math.abs(minValueNanos / sliderMinValue)
+      : 1;
 
-  function getValueLabel(value: number) {
-    return `${Math.round(getTsToSliderValue(value) / 1_000_000).toLocaleString()} ms`;
-  }
+  const getTsToSliderValue = useCallback(
+    (tsNanos: number) =>
+      tsNanos < 0 ? beforeZeroSliderMulti * tsNanos : tsNanos,
+    [beforeZeroSliderMulti],
+  );
+
+  const getRangeMinMaxValues = useCallback(
+    (range: number[]) => {
+      if (range.length < 2) return;
+      return {
+        min: getTsToSliderValue(range[0]),
+        max: getTsToSliderValue(range[1]),
+      };
+    },
+    [getTsToSliderValue],
+  );
+
+  const getValueLabel = useCallback(
+    (value: number) =>
+      `${Math.round(getTsToSliderValue(value) / 1_000_000).toLocaleString()} ms`,
+    [getTsToSliderValue],
+  );
 
   const minValueLabel = getValueLabel(rangeValue[0]);
   const maxValueLabel = getValueLabel(rangeValue[1]);
 
-  const filterChart = useThrottledCallback(
+  const filterChart = useCallback(
     (value: number[]) => {
-      requestAnimationFrame(() =>
-        uplotAction((u, bankIdx) =>
-          filterArrival(
-            u,
-            transactions,
-            bankIdx,
-            sliderMaxValue,
-            getRangeMinMaxValues(value),
-          ),
+      uplotAction((u, bankIdx) =>
+        filterArrival(
+          u,
+          transactions,
+          bankIdx,
+          sliderMaxValue,
+          getRangeMinMaxValues(value),
         ),
       );
     },
+    [
+      filterArrival,
+      getRangeMinMaxValues,
+      transactions,
+      sliderMaxValue,
+      uplotAction,
+    ],
+  );
+
+  // Throttled for slider drag performance
+  const filterChartThrottled = useThrottledCallback(
+    (value: number[]) => {
+      requestAnimationFrame(() => filterChart(value));
+    },
     100,
     { leading: false, trailing: true },
+  );
+
+  const updateArrivalRange = useCallback(
+    (value: number[]) => {
+      setRangeValue(value);
+      filterChart(value);
+    },
+    [filterChart],
+  );
+
+  useEffect(() => {
+    updateArrivalRange([sliderMinValue, sliderMaxValue]);
+  }, [sliderMinValue, sliderMaxValue, updateArrivalRange]);
+
+  useChartControl(ARRIVAL_CONTROL_KEY, updateArrivalRange, () =>
+    updateArrivalRange([sliderMinValue, sliderMaxValue]),
   );
 
   return (
@@ -781,7 +841,7 @@ function ArrivalControl({ transactions }: WithTransactionsProps) {
               u.setCursor({ left, top: 0 });
             });
 
-            filterChart(value);
+            filterChartThrottled(value);
           }}
         />
       </div>

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/useChartControl.ts
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/useChartControl.ts
@@ -8,19 +8,29 @@ import {
 export default function useChartControl<K extends ChartControlKey>(
   key: K,
   update: ChartControlCallback<K>,
+  reset: () => void,
 ) {
   const { registerControl } = useContext(ChartControlsContext);
   const updateRef = useRef(update);
   updateRef.current = update;
+  const resetRef = useRef(reset);
+  resetRef.current = reset;
 
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
   const closeTooltip = useCallback(() => setIsTooltipOpen(false), []);
 
   useEffect(() => {
-    return registerControl(key, (value) => {
-      updateRef.current(value);
-      setIsTooltipOpen(true);
-    });
+    return registerControl(
+      key,
+      (value) => {
+        updateRef.current(value);
+        setIsTooltipOpen(true);
+      },
+      () => {
+        resetRef.current();
+        setIsTooltipOpen(false);
+      },
+    );
   }, [key, registerControl]);
 
   return { isTooltipOpen, closeTooltip };

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/useToggleGroupChartControl.ts
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartControls/useToggleGroupChartControl.ts
@@ -1,0 +1,36 @@
+import { useCallback, useRef } from "react";
+import type {
+  ChartControlCallback,
+  ChartControlMap,
+  ToggleOptionChartControlKey,
+} from "../../../../SlotDetails/ChartControlsContext";
+import type { ToggleGroupControlRef } from "./ToggleGroupControl";
+import useChartControl from "./useChartControl";
+import { getUplotId } from "../chartUtils";
+
+export default function useToggleGroupChartControl<
+  K extends ToggleOptionChartControlKey,
+>(key: K, update: ChartControlCallback<K>, reset: () => void) {
+  const toggleGroupRef =
+    useRef<ToggleGroupControlRef<ChartControlMap[K]>>(null);
+
+  const handleUpdate = useCallback(
+    (value: ChartControlMap[K]) => {
+      update(value);
+      toggleGroupRef.current?.focus(value);
+      // Targets the first bank tile since the filter affects all tiles
+      document
+        .getElementById(getUplotId(0))
+        ?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    },
+    [update],
+  );
+
+  const { isTooltipOpen, closeTooltip } = useChartControl(
+    key,
+    handleUpdate,
+    reset,
+  );
+
+  return { isTooltipOpen, closeTooltip, toggleGroupRef };
+}

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/atoms.ts
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/atoms.ts
@@ -162,12 +162,13 @@ function filterChartDataAtom<T>(
         maxTs,
         Object.values(filters),
       );
-
-      set(chartFiltersAtom, filters);
-
+      // Update the data first to ensure chartFiltersAtom updates based on filteredData
       u.data.splice(1, 1, filteredData[1]);
       u.data.splice(2, 1, filteredData[2]);
       u.setData(u.data, false);
+
+      set(chartFiltersAtom, filters);
+
       u.redraw(true, true);
     },
   );

--- a/src/features/SlotDetails/ChartControlsContext.tsx
+++ b/src/features/SlotDetails/ChartControlsContext.tsx
@@ -2,6 +2,10 @@ import { createContext } from "react";
 
 export type ChartControlsCleanup = () => void;
 
+export const ERROR_STATE_FILTER_OPTIONS = ["All", "Success", "Errors"] as const;
+export type ErrorStateFilterOption =
+  (typeof ERROR_STATE_FILTER_OPTIONS)[number];
+
 export const INCLUSION_FILTER_OPTIONS = ["All", "Yes", "No"] as const;
 export type InclusionFilterOption = (typeof INCLUSION_FILTER_OPTIONS)[number];
 
@@ -15,19 +19,34 @@ export const enum SearchMode {
 export type Search = { mode: SearchMode; text: string };
 
 export type ChartControlMap = {
+  errorState: ErrorStateFilterOption;
   bundle: InclusionFilterOption;
+  landed: InclusionFilterOption;
+  vote: InclusionFilterOption;
   focusBank: number | undefined;
   search: Search;
+  arrival: number[];
 };
 
 export type ChartControlKey = keyof ChartControlMap;
+export type ToggleOptionChartControlKey = {
+  [K in ChartControlKey]: ChartControlMap[K] extends
+    | InclusionFilterOption
+    | ErrorStateFilterOption
+    ? K
+    : never;
+}[ChartControlKey];
 export type ChartControlCallback<K extends ChartControlKey> = (
   value: ChartControlMap[K],
 ) => void;
 
+export const ERROR_STATE_CONTROL_KEY = "errorState" satisfies ChartControlKey;
 export const BUNDLE_CONTROL_KEY = "bundle" satisfies ChartControlKey;
+export const LANDED_CONTROL_KEY = "landed" satisfies ChartControlKey;
+export const VOTE_CONTROL_KEY = "vote" satisfies ChartControlKey;
 export const FOCUS_BANK_KEY = "focusBank" satisfies ChartControlKey;
 export const SEARCH_KEY = "search" satisfies ChartControlKey;
+export const ARRIVAL_CONTROL_KEY = "arrival" satisfies ChartControlKey;
 
 export type ChartControls = {
   triggerControl: <K extends ChartControlKey>(
@@ -37,12 +56,17 @@ export type ChartControls = {
   registerControl: <K extends ChartControlKey>(
     key: K,
     callback: ChartControlCallback<K>,
+    reset: () => void,
   ) => ChartControlsCleanup;
+  resetControl: (key: ChartControlKey) => void;
+  resetAllControls: (exclude?: ChartControlKey[]) => void;
 };
 
 export const DEFAULT_CHART_CONTROLS_CONTEXT: ChartControls = {
   triggerControl: () => {},
   registerControl: () => () => {},
+  resetControl: () => {},
+  resetAllControls: () => {},
 };
 
 export const ChartControlsContext = createContext<ChartControls>(

--- a/src/features/SlotDetails/ChartControlsProvider.tsx
+++ b/src/features/SlotDetails/ChartControlsProvider.tsx
@@ -11,17 +11,23 @@ export default function ChartControlsProvider({ children }: PropsWithChildren) {
   const callbacksRef = useRef<
     Map<ChartControlKey, ChartControlCallback<ChartControlKey>>
   >(new Map());
+  const resetsRef = useRef<Map<ChartControlKey, () => void>>(new Map());
 
   const value: ChartControls = useMemo(() => {
     const registerControl = <K extends ChartControlKey>(
       key: K,
       callback: ChartControlCallback<K>,
+      reset: () => void,
     ) => {
       callbacksRef.current.set(
         key,
         callback as ChartControlCallback<ChartControlKey>,
       );
-      return () => callbacksRef.current.delete(key);
+      resetsRef.current.set(key, reset);
+      return () => {
+        callbacksRef.current.delete(key);
+        resetsRef.current.delete(key);
+      };
     };
 
     const triggerControl = <K extends ChartControlKey>(
@@ -33,7 +39,17 @@ export default function ChartControlsProvider({ children }: PropsWithChildren) {
       );
     };
 
-    return { registerControl, triggerControl };
+    const resetControl = (key: ChartControlKey) => {
+      resetsRef.current.get(key)?.();
+    };
+
+    const resetAllControls = (exclude?: ChartControlKey[]) => {
+      for (const [key, reset] of resetsRef.current) {
+        if (!exclude?.includes(key)) reset();
+      }
+    };
+
+    return { registerControl, triggerControl, resetControl, resetAllControls };
   }, []);
 
   return (

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByBundle.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByBundle.tsx
@@ -8,6 +8,9 @@ import {
   BUNDLE_CONTROL_KEY,
   ChartControlsContext,
 } from "../../ChartControlsContext";
+import { useSetAtom } from "jotai";
+import { txnBarsUplotActionAtom } from "../../../Overview/SlotPerformance/TransactionBarsCard/uplotAtoms";
+import { banksXScaleKey } from "../../../Overview/SlotPerformance/ComputeUnitsCard/consts";
 
 const bundleLabel = "Bundle";
 
@@ -15,7 +18,8 @@ interface IncomeByTxnProps {
   transactions: SlotTransactions;
 }
 export default function IncomeByBundle({ transactions }: IncomeByTxnProps) {
-  const { triggerControl } = useContext(ChartControlsContext);
+  const { triggerControl, resetAllControls } = useContext(ChartControlsContext);
+  const uplotAction = useSetAtom(txnBarsUplotActionAtom);
 
   const data = useMemo(() => {
     const bundleValues = transactions.txn_from_bundle.map((fromBundle, i) => {
@@ -34,9 +38,18 @@ export default function IncomeByBundle({ transactions }: IncomeByTxnProps) {
   }, [transactions]);
 
   const onItemClick = useCallback(
-    ({ label }: { label: string; value: number }) =>
-      triggerControl(BUNDLE_CONTROL_KEY, label === bundleLabel ? "Yes" : "No"),
-    [triggerControl],
+    ({ label }: { label: string; value: number }) => {
+      resetAllControls([BUNDLE_CONTROL_KEY]);
+      triggerControl(BUNDLE_CONTROL_KEY, label === bundleLabel ? "Yes" : "No");
+      // Zoom out so all transactions are visible
+      uplotAction((u) => {
+        u.setScale(banksXScaleKey, {
+          min: u.data[0][0],
+          max: u.data[0][u.data[0].length - 1],
+        });
+      });
+    },
+    [resetAllControls, triggerControl, uplotAction],
   );
 
   return (

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByIp.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByIp.tsx
@@ -15,7 +15,7 @@ interface IncomeByTxnProps {
 }
 
 export default function IncomeByIp({ transactions }: IncomeByTxnProps) {
-  const { triggerControl } = useContext(ChartControlsContext);
+  const { triggerControl, resetAllControls } = useContext(ChartControlsContext);
 
   const data = useMemo(() => {
     const ipValues = transactions.txn_source_ipv4.map((ip, i) => {
@@ -34,9 +34,10 @@ export default function IncomeByIp({ transactions }: IncomeByTxnProps) {
 
   const onItemClick = useCallback(
     ({ label }: { label: string; value: number }) => {
+      resetAllControls([SEARCH_KEY]);
       triggerControl(SEARCH_KEY, { mode: SearchMode.Ip, text: label });
     },
-    [triggerControl],
+    [resetAllControls, triggerControl],
   );
 
   return (

--- a/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByTxn.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/FeeSection/IncomeByTxn.tsx
@@ -14,7 +14,7 @@ interface IncomeByTxnProps {
   transactions: SlotTransactions;
 }
 export default function IncomeByTxn({ transactions }: IncomeByTxnProps) {
-  const { triggerControl } = useContext(ChartControlsContext);
+  const { triggerControl, resetAllControls } = useContext(ChartControlsContext);
 
   const data = useMemo(() => {
     const signatureValues = transactions.txn_signature.map((signature, i) => {
@@ -34,12 +34,13 @@ export default function IncomeByTxn({ transactions }: IncomeByTxnProps) {
 
   const onItemClick = useCallback(
     ({ label }: { label: string; value: number }) => {
+      resetAllControls([SEARCH_KEY]);
       triggerControl(SEARCH_KEY, {
         mode: SearchMode.TxnSignature,
         text: label,
       });
     },
-    [triggerControl],
+    [resetAllControls, triggerControl],
   );
 
   return (

--- a/src/transactionUtils.ts
+++ b/src/transactionUtils.ts
@@ -5,7 +5,10 @@ import { isFrankendancer } from "./client";
 
 export const chartBufferMs = 2_000_000;
 
-export function getMaxTsWithBuffer(transactions: SlotTransactions) {
+export function getMaxTs(
+  transactions: SlotTransactions,
+  includeBuffer: boolean = false,
+) {
   if (!transactions) return 0;
 
   const txnTs = transactions.txn_mb_end_timestamps_nanos.map((ts) =>
@@ -17,7 +20,8 @@ export function getMaxTsWithBuffer(transactions: SlotTransactions) {
         transactions.start_timestamp_nanos,
     ),
   );
-  return (max(txnTs) ?? 0) + chartBufferMs;
+  const maxTxnTs = max(txnTs) ?? 0;
+  return includeBuffer ? maxTxnTs + chartBufferMs : maxTxnTs;
 }
 
 export function getTxnStateDurations(


### PR DESCRIPTION
- add error state, landed, vote, and arrival to chart controls
- reset other chart controls when trigger a control externally (from distribution bars)
- fix stale rangeValue when transactions change
- fix divide by zero for beforeZeroSliderMulti
- fix ordering of data update and chart filter update, so filteredTxnIdxAtom does not use stale data