### PR TITLE
feat: filter by client id on leader schedule; wait for peers to load …

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -65,6 +65,18 @@ export default tseslint.config(
         { allowNumber: true, allowBoolean: true },
       ],
       "@typescript-eslint/no-unsafe-enum-comparison": "off",
+      "@typescript-eslint/only-throw-error": [
+        "error",
+        {
+          allow: [
+            {
+              from: "package",
+              package: "@tanstack/router-core",
+              name: "Redirect",
+            },
+          ],
+        },
+      ],
       "@typescript-eslint/prefer-promise-reject-errors": [
         "error",
         { allowEmptyReject: true },

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -551,21 +551,32 @@ export const myStakePctAtom = atom((get) => {
   return (Number(stake) / Number(totalActivePeersStake)) * 100;
 });
 
-export const allLeaderNamesAtom = atom((get) => {
+export const leaderScheduleSearchDependenciesAtom = atom((get) => {
   const epoch = get(epochAtom);
   const peers = get(peersAtom);
+  const peersCount = get(peersCountAtom);
 
-  if (!epoch || !peers) return;
+  if (!epoch || peersCount === 0) return;
+  return {
+    epoch,
+    peers,
+  };
+});
+
+export const allLeaderNamesClientIdsAtom = atom((get) => {
+  const dependencies = get(leaderScheduleSearchDependenciesAtom);
+  if (!dependencies) return;
+
+  const { epoch, peers } = dependencies;
 
   const uniquePubkeys = new Set(
     epoch.leader_slots.map((i) => epoch.staked_pubkeys[i]),
   );
-  const leadersWithNames = [...uniquePubkeys].map((pubkey) => ({
+  return [...uniquePubkeys].map((pubkey) => ({
     pubkey: pubkey,
     name: peers[pubkey]?.info?.name?.toLowerCase(),
+    clientId: peers[pubkey]?.gossip?.client_id,
   }));
-
-  return leadersWithNames;
 });
 
 type SupermajorityEpochByPubkey = Map<

--- a/src/features/LeaderSchedule/Search.tsx
+++ b/src/features/LeaderSchedule/Search.tsx
@@ -8,11 +8,10 @@ import {
   Reset,
   Tooltip,
 } from "@radix-ui/themes";
-import { atom, useAtomValue, useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { setSearchLeaderSlotsAtom, searchLeaderSlotsAtom } from "./atoms";
 import { useMount } from "react-use";
 import {
-  currentLeaderSlotAtom,
   discountedLateVoteSlotsAtom,
   leaderSlotsAtom,
   skipRateAtom,
@@ -34,10 +33,7 @@ import clsx from "clsx";
 import { getSlotGroupLeader } from "../../utils";
 import { isFiredancer } from "../../client";
 
-const isVisibleAtom = atom((get) => !!get(currentLeaderSlotAtom));
-
 export default function Search() {
-  const isVisible = useAtomValue(isVisibleAtom);
   const setSearch = useSetAtom(setSearchLeaderSlotsAtom);
 
   const setSlotOverride = useSetAtom(slotOverrideAtom);
@@ -69,13 +65,11 @@ export default function Search() {
     }
   });
 
-  if (!isVisible) return;
-
   return (
     <Flex className={styles.container} gap="2" wrap="wrap">
       <Box className={styles.searchBox}>
         <TextField.Root
-          placeholder="Name, pubkey, or slot (separate with , or ; for multiple values)"
+          placeholder="Name, Client Id, Pubkey, or Slot (use , for multiple)"
           variant="soft"
           color="gray"
           onChange={(e) => {

--- a/src/features/LeaderSchedule/atoms.ts
+++ b/src/features/LeaderSchedule/atoms.ts
@@ -1,12 +1,12 @@
 import { atom } from "jotai";
 import {
-  allLeaderNamesAtom,
+  allLeaderNamesClientIdsAtom,
   currentLeaderSlotAtom,
   epochAtom,
   slotOverrideAtom,
 } from "../../atoms";
 import { getLeaderSlots } from "../../utils";
-import { slotsPerLeader } from "../../consts";
+import { clientIdToClientName, slotsPerLeader } from "../../consts";
 
 /** first slot of leader slot groups in asc order */
 export const searchLeaderSlotsAtom = atom<number[] | undefined>(undefined);
@@ -43,16 +43,28 @@ export const setSearchLeaderSlotsAtom = atom(
     }
 
     const searchTextParts = searchText
-      .split(/[,;]/)
+      .split(",")
       .map((s) => s.trim().toLowerCase())
       .filter((s) => !!s);
 
-    const leaderNames = get(allLeaderNamesAtom);
-    const searchPubkeys = leaderNames
-      ?.filter(({ name, pubkey }) =>
-        searchTextParts.some(
-          (s) => name?.includes(s) || pubkey.toLowerCase().includes(s),
-        ),
+    const matchingClientIds = Object.entries(clientIdToClientName).reduce(
+      (acc, [clientId, clientName]) => {
+        if (searchTextParts.some((s) => clientName.toLowerCase().includes(s))) {
+          acc.add(parseInt(clientId));
+        }
+        return acc;
+      },
+      new Set<number>(),
+    );
+
+    const leaders = get(allLeaderNamesClientIdsAtom);
+    const searchPubkeys = leaders
+      ?.filter(
+        ({ name, pubkey, clientId }) =>
+          (clientId != null && matchingClientIds.has(clientId)) ||
+          searchTextParts.some(
+            (s) => name?.includes(s) || pubkey.toLowerCase().includes(s),
+          ),
       )
       .map(({ pubkey }) => pubkey);
 

--- a/src/features/LeaderSchedule/index.tsx
+++ b/src/features/LeaderSchedule/index.tsx
@@ -1,12 +1,23 @@
 import { Flex } from "@radix-ui/themes";
 import Slots from "./Slots";
-import { useAtomValue, useSetAtom } from "jotai";
-import { epochAtom, slotNavFilterAtom, slotOverrideAtom } from "../../atoms";
+import { atom, useAtomValue, useSetAtom } from "jotai";
+import {
+  currentLeaderSlotAtom,
+  leaderScheduleSearchDependenciesAtom,
+  slotNavFilterAtom,
+  slotOverrideAtom,
+} from "../../atoms";
 import { useMount } from "react-use";
 import { clusterIndicatorHeight, headerHeight } from "../../consts";
 
+const isVisibleAtom = atom(
+  (get) =>
+    get(currentLeaderSlotAtom) != null &&
+    !!get(leaderScheduleSearchDependenciesAtom),
+);
+
 export function LeaderSchedule() {
-  const epoch = useAtomValue(epochAtom);
+  const isVisible = useAtomValue(isVisibleAtom);
   const setSlotOverride = useSetAtom(slotOverrideAtom);
   const setSlotNavFilter = useSetAtom(slotNavFilterAtom);
 
@@ -21,7 +32,7 @@ export function LeaderSchedule() {
     }
   };
 
-  if (!epoch) return;
+  if (!isVisible) return;
 
   return (
     <Flex

--- a/src/routes/gossip.tsx
+++ b/src/routes/gossip.tsx
@@ -6,7 +6,6 @@ export const Route = createFileRoute("/gossip")({
   component: Gossip,
   beforeLoad: ({ context, location }) => {
     if (isFrankendancer) {
-      // eslint-disable-next-line @typescript-eslint/only-throw-error
       throw redirect({
         to: "/",
       });

--- a/src/routes/leaderSchedule.tsx
+++ b/src/routes/leaderSchedule.tsx
@@ -1,5 +1,6 @@
 import {
   createFileRoute,
+  redirect,
   retainSearchParams,
   stripSearchParams,
 } from "@tanstack/react-router";
@@ -35,5 +36,17 @@ export const Route = createFileRoute("/leaderSchedule")({
       stripSearchParams(defaultValues),
       retainSearchParams(["searchType", "searchText"]),
     ],
+  },
+  beforeLoad: ({ search }) => {
+    if (!search.searchText.includes(";")) return;
+
+    // Replace ; with , for backwards compatibility
+    throw redirect({
+      to: "/leaderSchedule",
+      search: {
+        ...search,
+        searchText: search.searchText.replaceAll(";", ","),
+      },
+    });
   },
 });


### PR DESCRIPTION
…before filtering

- fix race condition where filtering happened before peers were loaded, so results showed no peers matches
- allow filtering by client ID
- remove `;` for multi-value filtering (use commas instead). Added redirect to be backwards compatible for previous links with `;`