### PR TITLE
chore: prevent overscroll on startup overlay

### DIFF
--- a/src/features/StartupProgress/Firedancer/body.module.css
+++ b/src/features/StartupProgress/Firedancer/body.module.css
@@ -5,10 +5,8 @@
   --transform-origin: top right;
 
   position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  inset: 0;
+  overscroll-behavior: none;
   z-index: 20;
 
   background-color: var(--startup-background-color);


### PR DESCRIPTION
macOS has a feature commonly called "rubber band scrolling" or "elastic scrolling" where scrolling past the edge of the page content causes a bounce-back effect. This has UX benefits of providing visual feedback when the user has reached the edge of the content, but for our startup overlay, it reveals the app underneath and looks unnatural. Adding `overscroll-behavior: none` here prevents this behavior for the startup overlay only.