### PR TITLE
fix: tiles pinned right border clipping

### DIFF
--- a/src/features/Overview/LiveTileMetrics/consts.ts
+++ b/src/features/Overview/LiveTileMetrics/consts.ts
@@ -204,9 +204,10 @@ export const metricGroups: {
 export const pinnedGroups = metricGroups.filter(({ pinned }) => pinned);
 export const unpinnedGroups = metricGroups.filter(({ pinned }) => !pinned);
 
+// start with one pixel to account for border width
 export const pinnedTableWidth = pinnedGroups.reduce((acc, group) => {
   for (const metric of group.metrics) {
     acc += metric.headerColWidth;
   }
   return acc;
-}, 0);
+}, 1);


### PR DESCRIPTION
The pinned column's right border in the Tiles table was getting clipped. At a regular zoom level, it was present but looked thinner than the other right borders in the unpinned portion of the table. At 50% zoom level, it completely disappeared (likely because of px rounding to 0). This fixes the clipping by accounting for 1px of border width in the pinnedTableWidth calculation