### PR TITLE
fix: program cache font size

### DIFF
--- a/src/components/CardStat.tsx
+++ b/src/components/CardStat.tsx
@@ -40,7 +40,7 @@ export default function CardStat({
       style={{ "--value-color": valueColor } as CSSProperties}
     >
       <Text className={styles.label}>{label}</Text>
-      <Flex align="baseline" gap="1" className={styles.valueContainer}>
+      <Flex align="baseline" gap="1" width="100%">
         {typeof value === "number" && animateInteger ? (
           <AnimatedInteger value={value} className={valueClassName} />
         ) : (

--- a/src/components/cardStat.module.css
+++ b/src/components/cardStat.module.css
@@ -9,25 +9,22 @@
   text-wrap: nowrap;
 }
 
-.value-container {
-  width: 100%;
-  .value {
-    line-height: normal;
-    color: var(--value-color, var(--regular-text-color));
-    overflow: hidden;
+.value {
+  line-height: normal;
+  color: var(--value-color, var(--regular-text-color));
+  overflow: hidden;
 
-    &.small {
-      font-size: 18px;
-      font-weight: 500;
-    }
-    &.medium {
-      font-size: 28px;
-      letter-spacing: -1.12px;
-    }
-    &.large {
-      font-size: 32px;
-      line-height: 16px;
-    }
+  &.small {
+    font-size: 18px;
+    font-weight: 500;
+  }
+  &.medium {
+    font-size: 28px;
+    letter-spacing: -1.12px;
+  }
+  &.large {
+    font-size: 32px;
+    line-height: 16px;
   }
 }
 


### PR DESCRIPTION
Wrapping the `.value` style in `.value-container` caused the `.value` and related font size styles to not work for the hit rate and storage stats (built sharing the card stat styles but separate because they have more custom layout). This change removes the class and applies the width prop to the Flex directly