### PR TITLE
fix: rename/reorder txn states

### DIFF
--- a/src/api/entities.ts
+++ b/src/api/entities.ts
@@ -378,31 +378,51 @@ export const bootProgressSchema = z.object({
   catching_up_first_replay_slot: z.number().nullable().optional(),
 });
 
-export const slotTransactionsSchema = z.object({
-  start_timestamp_nanos: z.coerce.bigint(),
-  target_end_timestamp_nanos: z.coerce.bigint(),
-  txn_mb_start_timestamps_nanos: z.coerce.bigint().array(),
-  txn_mb_end_timestamps_nanos: z.coerce.bigint().array(),
-  txn_compute_units_requested: z.number().array(),
-  txn_compute_units_consumed: z.number().array(),
-  txn_transaction_fee: z.coerce.bigint().array(),
-  txn_priority_fee: z.coerce.bigint().array(),
-  txn_tips: z.coerce.bigint().array(),
-  txn_error_code: z.number().array(),
-  txn_from_bundle: z.boolean().array(),
-  txn_is_simple_vote: z.boolean().array(),
-  txn_bank_idx: z.number().array(),
-  txn_preload_end_timestamps_nanos: z.coerce.bigint().array(),
-  txn_start_timestamps_nanos: z.coerce.bigint().array(),
-  txn_load_end_timestamps_nanos: z.coerce.bigint().array(),
-  txn_end_timestamps_nanos: z.coerce.bigint().array(),
-  txn_arrival_timestamps_nanos: z.coerce.bigint().array(),
-  txn_microblock_id: z.number().array(),
-  txn_landed: z.boolean().array(),
-  txn_signature: z.string().array(),
-  txn_source_ipv4: z.string().array(),
-  txn_source_tpu: z.string().array(),
-});
+export const slotTransactionsSchema = z.preprocess(
+  (data) => {
+    if (!data || typeof data !== "object" || Array.isArray(data)) return data;
+    const d = data as Record<string, unknown>;
+    return {
+      ...d,
+      // Forwards/Backwards compatibility for upcoming name change
+      txn_preload_end_timestamps_nanos:
+        d.txn_preload_end_timestamps_nanos ??
+        d.txn_check_start_timestamps_nanos,
+      txn_start_timestamps_nanos:
+        d.txn_start_timestamps_nanos ?? d.txn_load_start_timestamps_nanos,
+      txn_load_end_timestamps_nanos:
+        d.txn_load_end_timestamps_nanos ?? d.txn_execute_start_timestamps_nanos,
+      txn_end_timestamps_nanos:
+        d.txn_end_timestamps_nanos ?? d.txn_commit_start_timestamps_nanos,
+    };
+  },
+  z.object({
+    start_timestamp_nanos: z.coerce.bigint(),
+    target_end_timestamp_nanos: z.coerce.bigint(),
+    txn_mb_start_timestamps_nanos: z.coerce.bigint().array(),
+    txn_mb_end_timestamps_nanos: z.coerce.bigint().array(),
+    txn_compute_units_requested: z.number().array(),
+    txn_compute_units_consumed: z.number().array(),
+    txn_transaction_fee: z.coerce.bigint().array(),
+    txn_priority_fee: z.coerce.bigint().array(),
+    txn_tips: z.coerce.bigint().array(),
+    txn_error_code: z.number().array(),
+    txn_from_bundle: z.boolean().array(),
+    txn_is_simple_vote: z.boolean().array(),
+    txn_bank_idx: z.number().array(),
+    txn_preload_end_timestamps_nanos: z.coerce.bigint().array(),
+    txn_start_timestamps_nanos: z.coerce.bigint().array(),
+    txn_load_end_timestamps_nanos: z.coerce.bigint().array(),
+    txn_end_timestamps_nanos: z.coerce.bigint().array(),
+    txn_commit_end_timestamps_nanos: z.coerce.bigint().array().optional(),
+    txn_arrival_timestamps_nanos: z.coerce.bigint().array(),
+    txn_microblock_id: z.number().array(),
+    txn_landed: z.boolean().array(),
+    txn_signature: z.string().array(),
+    txn_source_ipv4: z.string().array(),
+    txn_source_tpu: z.string().array(),
+  }),
+);
 
 export const slotLevelSchema = z.enum([
   "incomplete",

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartTooltip.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/ChartTooltip.tsx
@@ -31,6 +31,7 @@ import {
   getTxnBundleStats,
   getTxnStateDurations,
 } from "../../../../transactionUtils";
+import { isFiredancer } from "../../../../client";
 import { sum, values } from "lodash";
 import CopyButton from "../../../../components/CopyButton";
 
@@ -350,20 +351,41 @@ function StateDurationDisplay({
             width={`${durationRatios.preLoading}%`}
             fill={stateTextColors[TxnState.PRELOADING]}
           />
-          <rect
-            height="8"
-            width={`${durationRatios.validating}%`}
-            fill={stateTextColors[TxnState.VALIDATE]}
-            x={`${durationRatios.preLoading}%`}
-            y="20%"
-          />
-          <rect
-            height="8"
-            width={`${durationRatios.loading}%`}
-            fill={stateTextColors[TxnState.LOADING]}
-            x={`${durationRatios.preLoading + durationRatios.validating}%`}
-            y="40%"
-          />
+          {isFiredancer ? (
+            <>
+              <rect
+                height="8"
+                width={`${durationRatios.loading}%`}
+                fill={stateTextColors[TxnState.LOADING]}
+                x={`${durationRatios.preLoading}%`}
+                y="20%"
+              />
+              <rect
+                height="8"
+                width={`${durationRatios.validating}%`}
+                fill={stateTextColors[TxnState.VALIDATE]}
+                x={`${durationRatios.preLoading + durationRatios.loading}%`}
+                y="40%"
+              />
+            </>
+          ) : (
+            <>
+              <rect
+                height="8"
+                width={`${durationRatios.validating}%`}
+                fill={stateTextColors[TxnState.VALIDATE]}
+                x={`${durationRatios.preLoading}%`}
+                y="20%"
+              />
+              <rect
+                height="8"
+                width={`${durationRatios.loading}%`}
+                fill={stateTextColors[TxnState.LOADING]}
+                x={`${durationRatios.preLoading + durationRatios.validating}%`}
+                y="40%"
+              />
+            </>
+          )}
           <rect
             height="8"
             width={`${durationRatios.execute}%`}
@@ -386,18 +408,37 @@ function StateDurationDisplay({
         value={durationUnits.preLoading.value}
         unit={durationUnits.preLoading.unit}
       />
-      <LabelValueDisplay
-        label={TxnState.VALIDATE}
-        color={stateTextColors[TxnState.VALIDATE]}
-        value={durationUnits.validating.value}
-        unit={durationUnits.validating.unit}
-      />
-      <LabelValueDisplay
-        label={TxnState.LOADING}
-        color={stateTextColors[TxnState.LOADING]}
-        value={durationUnits.loading.value}
-        unit={durationUnits.loading.unit}
-      />
+      {isFiredancer ? (
+        <>
+          <LabelValueDisplay
+            label={TxnState.LOADING}
+            color={stateTextColors[TxnState.LOADING]}
+            value={durationUnits.loading.value}
+            unit={durationUnits.loading.unit}
+          />
+          <LabelValueDisplay
+            label={TxnState.VALIDATE}
+            color={stateTextColors[TxnState.VALIDATE]}
+            value={durationUnits.validating.value}
+            unit={durationUnits.validating.unit}
+          />
+        </>
+      ) : (
+        <>
+          <LabelValueDisplay
+            label={TxnState.VALIDATE}
+            color={stateTextColors[TxnState.VALIDATE]}
+            value={durationUnits.validating.value}
+            unit={durationUnits.validating.unit}
+          />
+          <LabelValueDisplay
+            label={TxnState.LOADING}
+            color={stateTextColors[TxnState.LOADING]}
+            value={durationUnits.loading.value}
+            unit={durationUnits.loading.unit}
+          />
+        </>
+      )}
       <LabelValueDisplay
         label={TxnState.EXECUTE}
         color={stateTextColors[TxnState.EXECUTE]}

--- a/src/features/SlotDetails/DetailedSlotStats/ComputeSection/CumulativeExecutionTimeStats.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/ComputeSection/CumulativeExecutionTimeStats.tsx
@@ -14,6 +14,8 @@ import {
   getTxnBundleStats,
   getTxnStateDurations,
 } from "../../../../transactionUtils";
+import { TxnState } from "../../../Overview/SlotPerformance/TransactionBarsCard/consts";
+import { isFiredancer } from "../../../../client";
 
 const initDurations = {
   preLoading: 0,
@@ -103,20 +105,41 @@ export default function CumulativeExecutionTimeStats() {
           unlanded={unlanded.preLoading}
           max={max}
         />
-        <Row
-          label="Validating"
-          landedSuccess={landedSuccess.validating}
-          landedFailed={landedFailed.validating}
-          unlanded={unlanded.validating}
-          max={max}
-        />
-        <Row
-          label="Loading"
-          landedSuccess={landedSuccess.loading}
-          landedFailed={landedFailed.loading}
-          unlanded={unlanded.loading}
-          max={max}
-        />
+        {isFiredancer ? (
+          <>
+            <Row
+              label={TxnState.LOADING}
+              landedSuccess={landedSuccess.loading}
+              landedFailed={landedFailed.loading}
+              unlanded={unlanded.loading}
+              max={max}
+            />
+            <Row
+              label={TxnState.VALIDATE}
+              landedSuccess={landedSuccess.validating}
+              landedFailed={landedFailed.validating}
+              unlanded={unlanded.validating}
+              max={max}
+            />
+          </>
+        ) : (
+          <>
+            <Row
+              label={TxnState.VALIDATE}
+              landedSuccess={landedSuccess.validating}
+              landedFailed={landedFailed.validating}
+              unlanded={unlanded.validating}
+              max={max}
+            />
+            <Row
+              label={TxnState.LOADING}
+              landedSuccess={landedSuccess.loading}
+              landedFailed={landedFailed.loading}
+              unlanded={unlanded.loading}
+              max={max}
+            />
+          </>
+        )}
         <Row
           label="Execute"
           landedSuccess={landedSuccess.execute}

--- a/src/features/SlotDetails/DetailedSlotStats/ComputeSection/ExecutionTime.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/ComputeSection/ExecutionTime.tsx
@@ -133,30 +133,50 @@ function getX(pct: number) {
 }
 
 function Row({ label, value, max, minValue, maxValue }: RowProps) {
-  const pct = (value / max) * 100;
-  const minPct = (minValue / max) * 100;
-  const maxPct = (maxValue / max) * 100;
+  const hasData = isFinite(value) && isFinite(minValue) && isFinite(maxValue);
 
-  const formatted = getDurationWithUnits(value);
-  const minFormatted = getDurationWithUnits(minValue);
-  const maxFormatted = getDurationWithUnits(maxValue);
+  const pct = hasData ? (value / max) * 100 : 0;
+  const minPct = hasData ? (minValue / max) * 100 : 0;
+  const maxPct = hasData ? (maxValue / max) * 100 : 0;
+
+  const formatted = hasData ? getDurationWithUnits(value) : null;
+  const minFormatted = hasData ? getDurationWithUnits(minValue) : null;
+  const maxFormatted = hasData ? getDurationWithUnits(maxValue) : null;
 
   return (
     <>
       <Text className={styles.label}>{label}</Text>
       <Text className={styles.value} style={{ color: "#6E56CF" }} align="right">
-        {minFormatted.value}
-        <MonoText>{minFormatted.unit}</MonoText>
+        {minFormatted ? (
+          <>
+            {minFormatted.value}
+            <MonoText>{minFormatted.unit}</MonoText>
+          </>
+        ) : (
+          "-"
+        )}
       </Text>
       <Text className={styles.value}>/</Text>
       <Text className={styles.value} style={{ color: "#BAA7FF" }} align="right">
-        {formatted.value}
-        <MonoText>{formatted.unit}</MonoText>
+        {formatted ? (
+          <>
+            {formatted.value}
+            <MonoText>{formatted.unit}</MonoText>
+          </>
+        ) : (
+          "-"
+        )}
       </Text>
       <Text className={styles.value}>/</Text>
       <Text className={styles.value} style={{ color: "#6E56CF" }} align="right">
-        {maxFormatted.value}
-        <MonoText>{maxFormatted.unit}</MonoText>
+        {maxFormatted ? (
+          <>
+            {maxFormatted.value}
+            <MonoText>{maxFormatted.unit}</MonoText>
+          </>
+        ) : (
+          "-"
+        )}
       </Text>
       <svg
         height="13"

--- a/src/transactionUtils.ts
+++ b/src/transactionUtils.ts
@@ -1,7 +1,7 @@
 import { max } from "lodash";
 import type { SlotTransactions } from "./api/types";
 import { TxnState } from "./features/Overview/SlotPerformance/TransactionBarsCard/consts";
-import { isFrankendancer } from "./client";
+import { isFiredancer, isFrankendancer } from "./client";
 
 export const chartBufferMs = 2_000_000;
 
@@ -40,28 +40,48 @@ export function getTxnStateDurations(
   let startTs = transactions.txn_mb_start_timestamps_nanos[txnIdx];
   let endTs = transactions.txn_mb_end_timestamps_nanos[txnIdx];
 
-  // for bundle txs, we use the previous/next transaction to bound
+  // for bundle txs, we use the previous/next transaction to bound.
+  const firstPhaseBoundary = isFiredancer
+    ? transactions.txn_start_timestamps_nanos
+    : transactions.txn_preload_end_timestamps_nanos;
   if (transactions.txn_from_bundle[txnIdx] && bundleTxnIdx?.length) {
     const bundleIdx = bundleTxnIdx.indexOf(txnIdx) ?? -1;
     const prevTxnIdx = bundleTxnIdx[bundleIdx - 1];
     if (prevTxnIdx > 0) {
-      startTs = transactions.txn_preload_end_timestamps_nanos[txnIdx];
+      startTs = firstPhaseBoundary[txnIdx];
     }
 
     const nextTxnIdx = bundleIdx !== -1 ? bundleTxnIdx[bundleIdx + 1] : -1;
     if (nextTxnIdx > 0) {
-      endTs = transactions.txn_preload_end_timestamps_nanos[nextTxnIdx];
+      endTs = firstPhaseBoundary[nextTxnIdx];
     }
   }
 
-  const preLoading =
-    transactions.txn_preload_end_timestamps_nanos[txnIdx] - startTs;
-  const validating =
-    transactions.txn_start_timestamps_nanos[txnIdx] -
-    transactions.txn_preload_end_timestamps_nanos[txnIdx];
-  const loading =
-    transactions.txn_load_end_timestamps_nanos[txnIdx] -
-    transactions.txn_start_timestamps_nanos[txnIdx];
+  // Chronological order differs by client:
+  //   Frankendancer: preload_end < start < load_end < end
+  //   Firedancer:    start < preload_end < load_end < end
+  //
+  // Both clients have 4 phases between startTs and endTs:
+  //   Pre-Loading, Loading, Validating, Execute
+  // but the order of Loading and Validating is swapped.
+  const preload_end = transactions.txn_preload_end_timestamps_nanos[txnIdx];
+  const start = transactions.txn_start_timestamps_nanos[txnIdx];
+  const load_end = transactions.txn_load_end_timestamps_nanos[txnIdx];
+
+  let preLoading: bigint;
+  let loading: bigint;
+  let validating: bigint;
+  if (isFiredancer) {
+    // Firedancer: startTs -> start(load_start) -> preload_end(check_start) -> load_end(exec_start)
+    preLoading = start - startTs;
+    loading = preload_end - start;
+    validating = load_end - preload_end;
+  } else {
+    // Frankendancer: startTs -> preload_end(check_start) -> start(load_start) -> load_end(exec_start)
+    preLoading = preload_end - startTs;
+    validating = start - preload_end;
+    loading = load_end - start;
+  }
 
   let execute;
   let postExecute;
@@ -81,7 +101,7 @@ export function getTxnStateDurations(
 
     if (nextTxnIdx > 0) {
       execute =
-        transactions.txn_preload_end_timestamps_nanos[nextTxnIdx] -
+        firstPhaseBoundary[nextTxnIdx] -
         transactions.txn_load_end_timestamps_nanos[txnIdx];
       postExecute =
         transactions.txn_end_timestamps_nanos[nextTxnIdx] -
@@ -140,19 +160,34 @@ export function getTxnState(
     return Number(timestamp - transactions.start_timestamp_nanos);
   };
 
-  // Check transaction stages in sequence
-  if (
-    ts < relativeTime(transactions.txn_preload_end_timestamps_nanos[txnIdx])
-  ) {
-    return TxnState.PRELOADING;
-  }
-
-  if (ts < relativeTime(transactions.txn_start_timestamps_nanos[txnIdx])) {
-    return TxnState.VALIDATE;
-  }
-
-  if (ts < relativeTime(transactions.txn_load_end_timestamps_nanos[txnIdx])) {
-    return TxnState.LOADING;
+  // Check transaction stages in chronological order.
+  // The timestamp order differs by client:
+  //   Frankendancer: preload_end < start < load_end  (Pre-Loading, Validate, Loading)
+  //   Firedancer:    start < preload_end < load_end   (Pre-Loading, Loading, Validate)
+  if (isFiredancer) {
+    if (ts < relativeTime(transactions.txn_start_timestamps_nanos[txnIdx])) {
+      return TxnState.PRELOADING;
+    }
+    if (
+      ts < relativeTime(transactions.txn_preload_end_timestamps_nanos[txnIdx])
+    ) {
+      return TxnState.LOADING;
+    }
+    if (ts < relativeTime(transactions.txn_load_end_timestamps_nanos[txnIdx])) {
+      return TxnState.VALIDATE;
+    }
+  } else {
+    if (
+      ts < relativeTime(transactions.txn_preload_end_timestamps_nanos[txnIdx])
+    ) {
+      return TxnState.PRELOADING;
+    }
+    if (ts < relativeTime(transactions.txn_start_timestamps_nanos[txnIdx])) {
+      return TxnState.VALIDATE;
+    }
+    if (ts < relativeTime(transactions.txn_load_end_timestamps_nanos[txnIdx])) {
+      return TxnState.LOADING;
+    }
   }
 
   // Handle execution phase based on client type and bundle conditions
@@ -167,11 +202,14 @@ export function getTxnState(
     const bundleIdx = bundleTxnIdx.indexOf(txnIdx);
     const nextTxnIdx = bundleIdx !== -1 ? bundleTxnIdx[bundleIdx + 1] : -1;
 
+    // Use the first phase boundary of the next txn (see comment
+    // in getTxnStateDurations for the per-client ordering).
+    const nextFirstBoundary = isFiredancer
+      ? transactions.txn_start_timestamps_nanos[nextTxnIdx]
+      : transactions.txn_preload_end_timestamps_nanos[nextTxnIdx];
+
     if (nextTxnIdx > 0) {
-      if (
-        ts <
-        relativeTime(transactions.txn_preload_end_timestamps_nanos[nextTxnIdx])
-      ) {
+      if (ts < relativeTime(nextFirstBoundary)) {
         return TxnState.EXECUTE;
       }
     } else if (


### PR DESCRIPTION
In anticipation of the corresponding backend changes:

https://github.com/firedancer-io/firedancer/pull/9869

- maps the new names to the old ones to stay forwards/backwards compatible. This will keep the slot details page most functional on older backends.
- In firedancer, load actually comes before validate, so we need to swap these. This is technically a breaking change, but it should only cause the load/validate states to display incorrectly which isn't a dealbreaker.

Will merge the backend support alongside a build with this commit.