### PR TITLE
fix: startup slot check for shreds

### DIFF
--- a/src/api/atoms.ts
+++ b/src/api/atoms.ts
@@ -39,6 +39,7 @@ import type {
   ResetSlot,
   RepairSlot,
   LiveProgramCache,
+  SlotCaughtUp,
 } from "./types";
 import { rafAtom } from "../atomUtils";
 import type { ValuesWithHistory } from "./worker/types";
@@ -87,6 +88,8 @@ export const voteSlotAtom = atom<VoteSlot | undefined>(undefined);
 export const repairSlotAtom = atom<RepairSlot | undefined>(undefined);
 
 export const turbineSlotAtom = atom<TurbineSlot | undefined>(undefined);
+
+export const slotCaughtUpAtom = atom<SlotCaughtUp | undefined>(undefined);
 
 export const estimatedSlotDurationAtom = atom<
   EstimatedSlotDuration | undefined

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -66,6 +66,7 @@ import type {
   supermajorityEpochSchema,
   peerUpdateInfoSchema,
   liveProgramCacheSchema,
+  slotCaughtUpSchema,
 } from "./entities";
 
 export type Client = z.infer<typeof clientSchema>;
@@ -95,6 +96,7 @@ export type OptimisticallyConfirmedSlot = z.infer<
 >;
 
 export type CompletedSlot = z.infer<typeof completedSlotSchema>;
+
 export type CatchUpHistory = z.infer<typeof catchUpHistorySchema>;
 
 export type ServerTimeNanos = z.infer<typeof serverTimeNanosSchema>;
@@ -103,6 +105,8 @@ export type EstimatedSlot = z.infer<typeof estimatedSlotSchema>;
 export type ResetSlot = z.infer<typeof resetSlotSchema>;
 export type StorageSlot = z.infer<typeof storageSlotSchema>;
 export type VoteSlot = z.infer<typeof voteSlotSchema>;
+
+export type SlotCaughtUp = z.infer<typeof slotCaughtUpSchema>;
 
 export type EstimatedSlotDuration = z.infer<typeof estimatedSlotDurationSchema>;
 

