### PR TITLE
feat: copy any slot number to clipboard from the schedule

### DIFF
--- a/src/features/LeaderSchedule/Slots/SlotText.tsx
+++ b/src/features/LeaderSchedule/Slots/SlotText.tsx
@@ -1,7 +1,8 @@
 import { Link } from "@tanstack/react-router";
-import { Text } from "@radix-ui/themes";
+import { Flex, Text } from "@radix-ui/themes";
 import styles from "./slotText.module.css";
 import clsx from "clsx";
+import CopyButton from "../../../components/CopyButton";
 
 interface LinkedSlotTextProps {
   slot: number;
@@ -15,15 +16,24 @@ export default function LinkedSlotText({
   className,
 }: LinkedSlotTextProps) {
   const clsxName = clsx(className, styles.slotText);
-  if (!isLeader) {
-    return <Text className={clsxName}>{slot}</Text>;
-  }
 
+  // Copy button sibling (can't wrap the <a>), revealed on hover/focus.
   return (
-    <Text className={clsxName}>
-      <Link to="/slotDetails" search={{ slot }}>
-        {slot}
-      </Link>
-    </Text>
+    <Flex align="center" gap="1" className={styles.slotWithCopy}>
+      <Text className={clsxName}>
+        {isLeader ? (
+          <Link to="/slotDetails" search={{ slot }}>
+            {slot}
+          </Link>
+        ) : (
+          slot
+        )}
+      </Text>
+      <CopyButton
+        value={String(slot)}
+        size={12}
+        className={styles.copyAffordance}
+      />
+    </Flex>
   );
 }

--- a/src/features/LeaderSchedule/Slots/slotText.module.css
+++ b/src/features/LeaderSchedule/Slots/slotText.module.css
@@ -14,3 +14,16 @@
     color: var(--slot-text-active-link-color);
   }
 }
+
+.slot-with-copy {
+  /* Reveal on hover without shifting the digits. */
+  .copy-affordance {
+    opacity: 0;
+    transition: opacity 0.1s ease-in-out;
+  }
+
+  &:hover .copy-affordance,
+  &:focus-within .copy-affordance {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary

Add a copy button next to every slot number in the schedule to make slot IDs easier to copy manually.

## Details

Slot numbers in the schedule were awkward to select and copy by hand:

- Our own leader slots are rendered as links to the slot details page.
- Other validators’ slots are rendered as plain text in a tightly packed row.

This change adds a copy button next to each slot number, revealed on hover or focus, using the existing `CopyButton` component.

The copy button is rendered as a sibling of the slot number rather than wrapping it, so it works consistently for both linked and plain-text slots. It remains in the layout flow and is shown via an opacity toggle, preventing surrounding digits from shifting when the button appears.

## UX

- Copy action is available for every slot number.
- Button appears on hover/focus.
- Layout remains stable when the button is revealed.
- Existing slot links continue to behave as before.