### PR TITLE
fix: view slot details regardless of current identity

### DIFF
--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -7,6 +7,7 @@ import {
   identityKeyAtom,
   serverTimeNanosAtom,
   skippedSlotsAtom,
+  slotRankingsAtom,
   startupProgressAtom,
 } from "./api/atoms";
 import type {
@@ -228,6 +229,16 @@ export const slotPublishAtomFamily = atomFamily((slot?: number) =>
 export const slotResponseAtomFamily = atomFamily((slot?: number) =>
   atom((get) => (slot !== undefined ? get(slotResponseAtom)[slot] : undefined)),
 );
+
+/** Cached slots this node produced, per the server-stamped `mine` flag. */
+export const cachedMineSlotsAtom = atom((get) => {
+  const responses = get(slotResponseAtom);
+  const slots: number[] = [];
+  for (const key in responses) {
+    if (responses[key].publish.mine) slots.push(Number(key));
+  }
+  return slots;
+});
 
 export const setSlotResponseAtom = atom(
   null,
@@ -938,23 +949,55 @@ export const [
   ];
 })();
 
-export const quickSearchSlotsAtom = atom((get) => {
-  const leaderSlots = get(leaderSlotsAtom);
-  const firstProcessedLeaderIndex = get(firstProcessedLeaderIndexAtom);
-  const nextLeaderIndex = get(nextLeaderSlotIndexAtom);
-
-  if (!leaderSlots || firstProcessedLeaderIndex === undefined) {
-    return {};
+/**
+ * Processed slots this node produced this epoch, unioned from the cache and the
+ * mine rankings. Partial (the server exposes no full list) but never includes
+ * slots the identity produced on another node after an identity switch.
+ */
+export const mineProcessedSlotsAtom = atom((get) => {
+  const epoch = get(epochAtom);
+  const currentSlot = get(currentSlotAtom);
+  const firstProcessedSlot = get(firstProcessedSlotAtom);
+  if (!epoch || currentSlot === undefined || firstProcessedSlot === undefined) {
+    return [];
   }
 
-  const pastProcessedSlots = leaderSlots.slice(
-    firstProcessedLeaderIndex,
-    nextLeaderIndex,
-  );
+  const rankings = get(slotRankingsAtom);
+  const rankingSlots = rankings
+    ? [
+        ...rankings.slots_largest_tips,
+        ...rankings.slots_smallest_tips,
+        ...rankings.slots_largest_fees,
+        ...rankings.slots_smallest_fees,
+        ...rankings.slots_largest_rewards,
+        ...rankings.slots_smallest_rewards,
+        ...rankings.slots_largest_duration,
+        ...rankings.slots_smallest_duration,
+        ...rankings.slots_largest_compute_units,
+        ...rankings.slots_smallest_compute_units,
+      ]
+    : [];
+
+  const slots = new Set<number>();
+  for (const slot of [...get(cachedMineSlotsAtom), ...rankingSlots]) {
+    if (
+      slot >= epoch.start_slot &&
+      slot <= epoch.end_slot &&
+      slot >= firstProcessedSlot &&
+      slot < currentSlot
+    ) {
+      slots.add(slot);
+    }
+  }
+  return [...slots].sort((a, b) => a - b);
+});
+
+export const quickSearchSlotsAtom = atom((get) => {
+  const mineSlots = get(mineProcessedSlotsAtom);
+  if (!mineSlots.length) return {};
+
   return {
-    earliestQuickSlots: pastProcessedSlots.slice(0, numQuickSearchSlots),
-    mostRecentQuickSlots: pastProcessedSlots
-      .slice(-numQuickSearchSlots)
-      .toReversed(),
+    earliestQuickSlots: mineSlots.slice(0, numQuickSearchSlots),
+    mostRecentQuickSlots: mineSlots.slice(-numQuickSearchSlots).toReversed(),
   };
 });

--- a/src/features/Overview/SlotPerformance/ComputeUnitsCard/index.tsx
+++ b/src/features/Overview/SlotPerformance/ComputeUnitsCard/index.tsx
@@ -34,8 +34,11 @@ export default function ComputeUnitsCard() {
     [],
   );
 
-  if (!slot || !query.response?.transactions)
+  if (!slot || !query.response?.transactions) {
+    // Per-transaction data expires server-side; stop the spinner once resolved.
+    if (query.hasWaitedForData) return <ComputeUnitCardUnavailable />;
     return <ComputeUnitCardPlaceholder />;
+  }
 
   return (
     <>
@@ -77,6 +80,25 @@ function ComputeUnitCardPlaceholder() {
       }}
     >
       <Text>Loading Slot Progress...</Text>
+    </Card>
+  );
+}
+
+function ComputeUnitCardUnavailable() {
+  return (
+    <Card
+      style={{
+        display: "flex",
+        flexGrow: "1",
+        height,
+        justifyContent: "center",
+        alignItems: "center",
+        textAlign: "center",
+      }}
+    >
+      <Text color="gray">
+        Per-transaction data is no longer retained for this slot.
+      </Text>
     </Card>
   );
 }

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/index.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/index.tsx
@@ -9,8 +9,11 @@ import { Text } from "@radix-ui/themes";
 export default function TransactionsBarsCard() {
   const slot = useAtomValue(selectedSlotAtom);
   const query = useSlotQueryResponseTransactions(slot);
-  if (!slot || !query.response?.transactions)
+  if (!slot || !query.response?.transactions) {
+    // Per-transaction data expires server-side; stop the spinner once resolved.
+    if (query.hasWaitedForData) return <TransactionsBarsCardUnavailable />;
     return <TransactionsBarsCardPlaceholder />;
+  }
 
   return (
     <>
@@ -34,6 +37,25 @@ function TransactionsBarsCardPlaceholder() {
       }}
     >
       <Text>Loading Banks...</Text>
+    </Card>
+  );
+}
+
+function TransactionsBarsCardUnavailable() {
+  return (
+    <Card
+      style={{
+        display: "flex",
+        flexGrow: "1",
+        height: "400px",
+        justifyContent: "center",
+        alignItems: "center",
+        textAlign: "center",
+      }}
+    >
+      <Text color="gray">
+        Per-transaction data is no longer retained for this slot.
+      </Text>
     </Card>
   );
 }

--- a/src/features/Overview/SlotPerformance/atoms.ts
+++ b/src/features/Overview/SlotPerformance/atoms.ts
@@ -14,6 +14,7 @@ import {
   epochAtom,
   firstProcessedSlotAtom,
   leaderSlotsAtom,
+  slotPublishAtomFamily,
 } from "../../../atoms";
 import { getSlotGroupLeader } from "../../../utils";
 
@@ -32,6 +33,7 @@ function getSlotState(
   leaderSlots?: number[],
   firstProcessedSlot?: number,
   currentSlot?: number,
+  hasResponse?: boolean,
 ) {
   if (slot === undefined) return SelectedSlotValidityState.Valid;
   if (
@@ -43,11 +45,15 @@ function getSlotState(
     return SelectedSlotValidityState.NotReady;
   if (slot < epoch.start_slot || epoch.end_slot < slot)
     return SelectedSlotValidityState.OutsideEpoch;
-  if (!leaderSlots.includes(getSlotGroupLeader(slot)))
-    return SelectedSlotValidityState.NotYou;
-  if (slot < firstProcessedSlot)
-    return SelectedSlotValidityState.BeforeFirstProcessed;
   if (slot >= currentSlot) return SelectedSlotValidityState.Future;
+  // Gate on data availability, not identity: any slot with a response is
+  // viewable. Only unfetched slots fall back to the identity/restart checks.
+  if (!hasResponse) {
+    if (!leaderSlots.includes(getSlotGroupLeader(slot)))
+      return SelectedSlotValidityState.NotYou;
+    if (slot < firstProcessedSlot)
+      return SelectedSlotValidityState.BeforeFirstProcessed;
+  }
   return SelectedSlotValidityState.Valid;
 }
 
@@ -63,12 +69,14 @@ export const baseSelectedSlotAtoms = (function () {
     const leaderSlots = get(leaderSlotsAtom);
     const firstProcessedSlot = get(firstProcessedSlotAtom);
     const currentSlot = get(currentSlotAtom);
+    const hasResponse = get(slotPublishAtomFamily(slot)) !== undefined;
     return getSlotState(
       slot,
       epoch,
       leaderSlots,
       firstProcessedSlot,
       currentSlot,
+      hasResponse,
     );
   });
 

--- a/src/features/SlotDetails/DetailedSlotStats/index.tsx
+++ b/src/features/SlotDetails/DetailedSlotStats/index.tsx
@@ -11,8 +11,25 @@ import SlotDetailsHeader from "./SlotDetailsHeader";
 
 export default function DetailedSlotStats() {
   const selectedSlot = useAtomValue(selectedSlotAtom);
-  const queryResponse = useSlotQueryResponseDetailed(selectedSlot).response;
-  if (!queryResponse?.limits) return <DetailedSlotStatsPlaceholder />;
+  const { response: queryResponse, hasWaitedForData } =
+    useSlotQueryResponseDetailed(selectedSlot);
+
+  // Render once any detail field is present (each section hides its own missing
+  // data); older slots may have e.g. the waterfall but not transactions.
+  const hasAnyDetail =
+    !!queryResponse &&
+    (!!queryResponse.waterfall ||
+      !!queryResponse.tile_timers ||
+      !!queryResponse.tile_primary_metric ||
+      !!queryResponse.scheduler_counts ||
+      !!queryResponse.scheduler_stats ||
+      !!queryResponse.transactions ||
+      !!queryResponse.limits);
+
+  if (!hasAnyDetail) {
+    if (hasWaitedForData) return <DetailedSlotStatsUnavailable />;
+    return <DetailedSlotStatsPlaceholder />;
+  }
 
   return (
     <>
@@ -41,5 +58,28 @@ function DetailedSlotStatsPlaceholder() {
     >
       <Text>Loading Slot Statistics...</Text>
     </Card>
+  );
+}
+
+function DetailedSlotStatsUnavailable() {
+  return (
+    <>
+      <SlotDetailsHeader />
+      <Card
+        style={{
+          display: "flex",
+          flexGrow: "1",
+          height: "550px",
+          justifyContent: "center",
+          alignItems: "center",
+          textAlign: "center",
+        }}
+      >
+        <Text color="gray">
+          Detailed statistics are not available for this slot. This node only
+          retains full per-slot detail for slots it recently produced as leader.
+        </Text>
+      </Card>
+    </>
   );
 }

--- a/src/features/SlotDetails/SlotSearch.tsx
+++ b/src/features/SlotDetails/SlotSearch.tsx
@@ -281,7 +281,7 @@ function Errors() {
       case SelectedSlotValidityState.OutsideEpoch:
         return `Slot ${slot} is outside this epoch. Please try again with a different ID between ${epoch?.start_slot} - ${epoch?.end_slot}.`;
       case SelectedSlotValidityState.NotYou:
-        return `Slot ${slot} belongs to another validator. Please try again with a slot number processed by you.`;
+        return `No data for slot ${slot} on this node. It may belong to another validator or not have been replayed.`;
       case SelectedSlotValidityState.BeforeFirstProcessed:
         return `Slot ${slot} is in this epoch but its details are unavailable because it was processed before the restart.`;
       case SelectedSlotValidityState.Future:

--- a/src/features/SlotDetails/index.tsx
+++ b/src/features/SlotDetails/index.tsx
@@ -13,13 +13,18 @@ import SlotNavigation from "./SlotNavigation";
 import DetailedSlotStats from "./DetailedSlotStats";
 import { useEffect, useState } from "react";
 import ChartControlsProvider from "./ChartControlsProvider";
+import { useSlotQueryPublish } from "../../hooks/useSlotQuery";
 
 export default function SlotDetails() {
+  const baseSelectedSlot = useAtomValue(baseSelectedSlotAtoms.slot);
   const selectedSlot = useAtomValue(selectedSlotAtom);
+  const state = useAtomValue(baseSelectedSlotAtoms.state);
   const [waitedForDependencies, setWaitedForDependencies] = useState(false);
-  const isNotReady =
-    useAtomValue(baseSelectedSlotAtoms.state) ===
-    SelectedSlotValidityState.NotReady;
+  const isNotReady = state === SelectedSlotValidityState.NotReady;
+
+  // Query publish before the validity check so the server can confirm the slot
+  // exists (validity is gated on having a response — see getSlotState).
+  const { hasWaitedForData } = useSlotQueryPublish(baseSelectedSlot);
 
   useEffect(() => {
     if (isNotReady && !waitedForDependencies) {
@@ -30,6 +35,15 @@ export default function SlotDetails() {
 
   // wait a bit for dependencies to load before showing SlotSearch with Not Ready error
   if (isNotReady && !waitedForDependencies) return null;
+
+  // Wait for the publish query to resolve before showing the not-found error.
+  if (
+    selectedSlot === undefined &&
+    state === SelectedSlotValidityState.NotYou &&
+    !hasWaitedForData
+  ) {
+    return null;
+  }
 
   return selectedSlot === undefined ? <SlotSearch /> : <SlotContent />;
 }


### PR DESCRIPTION
## Summary

Fix slot details visibility for slots produced by this node under a previous identity, and improve handling of unavailable historical per-transaction data.

## Context

The slot details page previously gated validity on the current identity's leader slots. As a result, any slot not led by the current identity was shown as belonging to another validator.

This caused an issue after identity changes, for example after an unstake: slots actually produced by this node under a previous identity were hidden, because the server also recomputes the slot's `mine` flag against the new identity and therefore cannot always be used to recognize older slots correctly.

## Changes

### Slot details validity

- Gate slot detail validity on data availability rather than the current identity's leader schedule.
- Query the requested slot's publish data before deciding whether the slot is valid.
- Treat any slot for which the server returns data as viewable.
- Keep the header resolution based on the original leader from the epoch schedule.

This resolves the previous chicken-and-egg issue where a slot was only considered valid once fetched, but was only fetched once considered valid.

### Detailed view rendering

- Render the detailed view as soon as any detailed field is available.
- Let each subsection hide itself when its own data is missing.
- Avoid gating the entire page on retained per-transaction data.
- Show a clear `not available` message instead of a perpetual spinner when historical per-transaction data is no longer retained.

This applies to:

- `DetailedSlotStats`
- Compute card
- Banks card

### Quick-search behavior

Update the Earliest / Most Recent quick-search logic so it reflects slots produced by this node, instead of slots from the current identity's leader schedule.

Produced slots are now identified using the server-stamped `mine` flag, unioned from:

- cached slot responses
- mine rankings

This is more accurate after an identity move or unstake. The leader schedule lists every slot for an identity even after it moves to another node, which can incorrectly surface slots produced elsewhere. The server-stamped `mine` flag is a better signal for what this node actually produced.

## Review notes

Parts of this change were AI-assisted.

The non-obvious areas worth reviewing carefully are:

- `mineProcessedSlotsAtom` in `src/atoms.ts`
  - Recovers which slots this node produced using the server `mine` flag.
  - Designed to remain robust across identity switches.

- `getSlotState` in `src/features/Overview/SlotPerformance/atoms.ts`
  - Implements the data-availability gate for slot detail visibility.

## Validation

Verified live against a Firedancer `v0.911` validator.