--- a/src/api/useSetAtomWsData.ts
+++ b/src/api/useSetAtomWsData.ts
@@ -86,6 +86,7 @@ import {
   rootSlotAtom,
   optimisticallyConfirmedSlotAtom,
   liveProgramCacheAtom,
+  slotCaughtUpAtom,
 } from "./atoms";
 import {
   estimatedTpsDebounceMs,
@@ -421,6 +422,7 @@ function useUpdateAtoms() {
   const setOptimisticallyConfirmedSlot = useSetAtom(
     optimisticallyConfirmedSlotAtom,
   );
+  const setSlotCaughtUp = useSetAtom(slotCaughtUpAtom);
 
   const addLiveShreds = useSetAtom(shredsAtoms.addShredEvents);
 
@@ -624,6 +626,9 @@ function useUpdateAtoms() {
               setOptimisticallyConfirmedSlot(value);
               break;
             }
+            case "slot_caught_up":
+              setSlotCaughtUp(value);
+              break;
             case "catch_up_history": {
               addTurbineSlots(value.turbine);
               addRepairSlots(value.repair);
@@ -643,7 +648,6 @@ function useUpdateAtoms() {
             case "live_program_cache":
               setLiveProgramCache(value);
               break;
-            case "slot_caught_up":
             case "estimated_slot":
             case "ping":
             case "vote_key":
@@ -782,6 +786,7 @@ function useUpdateAtoms() {
       setServerTimeNanos,
       setSkipRate,
       setSkippedSlots,
+      setSlotCaughtUp,
       setSlotRankings,
       setSlotResponse,
       setStartupProgress,

--- a/src/features/Overview/ShredsProgression/atoms.ts
+++ b/src/features/Overview/ShredsProgression/atoms.ts
@@ -4,8 +4,8 @@ import { ShredEvent } from "../../../api/entities";
 import { delayMs, xRangeMs } from "./const";
 import { nsPerMs, slotsPerLeader } from "../../../consts";
 import { getSlotGroupLeader } from "../../../utils";
-import { startupFinalTurbineHeadAtom } from "../../StartupProgress/atoms";
 import { serverTimeMsAtom } from "../../../atoms";
+import { slotCaughtUpAtom } from "../../../api/atoms";
 
 type ShredEventTsDeltaMs = number | undefined;
 /**
@@ -44,14 +44,14 @@ export function createLiveShredsAtoms() {
   }>();
   const rangeAfterStartupAtom = atom((get) => {
     const range = get(_slotRangeAtom);
-    const startupFinalTurbineHead = get(startupFinalTurbineHeadAtom);
-    if (!range || startupFinalTurbineHead == null) return;
+    const slotCaughtUp = get(slotCaughtUpAtom);
+    if (!range || slotCaughtUp == null) return;
 
-    // no slots after final turbine head
-    if (startupFinalTurbineHead + 1 > range.max) return;
+    // no slots after startup
+    if (slotCaughtUp + 1 > range.max) return;
 
     return {
-      min: Math.max(startupFinalTurbineHead + 1, range.min),
+      min: Math.max(slotCaughtUp + 1, range.min),
       max: range.max,
     };
   });
@@ -62,16 +62,18 @@ export function createLiveShredsAtoms() {
     minCompletedSlot: atom((get) => get(_minCompletedSlotAtom)),
     range: atom((get) => get(_slotRangeAtom)),
     rangeAfterStartup: rangeAfterStartupAtom,
-    // leader slots after turbine head at the end of startup
+    /**
+     *  leader slots after startup, used for labels
+     * */
     groupLeaderSlots: atom((get) => {
-      const range = get(rangeAfterStartupAtom);
-      const startupFinalTurbineHead = get(startupFinalTurbineHeadAtom);
-      if (!range || startupFinalTurbineHead == null) return [];
+      const rangeAfterStartup = get(rangeAfterStartupAtom);
+      if (!rangeAfterStartup) return [];
 
-      const min = Math.max(startupFinalTurbineHead + 1, range.min);
-
-      const slots = [getSlotGroupLeader(min)];
-      while (slots[slots.length - 1] + slotsPerLeader - 1 < range.max) {
+      const slots = [getSlotGroupLeader(rangeAfterStartup.min)];
+      while (
+        slots[slots.length - 1] + slotsPerLeader - 1 <
+        rangeAfterStartup.max
+      ) {
         slots.push(
           getSlotGroupLeader(slots[slots.length - 1] + slotsPerLeader),
         );

--- a/src/features/StartupProgress/atoms.ts
+++ b/src/features/StartupProgress/atoms.ts
@@ -2,7 +2,6 @@ import { atom } from "jotai";
 import { bootProgressAtom } from "../../api/atoms";
 import { BootPhaseEnum } from "../../api/entities";
 import type { BootPhase } from "../../api/types";
-import { latestTurbineSlotAtom } from "./Firedancer/CatchingUp/atoms";
 import { isFrankendancer } from "../../client";
 
 export const bootProgressPhaseAtom = atom(
@@ -91,24 +90,7 @@ export const bootProgressCompletedPhasesAtom = atom((get) => {
   return completed;
 });
 
-export const [showStartupProgressAtom, startupFinalTurbineHeadAtom] =
-  (function getShowStartupProgressAtom() {
-    const _showStartupProgressAtom = atom(true);
-    const _startupFinalTurbineHeadAtom = atom<number>();
-    return [
-      atom(
-        (get) => get(_showStartupProgressAtom),
-        (get, set, show: boolean) => {
-          set(_showStartupProgressAtom, show);
-          set(
-            _startupFinalTurbineHeadAtom,
-            show ? undefined : (get(latestTurbineSlotAtom) ?? -1),
-          );
-        },
-      ),
-      atom((get) => get(_startupFinalTurbineHeadAtom)),
-    ];
-  })();
+export const showStartupProgressAtom = atom(true);
 
 export const isStartupProgressExpandedAtom = atom(true);
 export const expandStartupProgressElAtom = atom<HTMLButtonElement | null>(null);


### PR DESCRIPTION
- for shreds to determine which slot was before / after startup, use `slotCaughtUpAtom`.
- `startupFinalTurbineHeadAtom` doesn't work well because it:
  - was setting the slot not if startup finished, but when out that the phase is `running`
  - relies on the validator being connected at the time that startup closes