### PR TITLE
chore: show program cache misses

### DIFF
--- a/src/components/ColorText.tsx
+++ b/src/components/ColorText.tsx
@@ -42,12 +42,17 @@ export default function ColorText({
     prevValueRef.current = value;
   }, [value]);
 
+  const prevValue = prevValueRef.current;
+  const chars = value.split("");
+  const firstChangedIdx =
+    prevValue === undefined
+      ? 0
+      : chars.findIndex((_, idx) => isCharChanged(idx, value, prevValue));
+
   return (
     <Text className={className}>
-      {value.split("").map((char, idx) => {
-        const changed =
-          prevValueRef.current === undefined ||
-          isCharChanged(idx, value, prevValueRef.current);
+      {chars.map((char, idx) => {
+        const changed = firstChangedIdx !== -1 && idx >= firstChangedIdx;
         return (
           <span
             key={idx}

--- a/src/features/Overview/ProgramCacheCard/HitRateStat.tsx
+++ b/src/features/Overview/ProgramCacheCard/HitRateStat.tsx
@@ -21,9 +21,8 @@ type Status = "Unknown" | "Good" | "Average" | "Bad";
 
 type HitRateValues = {
   percentage: string;
-  numerator: string;
-  denominator: string;
-  showFraction: boolean;
+  hits: string;
+  misses: string;
   status: Status;
 };
 
@@ -49,19 +48,12 @@ const colorsMap: Record<Status, { changed: string; unchanged: string }> = {
 export default function HitRateStat() {
   const liveProgramCache = useAtomValue(liveProgramCacheAtom);
 
-  const {
-    percentage,
-    numerator,
-    denominator,
-    showFraction,
-    status,
-  }: HitRateValues = useMemo(() => {
+  const { percentage, hits, misses, status }: HitRateValues = useMemo(() => {
     if (!liveProgramCache) {
       return {
         percentage: "-",
-        numerator: "-",
-        denominator: "-",
-        showFraction: false,
+        hits: "-",
+        misses: "-",
         status: "Unknown",
       };
     }
@@ -79,10 +71,9 @@ export default function HitRateStat() {
             : "Good";
 
     return {
-      percentage: percentage === 100 ? "100" : percentage.toFixed(20),
-      numerator: hits.toLocaleString(),
-      denominator: lookups.toLocaleString(),
-      showFraction: Boolean(lookups),
+      percentage: (Math.trunc(percentage * 100) / 100).toFixed(2),
+      hits: hits.toLocaleString(),
+      misses: (lookups - hits).toLocaleString(),
       status,
     };
   }, [liveProgramCache]);
@@ -100,7 +91,7 @@ export default function HitRateStat() {
         <Text style={{ color: colorsMap[status].unchanged }}>{status}</Text>
       </Text>
       <Flex gap="2" align="center">
-        <Flex align="baseline" gap="1">
+        <Flex align="baseline" gap="1" minWidth="70px">
           <ColorText
             value={percentage}
             changedColor={colorsMap[status].changed}
@@ -109,21 +100,24 @@ export default function HitRateStat() {
           />
           <Text className={cardStatStyles.appendValue}>%</Text>
         </Flex>
-        {showFraction && (
-          <Flex direction="column" className={styles.fraction}>
-            <ColorText
-              value={numerator}
-              changedColor={unknownChangedColor}
-              unchangedColor={unknownUnchangedColor}
-            />
-            <hr className={styles.fractionLine} />
-            <ColorText
-              value={denominator}
-              changedColor={unknownChangedColor}
-              unchangedColor={unknownUnchangedColor}
-            />
-          </Flex>
-        )}
+        <Flex align="baseline" gap="1">
+          <ColorText
+            value={hits}
+            changedColor={unknownChangedColor}
+            unchangedColor={unknownUnchangedColor}
+            className={clsx(cardStatStyles.value, cardStatStyles.small)}
+          />
+          <Text className={cardStatStyles.appendValue}>Hits</Text>
+        </Flex>
+        <Flex align="baseline" gap="1">
+          <ColorText
+            value={misses}
+            changedColor={unknownChangedColor}
+            unchangedColor={unknownUnchangedColor}
+            className={clsx(cardStatStyles.value, cardStatStyles.small)}
+          />
+          <Text className={cardStatStyles.appendValue}>Misses</Text>
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/src/features/Overview/ProgramCacheCard/hitRateStat.module.css
+++ b/src/features/Overview/ProgramCacheCard/hitRateStat.module.css
@@ -1,14 +1,3 @@
 .trailing {
   color: var(--gray-9);
 }
-
-.fraction {
-  color: var(--gray-9);
-  text-align: center;
-}
-
-.fraction-line {
-  align-self: stretch;
-  border-color: var(--gray-9);
-  margin: 0;
-}


### PR DESCRIPTION
- show hits and misses instead of hits and lookups
- highlight changed text contiguously (every char to the right of the first changed char) instead of changed chars only