### PR TITLE
fix: leader schedule my skipped border and padding

### DIFF
--- a/src/features/LeaderSchedule/Slots/pastSlotCard.module.css
+++ b/src/features/LeaderSchedule/Slots/pastSlotCard.module.css
@@ -10,7 +10,7 @@
   }
 
   &.skipped {
-    border: 1px rgba(255, 71, 71, 0.38);
+    border: 1px solid rgba(255, 71, 71, 0.38);
     background: rgba(189, 62, 62, 0.15);
   }
 }

--- a/src/features/LeaderSchedule/Slots/slotCardGrid.module.css
+++ b/src/features/LeaderSchedule/Slots/slotCardGrid.module.css
@@ -68,5 +68,5 @@
 .slot-text {
   color: var(--slot-card-section-primary-color);
   border-right: 1px solid rgba(250, 250, 250, 0.12);
-  padding-right: 3px;
+  padding-right: 5px;
 }


### PR DESCRIPTION
- adjust padding in slot grid next to skipped icon
- fix the border for my skipped slot cards