### PR TITLE
fix: tiles column backp count grouping

### DIFF
--- a/src/features/Overview/LiveTileMetrics/consts.ts
+++ b/src/features/Overview/LiveTileMetrics/consts.ts
@@ -101,11 +101,6 @@ export const metricGroups: {
         headerColWidth: 70,
         headerColAlign: "right",
       },
-    ],
-  },
-  {
-    name: "Utilization",
-    metrics: [
       {
         uniqueName: "Backp Count",
         description:
@@ -113,6 +108,11 @@ export const metricGroups: {
         headerColWidth: 160,
         headerColAlign: "right",
       },
+    ],
+  },
+  {
+    name: "Utilization",
+    metrics: [
       {
         uniqueName: "Utilization",
         description:

--- a/src/features/Overview/LiveTileMetrics/index.tsx
+++ b/src/features/Overview/LiveTileMetrics/index.tsx
@@ -278,12 +278,11 @@ function DataRow({
       </Table.Cell>
       <Table.Cell
         align="right"
-        className={clsx(styles.rightBorder, { [styles.red]: inBackpressure })}
+        className={clsx({ [styles.red]: inBackpressure })}
       >
         {inBackpressure ? "Yes" : "-"}
       </Table.Cell>
-
-      <Table.Cell align="right">
+      <Table.Cell align="right" className={styles.rightBorder}>
         {backPressureCount?.toLocaleString() ?? "0"} |
         <Text
           className={clsx(styles.incrementText, {
@@ -300,6 +299,7 @@ function DataRow({
           ).toLocaleString()}
         </Text>
       </Table.Cell>
+
       <MUtilization idx={idx} />
 
       <PctCell


### PR DESCRIPTION
- backp count should be grouped with backp under the liveness category