### PR TITLE
fix: pinned columns vs unpinned columns gridlines

### DIFF
--- a/src/features/Overview/LiveTileMetrics/liveTileMetrics.module.css
+++ b/src/features/Overview/LiveTileMetrics/liveTileMetrics.module.css
@@ -26,6 +26,13 @@
       }
 
       td {
+        /* Prevent different row heights between pinned
+         * and non-pinned tables because of line height
+         * applied by Radix Text component */
+        :global(.rt-Text) {
+          line-height: inherit;
+        }
+
         color: var(--table-body-color);
         text-align: left;
         &[align="right"] {


### PR DESCRIPTION
At 50% zoom, the horizontal gridlines between rows look misaligned between the pinned columns and unpinned columns. This is because the `Backp Count` column in the unpinned columns has a `<Text />` component that applies its own `line-height` and causes the cell to have a slightly larger height (after fractional px rounding that occurs at certain zoom levels) than the cells without that component. The pinned columns do not have any cells that use `<Text />`, so the rows are slightly smaller, leading to visual misalignment of the gridlines. If all the columns were in the same grid, the row height would be the largest amongst all columns (meaning no misalignment), but to support the pinned columns feature, we're implementing it as two separate tables next to each other that draw from the same styles. The solution is to ignore the `line-height` provided by `<Text />` component and inherit it for consistency across the two tables.