### PR TITLE
chore: wrap performance section earlier

### DIFF
--- a/src/features/SlotDetails/DetailedSlotStats/PerformanceSection/index.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/PerformanceSection/index.tsx
@@ -12,7 +12,7 @@ export default function PerformanceSection() {
   return (
     <SlotDetailsSection title="Performance" flexGrow="3">
       <Flex
-        direction={{ xs: "row", initial: "column" }}
+        direction={{ sm: "row", initial: "column" }}
         gapX={sectionGapX}
         gapY={sectionGapY}
         flexGrow="1"


### PR DESCRIPTION
Due to the fail_alloc_limit field being added, the width of the Txn Schedule Outcomes table is larger (showing values such as 15,000,000,000,000,000,000) than it used to be. This causes issues with the CPU utilization and Txn Execution Duration charts not having enough space, so this change wraps the right half of the performance section at an earlier breakpoint.