### PR TITLE
chore: adjust supermajority table contrast and default expand accordions

### DIFF
--- a/src/colors.ts
+++ b/src/colors.ts
@@ -91,6 +91,10 @@ export const snapshotAreaChartGridLineColor = "#ffffff1a";
 
 export const supermajorityTableBorderColor = "rgba(250, 250, 250, 0.12)";
 export const supermajorityPieChartTextColor = "#cac4c4";
+export const supermajorityTableOfflinePrimaryColor = "var(--gray-11)";
+export const supermajorityTableOfflineSecondaryColor = "var(--gray-10)";
+export const supermajorityTableOnlinePrimaryColor = "var(--gray-9)";
+export const supermajorityTableOnlineSecondaryColor = "var(--gray-7)";
 
 // catching up bars
 export const firstTurbineSlotColor = "#3972C9";

--- a/src/features/StartupProgress/Firedancer/Supermajority/SupermajorityTable.tsx
+++ b/src/features/StartupProgress/Firedancer/Supermajority/SupermajorityTable.tsx
@@ -49,7 +49,7 @@ export default function SupermajorityTable({
   const size: Size = isXNarrow ? "xnarrow" : isNarrow ? "narrow" : "wide";
 
   const [isOfflineExpanded, setIsOfflineExpanded] = useState(true);
-  const [isOnlineExpanded, setIsOnlineExpanded] = useState(false);
+  const [isOnlineExpanded, setIsOnlineExpanded] = useState(true);
 
   const supermajorityEpoch = useAtomValue(supermajorityEpochAtom);
 
@@ -266,16 +266,18 @@ function DataRow({
   size,
 }: DataRowProps) {
   return (
-    <SizedRow size={size} className={clsx({ [styles.offline]: isOffline })}>
+    <SizedRow
+      size={size}
+      className={isOffline ? styles.offline : styles.online}
+    >
       <IconNameCell
         name={info?.name}
         iconUrl={getPeerIconUrl(info)}
-        isOffline={isOffline}
         size={size}
       />
       <StatusCell isOffline={isOffline} size={size} />
       <PubkeyCell pubkey={pubkey} size={size} />
-      <ClientVersionCell pubkey={pubkey} size={size} isOffline={isOffline} />
+      <ClientVersionCell pubkey={pubkey} size={size} />
       <StakeCell lamportsStake={lamportsStake} size={size} />
       <StakePctCell
         lamportsStake={lamportsStake}
@@ -320,20 +322,11 @@ function HeaderCell({
 interface IconNameCellProps {
   name: string | null | undefined;
   iconUrl: string | undefined;
-  isOffline?: boolean;
   size: Size;
 }
-function IconNameCell({
-  name,
-  iconUrl,
-  isOffline = false,
-  size,
-}: IconNameCellProps) {
+function IconNameCell({ name, iconUrl, size }: IconNameCellProps) {
   return (
-    <Cell
-      size={size}
-      className={clsx(styles.peer, { [styles.offline]: isOffline })}
-    >
+    <Cell size={size} className={styles.peer}>
       <PeerIcon url={iconUrl} size={16} />
       <Text truncate>{name ?? "-"}</Text>
     </Cell>
@@ -349,10 +342,7 @@ function StatusCell({ isOffline = false, size }: StatusCellProps) {
     ? FiberManualRecordIconOutlined
     : FiberManualRecordIcon;
   return (
-    <Cell
-      size={size}
-      className={clsx(styles.status, { [styles.offline]: isOffline })}
-    >
+    <Cell size={size} className={clsx(styles.status)}>
       <Icon height={12} width={12} fill="currentColor" />
       {size === "wide" && (
         <Text truncate>{isOffline ? "Offline" : "Online"}</Text>
@@ -380,22 +370,14 @@ function PubkeyCell({ pubkey, size }: PubkeyCellProps) {
 interface ClientVersionCellProps {
   pubkey: string;
   size: Size;
-  isOffline: boolean;
 }
-function ClientVersionCell({
-  pubkey,
-  size,
-  isOffline,
-}: ClientVersionCellProps) {
+function ClientVersionCell({ pubkey, size }: ClientVersionCellProps) {
   const peer = usePeer(pubkey);
   const { version, client } = usePeerInfo(peer);
 
   return (
-    <Cell
-      size={size}
-      className={clsx(styles.version, { [styles.offline]: isOffline })}
-    >
-      <Flex width="35px">
+    <Cell size={size} className={clsx(styles.version)}>
+      <Flex width="37px" flexShrink="0">
         <ClientIcons
           client={client}
           size="xlarge"
@@ -405,9 +387,7 @@ function ClientVersionCell({
         />
       </Flex>
       {size !== "xnarrow" && (
-        <Text truncate dir="rtl">
-          {version ? `v${version}` : "-"}
-        </Text>
+        <Text truncate>{version ? `v${version}` : "-"}</Text>
       )}
     </Cell>
   );

--- a/src/features/StartupProgress/Firedancer/Supermajority/supermajorityTable.module.css
+++ b/src/features/StartupProgress/Firedancer/Supermajority/supermajorityTable.module.css
@@ -45,17 +45,47 @@
     column-gap: 5px;
   }
 
-  /* override pubkey style from copy button */
-  &,
-  .pubkey-text {
-    color: var(--gray-10);
-    font-size: 14px;
+  &.online {
+    /* override pubkey style from copy button */
+    &,
+    .pubkey-text {
+      color: var(--supermajority-table-online-primary-color);
+      font-size: 14px;
+    }
+
+    .peer {
+      img {
+        opacity: 0.5;
+      }
+    }
+
+    .status {
+      color: var(--green-8);
+    }
+
+    .version .client-icon:not(.client-icon-placeholder) {
+      opacity: 0.5;
+    }
+
+    .suffix {
+      color: var(--supermajority-table-online-secondary-color);
+    }
   }
 
   &.offline {
+    /* override pubkey style from copy button */
     &,
     .pubkey-text {
-      color: var(--gray-7);
+      color: var(--supermajority-table-offline-primary-color);
+      font-size: 14px;
+    }
+
+    .status {
+      color: var(--red-9);
+    }
+
+    .suffix {
+      color: var(--supermajority-table-offline-secondary-color);
     }
   }
 
@@ -94,15 +124,6 @@
 
 .peer {
   column-gap: 4px;
-  color: var(--gray-11);
-  &.offline {
-    color: var(--gray-9);
-
-    img {
-      opacity: 0.5;
-    }
-  }
-
   min-width: 108px;
   flex: 10 1 170px;
   &.narrow {
@@ -117,11 +138,6 @@
 
 .status {
   column-gap: 8px;
-  color: var(--green-9);
-  &.offline {
-    color: var(--red-9);
-  }
-
   min-width: 62px;
   flex: 1 1 62px;
   &.narrow,
@@ -144,9 +160,6 @@
   column-gap: 8px;
   min-width: 100px;
   flex: 1 1 134px;
-  &.offline .client-icon:not(.client-icon-placeholder) {
-    opacity: 0.5;
-  }
 
   &.narrow {
     min-width: 80px;
@@ -160,9 +173,6 @@
 
 .stake {
   justify-content: flex-end;
-  .suffix {
-    color: var(--gray-7);
-  }
   min-width: 72px;
   flex: 1 1 72px;
   &.narrow {
@@ -178,9 +188,6 @@
   min-width: 62px;
   flex: 1 1 62px;
   justify-content: flex-end;
-  .suffix {
-    color: var(--gray-7);
-  }
   &.narrow,
   &.xnarrow {
     flex: 0 1 52px;


### PR DESCRIPTION
- adjust text color for better contrast
  - offline should be more prominent than online because that is the data we want to draw attention to
- truncate version text at end, not start
- default open both accordions