### PR TITLE
feat: copyable slot numbers in leader schedule

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@radix-ui/themes";
-import { useState, type PropsWithChildren } from "react";
+import { useCallback, useState } from "react";
+import type { PropsWithChildren } from "react";
 import { useDebouncedCallback } from "use-debounce";
 import { copyToClipboard } from "../utils";
 import { CheckIcon, CopyIcon } from "@radix-ui/react-icons";
@@ -12,6 +13,7 @@ interface CopyButtonProps {
   size?: string | number;
   hideIconUntilHover?: boolean;
   className?: string;
+  copyOnIconOnly?: boolean;
 }
 
 export default function CopyButton({
@@ -20,37 +22,63 @@ export default function CopyButton({
   size,
   hideIconUntilHover,
   className,
+  copyOnIconOnly,
   children,
 }: PropsWithChildren<CopyButtonProps>) {
   const [hasCopied, setHasCopied] = useState(false);
   const resetHasCopied = useDebouncedCallback(() => setHasCopied(false), 1_000);
 
+  const handleCopy = useCallback(
+    (e: React.MouseEvent) => {
+      if (value === undefined) return;
+
+      copyToClipboard(value);
+      setHasCopied(true);
+      resetHasCopied();
+      // When inside of a tooltip, seems to be caught by the outside
+      // tooltip click handler without this
+      e.stopPropagation();
+    },
+    [resetHasCopied, value],
+  );
+
   if (value === undefined) return children;
+
+  const icon = hasCopied ? (
+    <CheckIcon className={styles.icon} color="green" height={size} />
+  ) : (
+    <CopyIcon
+      className={styles.icon}
+      color={color}
+      height={size}
+      onClick={copyOnIconOnly ? handleCopy : undefined}
+    />
+  );
+
+  const sharedClasses = clsx(
+    className,
+    styles.copyButton,
+    hideIconUntilHover && styles.hideIconUntilHover,
+  );
+
+  if (copyOnIconOnly) {
+    return (
+      <span className={clsx(sharedClasses, styles.copyOnIconOnlyContainer)}>
+        {children}
+        {icon}
+      </span>
+    );
+  }
 
   return (
     <Button
-      className={clsx(
-        className,
-        styles.copyButton,
-        hideIconUntilHover && styles.hideIconUntilHover,
-      )}
+      className={sharedClasses}
       variant="ghost"
       size="1"
-      onClick={(e) => {
-        copyToClipboard(value);
-        setHasCopied(true);
-        resetHasCopied();
-        // When inside of a tooltip, seems to be caught by the outside
-        // tooltip click handler without this
-        e.stopPropagation();
-      }}
+      onClick={handleCopy}
     >
       {children}
-      {hasCopied ? (
-        <CheckIcon className={styles.icon} color="green" height={size} />
-      ) : (
-        <CopyIcon className={styles.icon} color={color} height={size} />
-      )}
+      {icon}
     </Button>
   );
 }

--- a/src/components/copyButton.module.css
+++ b/src/components/copyButton.module.css
@@ -4,26 +4,32 @@
   max-width: 100%;
   --button-ghost-padding-x: 2px;
   --button-ghost-padding-y: 2px;
+}
 
+.copy-on-icon-only-container {
+  display: inline-flex;
+  align-items: center;
+}
+
+.icon {
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.hide-icon-until-hover {
   .icon {
-    flex-shrink: 0;
+    display: none;
   }
 
-  &.hide-icon-until-hover {
-    .icon {
-      display: none;
-    }
-
-    &:hover .icon {
-      display: inherit;
-      position: absolute;
-      right: 0;
-      background: rgb(27, 49, 80, 0.75);
-      padding: 4px 2px;
-      border-radius: 2px;
-      box-shadow:
-        -4px 0 8px rgba(30, 58, 95, 0.8),
-        0 2px 8px rgba(0, 0, 0, 0.3);
-    }
+  &:hover .icon {
+    display: inherit;
+    position: absolute;
+    right: 0;
+    background: rgb(27, 49, 80, 0.75);
+    padding: 4px 2px;
+    border-radius: 2px;
+    box-shadow:
+      -4px 0 8px rgba(30, 58, 95, 0.8),
+      0 2px 8px rgba(0, 0, 0, 0.3);
   }
 }

--- a/src/features/LeaderSchedule/Slots/SlotText.tsx
+++ b/src/features/LeaderSchedule/Slots/SlotText.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { Text } from "@radix-ui/themes";
 import styles from "./slotText.module.css";
 import clsx from "clsx";
+import CopyButton from "../../../components/CopyButton";
 
 interface LinkedSlotTextProps {
   slot: number;
@@ -14,16 +15,22 @@ export default function LinkedSlotText({
   isLeader,
   className,
 }: LinkedSlotTextProps) {
-  const clsxName = clsx(className, styles.slotText);
-  if (!isLeader) {
-    return <Text className={clsxName}>{slot}</Text>;
-  }
-
   return (
-    <Text className={clsxName}>
-      <Link to="/slotDetails" search={{ slot }}>
-        {slot}
-      </Link>
-    </Text>
+    <CopyButton
+      className={styles.copyButton}
+      value={String(slot)}
+      hideIconUntilHover
+      copyOnIconOnly
+    >
+      <Text className={clsx(className, styles.slotText)}>
+        {isLeader ? (
+          <Link to="/slotDetails" search={{ slot }} draggable={false}>
+            {slot}
+          </Link>
+        ) : (
+          slot
+        )}
+      </Text>
+    </CopyButton>
   );
 }

--- a/src/features/LeaderSchedule/Slots/slotText.module.css
+++ b/src/features/LeaderSchedule/Slots/slotText.module.css
@@ -1,4 +1,6 @@
 .slot-text {
+  color: var(--slot-card-section-primary-color);
+  font-size: 14px;
   user-select: text;
   a:link {
     text-decoration: none;
@@ -13,4 +15,8 @@
     text-decoration: none;
     color: var(--slot-text-active-link-color);
   }
+}
+
+.copy-button {
+  color: var(--slot-card-section-primary-color);
 }


### PR DESCRIPTION
Add copy button to slot numbers in leader schedule.
Inspired by PR contributed by @theobolo: #353

Additional Considerations
- There is limited horizontal space in the leader schedule, so to save on space dedicated to a copy icon (which will be empty when the copy button is not hovered), we’ve overlayed the copy icon onto the slot number text.
- To prevent conflicting actions on a linked slot number text, copying only triggers when the user clicks on the copy icon. If the user clicks on the linked text, the user is redirected to the corresponding slot details page. If the text is not linked, nothing happens.
- The `copyOnIconOnly` prop is added to the CopyButton component to allow for reusability of this pattern elsewhere in the application
