### PR TITLE
feat: tiles table column groups

### DIFF
--- a/src/features/Overview/LiveNetworkMetrics/index.tsx
+++ b/src/features/Overview/LiveNetworkMetrics/index.tsx
@@ -23,6 +23,7 @@ import { tileChartDarkBackground } from "../../../colors";
 import { isFrankendancer } from "../../../client";
 import type { HistoryEntry } from "../../../api/worker/types";
 import { useEmaValue } from "../../../hooks/useEma";
+import clsx from "clsx";
 
 const chartHeight = 18;
 
@@ -66,7 +67,7 @@ function NetworkMetricsCard({
         <Text className={tableStyles.headerText}>Network {type}</Text>
         <Table.Root
           variant="ghost"
-          className={tableStyles.root}
+          className={clsx(tableStyles.root, styles.table)}
           size="1"
           style={{ "--bar-height": `${chartHeight}px` } as CSSProperties}
         >
@@ -179,7 +180,7 @@ function TableRow({
   );
 
   return (
-    <Table.Row className={className}>
+    <Table.Row className={clsx(styles.row, className)}>
       <Table.RowHeaderCell>{label}</Table.RowHeaderCell>
       <Table.Cell align="right">
         {formattedValue.value} {formattedValue.unit}

--- a/src/features/Overview/LiveNetworkMetrics/liveNetworkMetrics.module.css
+++ b/src/features/Overview/LiveNetworkMetrics/liveNetworkMetrics.module.css
@@ -4,6 +4,12 @@
   vertical-align: middle;
 }
 
-.total-row {
-  border-top: 1px solid rgba(250, 250, 250, 0.5);
+.table table tbody .row {
+  &.total-row {
+    border-top: 1px solid rgba(250, 250, 250, 0.5);
+  }
+  th,
+  td {
+    color: var(--table-body-color);
+  }
 }

--- a/src/features/Overview/LiveTileMetrics/TableDescriptionDialog.tsx
+++ b/src/features/Overview/LiveTileMetrics/TableDescriptionDialog.tsx
@@ -1,7 +1,7 @@
 import { Button, Dialog, Flex, Table, Tooltip } from "@radix-ui/themes";
 import styles from "./tableDescriptionDialog.module.css";
 import { InfoCircledIcon } from "@radix-ui/react-icons";
-import { metrics } from "./consts";
+import { metricGroups } from "./consts";
 import { appMaxWidth } from "../../../consts";
 
 export default function TableDescriptionDialog() {
@@ -40,12 +40,16 @@ export default function TableDescriptionDialog() {
           </Table.Header>
 
           <Table.Body>
-            {metrics.map((metric) => (
-              <Table.Row key={metric.name} className={styles.tr}>
-                <Table.Cell className={styles.name}>{metric.name}</Table.Cell>
-                <Table.Cell>{metric.description}</Table.Cell>
-              </Table.Row>
-            ))}
+            {metricGroups.map((group) =>
+              group.metrics.map((metric) => (
+                <Table.Row key={metric.uniqueName} className={styles.tr}>
+                  <Table.Cell className={styles.name}>
+                    {metric.uniqueName}
+                  </Table.Cell>
+                  <Table.Cell>{metric.description}</Table.Cell>
+                </Table.Row>
+              )),
+            )}
           </Table.Body>
         </Table.Root>
 

--- a/src/features/Overview/LiveTileMetrics/consts.ts
+++ b/src/features/Overview/LiveTileMetrics/consts.ts
@@ -24,141 +24,189 @@ export const regimes = [
 ];
 
 interface MetricDefinition {
-  name: string;
+  uniqueName: string;
+  columnName?: string;
   description: string;
   headerColWidth: number;
   headerColAlign?: Table.ColumnHeaderCellProps["align"];
   wrap?: boolean;
 }
 
-export const metrics: MetricDefinition[] = [
+export const metricGroups: {
+  name: string;
+  pinned?: boolean;
+  metrics: MetricDefinition[];
+}[] = [
   {
-    name: "Name",
-    description:
-      "The name and index of each tile. A tile represents a sandboxed process or individual thread that communicates with other tiles using message passing queues.",
-    headerColWidth: 70,
+    name: "",
+    pinned: true,
+    metrics: [
+      {
+        uniqueName: "Name",
+        description:
+          "The name and index of each tile. A tile represents a sandboxed process or individual thread that communicates with other tiles using message passing queues.",
+        headerColWidth: 70,
+      },
+    ],
   },
   {
-    name: "CPU",
-    description: "The CPU index on which the tile was last recorded executing.",
-    headerColWidth: 70,
-    headerColAlign: "right",
-  },
-  {
-    name: "Heartbeat",
-    description:
-      "Liveness indicator based on a periodic heartbeat timestamp written by tiles to a chunk of shared memory.",
-    headerColWidth: 70,
-    headerColAlign: "right",
-  },
-  {
-    name: "Minflt",
-    description:
-      "The number of cumulative minor page faults. Minor page faults occur for pages in RAM not indexed by the page table.",
-    headerColWidth: 80,
-    headerColAlign: "right",
-  },
-  {
-    name: "Majflt",
-    description:
-      "The number of cumulative major page faults. Major page faults occur for pages that are neither in RAM nor the page table.",
-    headerColWidth: 80,
-    headerColAlign: "right",
-  },
-  {
-    name: "Nivcsw",
-    description:
-      "The number of cumulative | immediate (10ms) involuntary context switches.",
-    headerColWidth: 160,
-    headerColAlign: "right",
-  },
-  {
-    name: "Nvcsw",
-    description:
-      "The number of cumulative | immediate (10ms) voluntary context switches.",
-    headerColWidth: 160,
-    headerColAlign: "right",
-  },
-  {
-    name: "Backp",
-    description:
-      "If a tile is backpressured, at least one outgoing message queue is at-capacity which can prevent the tile from moving forward with useful work.",
-    headerColWidth: 70,
-  },
-  {
-    name: "Backp Count",
-    description:
-      "The number of cumulative | immediate (10ms) times a CPU transitioned into a backpressured state.",
-    headerColWidth: 160,
-    headerColAlign: "right",
+    name: "Liveness",
+    metrics: [
+      {
+        uniqueName: "CPU",
+        description:
+          "The CPU index on which the tile was last recorded executing.",
+        headerColWidth: 70,
+        headerColAlign: "right",
+      },
+      {
+        uniqueName: "Heartbeat",
+        description:
+          "Liveness indicator based on a periodic heartbeat timestamp written by tiles to a chunk of shared memory.",
+        headerColWidth: 70,
+        headerColAlign: "right",
+      },
+      {
+        uniqueName: "Minflt",
+        description:
+          "The number of cumulative minor page faults. Minor page faults occur for pages in RAM not indexed by the page table.",
+        headerColWidth: 80,
+        headerColAlign: "right",
+      },
+      {
+        uniqueName: "Majflt",
+        description:
+          "The number of cumulative major page faults. Major page faults occur for pages that are neither in RAM nor the page table.",
+        headerColWidth: 80,
+        headerColAlign: "right",
+      },
+      {
+        uniqueName: "Nivcsw",
+        description:
+          "The number of cumulative | immediate (10ms) involuntary context switches.",
+        headerColWidth: 160,
+        headerColAlign: "right",
+      },
+      {
+        uniqueName: "Nvcsw",
+        description:
+          "The number of cumulative | immediate (10ms) voluntary context switches.",
+        headerColWidth: 160,
+        headerColAlign: "right",
+      },
+      {
+        uniqueName: "Backp",
+        description:
+          "If a tile is backpressured, at least one outgoing message queue is at-capacity which can prevent the tile from moving forward with useful work.",
+        headerColWidth: 70,
+        headerColAlign: "right",
+      },
+    ],
   },
   {
     name: "Utilization",
-    description:
-      "Visualized the percentage of the tile's CPU time spent doing useful work. Time spent in a context switch is not included.",
-    headerColWidth: 200,
+    metrics: [
+      {
+        uniqueName: "Backp Count",
+        description:
+          "The number of cumulative | immediate (10ms) times a CPU transitioned into a backpressured state.",
+        headerColWidth: 160,
+        headerColAlign: "right",
+      },
+      {
+        uniqueName: "Utilization",
+        description:
+          "Visualized the percentage of the tile's CPU time spent doing useful work. Time spent in a context switch is not included.",
+        headerColWidth: 200,
+      },
+      {
+        uniqueName: "History (1m)",
+        description: "A historical, low-pass-filtered view of CPU utilization.",
+        headerColWidth: 200,
+      },
+    ],
   },
   {
-    name: "History (1m)",
-    description: "A historical, low-pass-filtered view of CPU utilization.",
-    headerColWidth: 200,
+    name: "System",
+    metrics: [
+      {
+        uniqueName: "% Hkeep",
+        description:
+          "The percentage of CPU time spent on housekeeping tasks, which are meant to be infrequent and generally more expensive than tasks on the critical path.",
+        headerColWidth: 80,
+        headerColAlign: "right",
+      },
+      {
+        uniqueName: "% Wait",
+        description:
+          "The percentage of CPU time spent waiting for useful work to do.",
+        headerColWidth: 80,
+        headerColAlign: "right",
+      },
+      {
+        uniqueName: "% Backp",
+        description:
+          "The percentage of CPU time during which the tile was backpressured, excluding housekeeping time.",
+        headerColWidth: 80,
+        headerColAlign: "right",
+      },
+      {
+        uniqueName: "% Work",
+        description:
+          "The percentage of CPU time spent performing useful work, excluding housekeeping and backpressured time.",
+        headerColWidth: 80,
+        headerColAlign: "right",
+      },
+    ],
   },
   {
-    name: "% Hkeep",
-    description:
-      "The percentage of CPU time spent on housekeeping tasks, which are meant to be infrequent and generally more expensive than tasks on the critical path.",
-    headerColWidth: 80,
-    headerColAlign: "right",
-  },
-  {
-    name: "% Wait",
-    description:
-      "The percentage of CPU time spent waiting for useful work to do.",
-    headerColWidth: 80,
-    headerColAlign: "right",
-  },
-  {
-    name: "% Backp",
-    description:
-      "The percentage of CPU time during which the tile was backpressured, excluding housekeeping time.",
-    headerColWidth: 80,
-    headerColAlign: "right",
-  },
-  {
-    name: "% Work",
-    description:
-      "The percentage of CPU time spent performing useful work, excluding housekeeping and backpressured time.",
-    headerColWidth: 80,
-    headerColAlign: "right",
-  },
-  {
-    name: "% Wait (scheduler)",
-    description:
-      "The percentage of CPU time spent waiting in the runqueue before being dispatched.",
-    headerColWidth: 80,
-    headerColAlign: "right",
-    wrap: true,
-  },
-  {
-    name: "% User (scheduler)",
-    description: "The percentage of CPU time spent executing in user mode.",
-    headerColWidth: 80,
-    headerColAlign: "right",
-    wrap: true,
-  },
-  {
-    name: "% System (scheduler)",
-    description: "The percentage of CPU time spent executing in kernel mode.",
-    headerColWidth: 80,
-    headerColAlign: "right",
-    wrap: true,
-  },
-  {
-    name: "% Idle (scheduler)",
-    description:
-      "The percentage of CPU time unaccounted for by the other 3 regimes.",
-    headerColWidth: 80,
-    headerColAlign: "right",
-    wrap: true,
+    name: "Scheduler",
+    metrics: [
+      {
+        uniqueName: "% Wait (scheduler)",
+        columnName: "% Wait",
+        description:
+          "The percentage of CPU time spent waiting in the runqueue before being dispatched.",
+        headerColWidth: 80,
+        headerColAlign: "right",
+        wrap: true,
+      },
+      {
+        uniqueName: "% User (scheduler)",
+        columnName: "% User",
+        description: "The percentage of CPU time spent executing in user mode.",
+        headerColWidth: 80,
+        headerColAlign: "right",
+        wrap: true,
+      },
+      {
+        uniqueName: "% System (scheduler)",
+        columnName: "% System",
+        description:
+          "The percentage of CPU time spent executing in kernel mode.",
+        headerColWidth: 80,
+        headerColAlign: "right",
+        wrap: true,
+      },
+      {
+        uniqueName: "% Idle (scheduler)",
+        columnName: "% Idle",
+        description:
+          "The percentage of CPU time unaccounted for by the other 3 regimes.",
+        headerColWidth: 80,
+        headerColAlign: "right",
+        wrap: true,
+      },
+    ],
   },
 ];
+
+export const pinnedGroups = metricGroups.filter(({ pinned }) => pinned);
+export const unpinnedGroups = metricGroups.filter(({ pinned }) => !pinned);
+
+export const pinnedTableWidth = pinnedGroups.reduce((acc, group) => {
+  for (const metric of group.metrics) {
+    acc += metric.headerColWidth;
+  }
+  return acc;
+}, 0);

--- a/src/features/Overview/LiveTileMetrics/index.tsx
+++ b/src/features/Overview/LiveTileMetrics/index.tsx
@@ -31,11 +31,11 @@ import { tileChartDarkBackground } from "../../../colors";
 import { isEqual } from "lodash";
 import type { CellProps } from "@radix-ui/themes/components/table";
 import TableDescriptionDialog from "./TableDescriptionDialog";
-import { metrics } from "./consts";
+import { pinnedGroups, pinnedTableWidth, unpinnedGroups } from "./consts";
 
 const chartHeight = 18;
 
-export default function LiveTileMetrics() {
+export default memo(function LiveTileMetrics() {
   return (
     <Card>
       <Flex direction="column" gap={headerGap} width="100%">
@@ -43,15 +43,39 @@ export default function LiveTileMetrics() {
           <Text className={tableStyles.headerText}>Tiles</Text>
           <TableDescriptionDialog />
         </Flex>
-        <MLiveMetricTable />
+        <LiveMetricsTables />
       </Flex>
     </Card>
   );
+});
+
+function LiveMetricsTables() {
+  return (
+    <Flex>
+      <LiveMetricsTable isPinned={true} />
+      <LiveMetricsTable isPinned={false} />
+    </Flex>
+  );
 }
 
-const MLiveMetricTable = memo(function LiveMetricsTable() {
+interface LiveMetricsTableProps {
+  isPinned: boolean;
+}
+function LiveMetricsTable({ isPinned }: LiveMetricsTableProps) {
   const tiles = useAtomValue(tilesAtom);
   const liveTileMetrics = useAtomValue(liveTileMetricsAtom);
+
+  const groups = isPinned ? pinnedGroups : unpinnedGroups;
+
+  const rootStyle = useMemo(
+    () =>
+      ({
+        "--bar-height": `${chartHeight}px`,
+        minWidth: isPinned ? `${pinnedTableWidth}px` : "0px",
+        flexBasis: isPinned ? `${pinnedTableWidth}px` : undefined,
+      }) as CSSProperties,
+    [isPinned],
+  );
 
   if (!tiles || !liveTileMetrics) return;
 
@@ -60,32 +84,55 @@ const MLiveMetricTable = memo(function LiveMetricsTable() {
       variant="ghost"
       className={clsx(tableStyles.root, styles.table)}
       size="1"
-      style={
-        {
-          "--bar-height": `${chartHeight}px`,
-        } as CSSProperties
-      }
+      style={rootStyle}
     >
       <colgroup>
-        {metrics.map((metric) => (
-          <col key={metric.name} style={{ width: metric.headerColWidth }} />
-        ))}
+        {groups.map((group) =>
+          group.metrics.map((metric) => (
+            <col
+              key={metric.uniqueName}
+              style={{ width: metric.headerColWidth }}
+            />
+          )),
+        )}
       </colgroup>
+
       <Table.Header className={styles.header}>
         <Table.Row>
-          {metrics.map((metric) => (
+          {groups.map((group, i) => (
             <Table.ColumnHeaderCell
-              key={metric.name}
-              align={metric.headerColAlign}
-              className={clsx({
-                [styles.wrap]: !!metric.wrap,
+              key={group.name}
+              colSpan={group.metrics.length}
+              className={clsx(styles.groupHeader, {
+                [styles.rightBorder]: isPinned || i !== groups.length - 1,
               })}
             >
-              {metric.name}
+              {group.name}
             </Table.ColumnHeaderCell>
           ))}
         </Table.Row>
+
+        <Table.Row className={styles.lightBorderBottom}>
+          {groups.map((group, i) =>
+            group.metrics.map((metric, j) => (
+              <Table.ColumnHeaderCell
+                key={metric.uniqueName}
+                align={metric.headerColAlign}
+                className={clsx({
+                  [styles.wrap]: !!metric.wrap,
+                  [styles.rightBorder]:
+                    isPinned ||
+                    // last metric (except in last group) has right border
+                    (i !== groups.length - 1 && j === group.metrics.length - 1),
+                })}
+              >
+                {metric.columnName ?? metric.uniqueName}
+              </Table.ColumnHeaderCell>
+            )),
+          )}
+        </Table.Row>
       </Table.Header>
+
       <Table.Body>
         {tiles.map((tile, i) => (
           <TableRow
@@ -93,19 +140,21 @@ const MLiveMetricTable = memo(function LiveMetricsTable() {
             tile={tile}
             liveTileMetrics={liveTileMetrics}
             idx={i}
+            isPinned={isPinned}
           />
         ))}
       </Table.Body>
     </Table.Root>
   );
-});
+}
 
 interface TableRowProps {
   tile: Tile;
   liveTileMetrics: TileMetrics;
   idx: number;
+  isPinned: boolean;
 }
-function TableRow({ tile, liveTileMetrics, idx }: TableRowProps) {
+function TableRow({ tile, liveTileMetrics, idx, isPinned }: TableRowProps) {
   const prevLiveTileMetricsIdx = usePreviousDistinct(
     liveTileMetrics,
     (prev, next) => {
@@ -121,6 +170,52 @@ function TableRow({ tile, liveTileMetrics, idx }: TableRowProps) {
     },
   );
 
+  const alive =
+    liveTileMetrics.alive[idx] ?? prevLiveTileMetricsIdx?.alive[idx];
+
+  // Meaning tile has shut down, no need to list it in the table
+  if (alive === 2) return;
+
+  const timers =
+    liveTileMetrics.timers[idx] || prevLiveTileMetricsIdx?.timers[idx];
+
+  if (!timers) return;
+
+  if (isPinned) {
+    return (
+      <Table.Row className={styles.dataRow}>
+        <Table.Cell className={styles.rightBorder}>
+          {tile.kind}:{tile.kind_id}
+        </Table.Cell>
+      </Table.Row>
+    );
+  }
+
+  return (
+    <DataRow
+      alive={alive}
+      timers={timers}
+      liveTileMetrics={liveTileMetrics}
+      prevLiveTileMetricsIdx={prevLiveTileMetricsIdx}
+      idx={idx}
+    />
+  );
+}
+
+interface DataRowProps {
+  alive: number | null | undefined;
+  timers: number[];
+  liveTileMetrics: TileMetrics;
+  prevLiveTileMetricsIdx?: TileMetrics;
+  idx: number;
+}
+function DataRow({
+  alive,
+  timers,
+  liveTileMetrics,
+  prevLiveTileMetricsIdx,
+  idx,
+}: DataRowProps) {
   const prevSchedTimers = usePreviousDistinct(
     liveTileMetrics.sched_timers[idx],
   );
@@ -130,8 +225,6 @@ function TableRow({ tile, liveTileMetrics, idx }: TableRowProps) {
   const [schedWaitPct, schedIdlePct, schedUserPct, schedSystemPct] =
     schedTimers.map((v) => (v === -1 ? 0 : v));
 
-  const alive =
-    liveTileMetrics.alive[idx] ?? prevLiveTileMetricsIdx?.alive[idx];
   const nivcsw =
     liveTileMetrics.nivcsw[idx] ?? prevLiveTileMetricsIdx?.nivcsw[idx];
   const nvcsw =
@@ -151,14 +244,6 @@ function TableRow({ tile, liveTileMetrics, idx }: TableRowProps) {
   const prevNvcsw = usePrevious(nvcsw);
   const prevBackPressureCount = usePrevious(backPressureCount);
 
-  // Meaning tile has shut down, no need to list it in the table
-  if (alive === 2) return;
-
-  const timers =
-    liveTileMetrics.timers[idx] || prevLiveTileMetricsIdx?.timers[idx];
-
-  if (!timers) return;
-
   for (let i = 0; i < timers.length; i++) {
     if (timers[i] === -1) timers[i] = 0;
   }
@@ -169,10 +254,7 @@ function TableRow({ tile, liveTileMetrics, idx }: TableRowProps) {
   const workPct = timers[3] + timers[4] + timers[7];
 
   return (
-    <Table.Row className={styles.row}>
-      <Table.Cell>
-        {tile.kind}:{tile.kind_id}
-      </Table.Cell>
+    <Table.Row className={styles.dataRow}>
       <Table.Cell align="right">{cpu}</Table.Cell>
       <Table.Cell
         className={clsx({ [styles.green]: alive, [styles.red]: !alive })}
@@ -180,10 +262,8 @@ function TableRow({ tile, liveTileMetrics, idx }: TableRowProps) {
       >
         {alive ? "Live" : "Dead"}
       </Table.Cell>
-
       <Table.Cell align="right">{minflt}</Table.Cell>
       <Table.Cell align="right">{majflt}</Table.Cell>
-
       <Table.Cell align="right">
         {nivcsw?.toLocaleString() ?? "0"} |
         <IncrementText
@@ -196,9 +276,13 @@ function TableRow({ tile, liveTileMetrics, idx }: TableRowProps) {
           value={nvcsw != null && prevNvcsw != null ? nvcsw - prevNvcsw : 0}
         />
       </Table.Cell>
-      <Table.Cell className={clsx({ [styles.red]: inBackpressure })}>
+      <Table.Cell
+        align="right"
+        className={clsx(styles.rightBorder, { [styles.red]: inBackpressure })}
+      >
         {inBackpressure ? "Yes" : "-"}
       </Table.Cell>
+
       <Table.Cell align="right">
         {backPressureCount?.toLocaleString() ?? "0"} |
         <Text
@@ -217,6 +301,7 @@ function TableRow({ tile, liveTileMetrics, idx }: TableRowProps) {
         </Text>
       </Table.Cell>
       <MUtilization idx={idx} />
+
       <PctCell
         pct={hKeepPct}
         className={clsx({ [styles.red]: hKeepPct > 1 })}
@@ -228,13 +313,14 @@ function TableRow({ tile, liveTileMetrics, idx }: TableRowProps) {
       />
       <PctCell
         pct={workPct}
-        className={styles.pctGradient}
+        className={clsx(styles.pctGradient, styles.rightBorder)}
         style={
           {
             "--pct": `${workPct}%`,
           } as CSSProperties
         }
       />
+
       <PctCell pct={schedWaitPct} />
       <PctCell pct={schedUserPct} />
       <PctCell pct={schedSystemPct} />
@@ -333,7 +419,7 @@ const MUtilization = memo(function Utilization({ idx }: UtilizationProps) {
           <Bars value={pct >= 0 ? pct : (prevPct ?? 0)} max={1} barWidth={2} />
         </Flex>
       </Table.Cell>
-      <Table.Cell className={styles.noPadding}>
+      <Table.Cell className={clsx(styles.noPadding, styles.rightBorder)}>
         <TileSparkLine
           value={avgValue}
           history={initialHistory}

--- a/src/features/Overview/LiveTileMetrics/liveTileMetrics.module.css
+++ b/src/features/Overview/LiveTileMetrics/liveTileMetrics.module.css
@@ -1,55 +1,9 @@
-.row {
-  .green {
-    color: var(--green-9);
-  }
-
-  .red {
-    color: var(--red-9);
-  }
-
-  td {
-    text-align: left;
-    &[align="right"] {
-      text-align: right;
-    }
-    vertical-align: middle;
-
-    &.pct-gradient {
-      color: color-mix(
-        in srgb,
-        var(--tile-busy-green-color),
-        var(--tile-busy-red-color) var(--pct)
-      );
-    }
-
-    &.no-padding {
-      padding-top: 0;
-      padding-bottom: 0;
-    }
-
-    .increment-text {
-      min-width: 5ch;
-      display: inline-block;
-      font-variant-numeric: tabular-nums;
-
-      &.low-increment {
-        color: var(--low-increment-text-color);
-      }
-      &.mid-increment {
-        color: var(--mid-increment-text-color);
-      }
-      &.high-increment {
-        color: var(--high-increment-text-color);
-      }
-    }
-  }
+.group-header {
+  text-align: center;
+  padding: 5px;
 }
 
 .header {
-  position: sticky;
-  top: 0;
-  background: rgb(19, 23, 32);
-
   th {
     vertical-align: bottom;
     &.wrap {
@@ -61,5 +15,75 @@
 .table {
   table {
     table-layout: fixed;
+
+    .data-row {
+      .green {
+        color: var(--green-9);
+      }
+
+      .red {
+        color: var(--red-9);
+      }
+
+      td {
+        color: var(--table-body-color);
+        text-align: left;
+        &[align="right"] {
+          text-align: right;
+        }
+        vertical-align: middle;
+
+        &.pct-gradient {
+          color: color-mix(
+            in srgb,
+            var(--tile-busy-green-color),
+            var(--tile-busy-red-color) var(--pct)
+          );
+        }
+
+        &.no-padding {
+          padding-top: 0;
+          padding-bottom: 0;
+        }
+
+        .increment-text {
+          min-width: 5ch;
+          display: inline-block;
+          font-variant-numeric: tabular-nums;
+
+          &.low-increment {
+            color: var(--low-increment-text-color);
+          }
+          &.mid-increment {
+            color: var(--mid-increment-text-color);
+          }
+          &.high-increment {
+            color: var(--high-increment-text-color);
+          }
+        }
+      }
+    }
+
+    tr {
+      border: solid rgba(250, 250, 250, 0.12);
+      border-width: 1px 0px;
+    }
+
+    .light-border-bottom {
+      border-bottom: 1px solid rgba(250, 250, 250, 0.36);
+    }
+
+    .right-border {
+      border-right: 1px solid rgba(250, 250, 250, 0.36);
+    }
+
+    td.right-border {
+      padding-right: 10px;
+    }
+
+    td,
+    th {
+      box-shadow: none;
+    }
   }
 }


### PR DESCRIPTION
- add header groups to live metrics tile table
- pin the names column to the left, and make the other columns scroll horizontally
  - implemented using two tables (using sticky column would make the table scroll bar hide behind the sticky column)