### PR TITLE
chore: performance improvement for Bars

### DIFF
--- a/src/features/StartupProgress/Firedancer/Bars.tsx
+++ b/src/features/StartupProgress/Firedancer/Bars.tsx
@@ -1,10 +1,8 @@
 import styles from "./bars.module.css";
-import clsx from "clsx";
 import { clamp } from "lodash";
-import { useMeasure } from "react-use";
+import type { CSSProperties } from "react";
 
 const _barWidth = 2;
-const viewBoxHeight = 1000;
 
 interface BarsProps {
   value: number;
@@ -12,48 +10,18 @@ interface BarsProps {
   barWidth?: number;
 }
 export function Bars({ value, max, barWidth = _barWidth }: BarsProps) {
-  const [ref, { width }] = useMeasure<SVGSVGElement>();
-
-  const barGap = barWidth * 1.5;
-  const barCount = Math.trunc(width / (barWidth + barGap));
-
-  // only show empty bars if no max, or value is actually 0
-  const currentIndex =
-    !max || !value
-      ? -1
-      : clamp(Math.round((value / max) * barCount) - 1, 0, barCount - 1);
-
-  const usedWidth = barCount * (barWidth + barGap);
+  const pct = !max || !value ? 0 : clamp(value / max, 0, 1);
 
   return (
-    <svg
+    <div
       className={styles.bars}
-      ref={ref}
-      preserveAspectRatio="none"
-      width="100%"
-      viewBox={`0 0 ${usedWidth} ${viewBoxHeight}`}
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      {Array.from({ length: barCount }, (_, i) => {
-        const isHigh = i >= barCount * 0.95 || i === barCount - 1;
-        const isMid = !isHigh && i >= barCount * 0.85;
-
-        return (
-          <rect
-            key={i}
-            x={i * (usedWidth / barCount)}
-            width={barWidth}
-            height={viewBoxHeight}
-            ry={barWidth * 2}
-            className={clsx({
-              [styles.threshold]: i === currentIndex,
-              [styles.filled]: i < currentIndex,
-              [styles.high]: isHigh,
-              [styles.mid]: isMid,
-            })}
-          />
-        );
-      })}
-    </svg>
+      style={
+        {
+          "--bar-width": `${barWidth}px`,
+          "--bar-gap": `${barWidth * 1.5}px`,
+          "--pct": pct,
+        } as CSSProperties
+      }
+    />
   );
 }

--- a/src/features/StartupProgress/Firedancer/bars.module.css
+++ b/src/features/StartupProgress/Firedancer/bars.module.css
@@ -1,34 +1,109 @@
 .bars {
-  width: 100%;
+  --container-width: 100%;
+
+  position: relative;
+  width: var(--container-width);
   height: var(--bar-height, 50px);
 
-  rect {
-    fill: var(--boot-progress-gossip-bars-color);
-    &.threshold {
-      fill: var(--app-teal);
-    }
-    &.filled {
-      fill: var(--boot-progress-gossip-filled-bar-color);
-    }
+  --step: calc(var(--bar-width) + var(--bar-gap));
+  /*
+    n bars, n - 1 gaps
+    n = floor((container_width + gap) / step)
+    used_width = n * step - gap 
+    = floor((container_width + gap) / step) * step - gap
+    = round(down, container_width + gap, step) - gap
+    NOTE: floor(x / y) * y = round(down, x, y)
+  */
+  --used-width: max(
+    0px,
+    calc(
+      round(down, var(--container-width) + var(--bar-gap), var(--step)) -
+        var(--bar-gap)
+    )
+  );
 
-    &.mid {
-      fill: var(--boot-progress-gossip-mid-bar-color);
-      &.filled {
-        fill: var(--boot-progress-gossip-mid-filled-bar-color);
-      }
-      &.threshold {
-        fill: var(--boot-progress-gossip-mid-threshold-bar-color);
-      }
-    }
+  /*
+    n = (used_width + gap) / step
+    idx = round(pct * n) - 1
+    threshold_start = idx * step = (round(pct * n) - 1) * step 
+      = round(pct * n) * step - step
+      = round(pct * (used_width + gap) / step) * step - step
+      = round(nearest, pct * (used_width + gap), step) - step
+  */
 
-    &.high {
-      fill: var(--boot-progress-gossip-high-bar-color);
-      &.filled {
-        fill: var(--boot-progress-gossip-high-filled-bar-color);
-      }
-      &.threshold {
-        fill: var(--boot-progress-gossip-high-threshold-bar-color);
-      }
-    }
+  --threshold-start: max(
+    0px,
+    calc(
+      round(
+          nearest,
+          var(--pct) * (var(--used-width) + var(--bar-gap)),
+          var(--step)
+        ) -
+        var(--step)
+    )
+  );
+  --threshold-visible: sign(var(--pct));
+
+  /* Bar pattern mask */
+  mask-image: repeating-linear-gradient(
+    to right,
+    black 0 var(--bar-width),
+    transparent var(--bar-width) var(--step)
+  );
+  mask-size: var(--used-width) 100%;
+  mask-repeat: no-repeat;
+
+  /* Unfilled bars with zone colors */
+  background: linear-gradient(
+    to right,
+    var(--boot-progress-gossip-bars-color) 85%,
+    var(--boot-progress-gossip-mid-bar-color) 85% 95%,
+    var(--boot-progress-gossip-high-bar-color) 95%
+  );
+  background-size: var(--used-width) 100%;
+  background-repeat: no-repeat;
+
+  /* Filled bars */
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: var(--used-width);
+    clip-path: inset(
+      0 calc(100% - var(--threshold-start) + var(--bar-width)) 0 0
+    );
+    background: linear-gradient(
+      to right,
+      var(--boot-progress-gossip-filled-bar-color) 85%,
+      var(--boot-progress-gossip-mid-filled-bar-color) 85% 95%,
+      var(--boot-progress-gossip-high-filled-bar-color) 95%
+    );
+    background-size: var(--used-width) 100%;
+    background-repeat: no-repeat;
+  }
+
+  /* Threshold bar */
+  &::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: var(--used-width);
+    clip-path: inset(
+      0 calc(100% - var(--threshold-start) - var(--bar-width)) 0
+        var(--threshold-start)
+    );
+    opacity: var(--threshold-visible, 0);
+    background: linear-gradient(
+      to right,
+      var(--app-teal) 85%,
+      var(--boot-progress-gossip-mid-threshold-bar-color) 85% 95%,
+      var(--boot-progress-gossip-high-threshold-bar-color) 95%
+    );
+    background-size: var(--used-width) 100%;
+    background-repeat: no-repeat;
   }
 }


### PR DESCRIPTION
Adapted from @ripatel-fd https://github.com/firedancer-io/firedancer-frontend/pull/291

- Instead of using SVGs for Bars, use a div with pseudo elements, background color and masking
- Remove `useMeasure` which was triggering forced reflow. Use CSS vars and calc to determine widths instead