### PR TITLE
feat: let users turn off the changing-number animation

### DIFF
--- a/src/components/AnimatedInteger.tsx
+++ b/src/components/AnimatedInteger.tsx
@@ -10,8 +10,10 @@ import {
 import styles from "./animatedInteger.module.css";
 import clsx from "clsx";
 import { Box, Flex, Text, type FlexProps } from "@radix-ui/themes";
-import { useUnmount } from "react-use";
+import { useMedia, useUnmount } from "react-use";
+import { useAtomValue } from "jotai";
 import useIsDocumentVisible from "../hooks/useIsDocumentVisible";
+import { animateNumbersAtom } from "../settingsAtoms";
 
 const MIN_ANIMATION_DURATION_MS = 20;
 
@@ -31,11 +33,40 @@ interface AnimatedIntegerProps {
  */
 export default function AnimatedInteger(props: AnimatedIntegerProps) {
   const isDocumentVisible = useIsDocumentVisible();
+  const animateNumbers = useAtomValue(animateNumbersAtom);
+  const prefersReducedMotion = useMedia(
+    "(prefers-reduced-motion: reduce)",
+    false,
+  );
+
+  // Skip animation if disabled or prefers-reduced-motion.
+  if (!animateNumbers || prefersReducedMotion) {
+    return <StaticInteger {...props} />;
+  }
 
   // re-mount when visible again, so there's no need to catch up
   if (!isDocumentVisible) return null;
 
   return <AnimatedIntegerInner {...props} />;
+}
+
+/** Static render matching the animated variant's layout. */
+function StaticInteger({
+  value,
+  height,
+  className,
+  containerRowJustify,
+}: AnimatedIntegerProps) {
+  const heightStyle =
+    height == null ? undefined : ({ height: `${height}px` } as CSSProperties);
+
+  return (
+    <Flex position="relative" justify={containerRowJustify}>
+      <Text className={className} style={heightStyle}>
+        {value}
+      </Text>
+    </Flex>
+  );
 }
 
 type Direction = "incr" | "decr";

--- a/src/features/Header/DisplaySettings.tsx
+++ b/src/features/Header/DisplaySettings.tsx
@@ -1,0 +1,33 @@
+import { Flex, IconButton, Text } from "@radix-ui/themes";
+import { GearIcon } from "@radix-ui/react-icons";
+import { useAtom } from "jotai";
+import PopoverDropdown from "../../components/PopoverDropdown";
+import ToggleControl from "../../components/ToggleControl";
+import { animateNumbersAtom } from "../../settingsAtoms";
+
+/** Header gear popover for display preferences. */
+export default function DisplaySettings() {
+  const [animateNumbers, setAnimateNumbers] = useAtom(animateNumbersAtom);
+
+  return (
+    <PopoverDropdown
+      align="end"
+      content={
+        <Flex direction="column" gap="2" p="1">
+          <Text size="2" weight="bold">
+            Display
+          </Text>
+          <ToggleControl
+            label="Animate changing numbers"
+            checked={animateNumbers}
+            onCheckedChange={setAnimateNumbers}
+          />
+        </Flex>
+      }
+    >
+      <IconButton variant="ghost" color="gray" aria-label="Display settings">
+        <GearIcon />
+      </IconButton>
+    </PopoverDropdown>
+  );
+}

--- a/src/features/Header/index.tsx
+++ b/src/features/Header/index.tsx
@@ -30,6 +30,7 @@ import { bootProgressContainerElAtom } from "../../atoms";
 import { useCallback } from "react";
 import PopoverDropdown from "../../components/PopoverDropdown";
 import HealthPane from "./HealthPane";
+import DisplaySettings from "./DisplaySettings";
 
 export default function Header({ isStartup }: { isStartup?: boolean }) {
   const showDropdownNav = useMedia("(max-width: 1218px)");
@@ -117,6 +118,8 @@ export default function Header({ isStartup }: { isStartup?: boolean }) {
               <HealthPane />
 
               <Flex gap="1" direction={isNarrowScreen ? "column" : "row"}>
+                <DisplaySettings />
+
                 <Attribution />
 
                 {isStartup ? (

--- a/src/settingsAtoms.ts
+++ b/src/settingsAtoms.ts
@@ -1,0 +1,9 @@
+import { atomWithStorage } from "jotai/utils";
+
+/** Animate changing numbers with the digit-tumbling effect. */
+export const animateNumbersAtom = atomWithStorage(
+  "fd:animateNumbers",
+  true,
+  undefined,
+  { getOnInit: true },
+);


### PR DESCRIPTION
The digit-tumbling count-up animation plays on every numeric update
(slot counters tick a few times per second), which some users find
distracting and which can briefly lag the displayed value behind the
real one. Add a "Animate changing numbers" toggle under a new Display
settings popover in the header, persisted to localStorage, so each user
can opt out. The animation is also skipped when the OS requests reduced
motion. Default stays on, preserving the current experience.

