### PR TITLE
chore: shreds labels performance

### DIFF
--- a/src/features/Overview/ShredsProgression/ShredsSlotLabels.tsx
+++ b/src/features/Overview/ShredsProgression/ShredsSlotLabels.tsx
@@ -1,15 +1,38 @@
 import { useAtomValue } from "jotai";
 import { Flex, Text } from "@radix-ui/themes";
-import { getSlotGroupLabelId, getSlotLabelId } from "./utils";
+import {
+  getSlotGroupLabelId,
+  getSlotGroupNameId,
+  getSlotLabelId,
+} from "./utils";
 import styles from "./shreds.module.css";
-import { useMemo } from "react";
+import { memo, useLayoutEffect, useMemo, useState } from "react";
 import { slotsPerLeader } from "../../../consts";
 import { useSlotInfo } from "../../../hooks/useSlotInfo";
 import clsx from "clsx";
 import PeerIcon from "../../../components/PeerIcon";
-import { skippedClusterSlotsAtom } from "../../../atoms";
 import { isStartupProgressVisibleAtom } from "../../StartupProgress/atoms";
 import { liveShredsPostStartupLeaderSlotsAtom } from "./atoms";
+
+const extraGroups = 20;
+
+/**
+ * Add extra leaders to reduce update frequency
+ */
+function getRangeWithExtraLeaders(
+  range:
+    | {
+        min: number;
+        max: number;
+      }
+    | undefined,
+) {
+  if (!range) return;
+  return {
+    min: range.min,
+    max: range.max + extraGroups * slotsPerLeader,
+  };
+}
 
 /**
  * Labels for shreds slots.
@@ -18,40 +41,74 @@ import { liveShredsPostStartupLeaderSlotsAtom } from "./atoms";
  */
 export default function ShredsSlotLabels() {
   const isStartup = useAtomValue(isStartupProgressVisibleAtom);
-  const postStartupLeaderSlots = useAtomValue(
-    liveShredsPostStartupLeaderSlotsAtom,
+  const leaderSlotsRange = useAtomValue(liveShredsPostStartupLeaderSlotsAtom);
+  const [renderSlotRange, setRenderSlotRange] = useState(
+    getRangeWithExtraLeaders(leaderSlotsRange),
   );
+
+  useLayoutEffect(() => {
+    if (!leaderSlotsRange) {
+      // reset
+      setRenderSlotRange(undefined);
+      return;
+    }
+
+    setRenderSlotRange((prev) => {
+      if (!prev || prev.max < leaderSlotsRange.max) {
+        // need to render more groups
+        return getRangeWithExtraLeaders(leaderSlotsRange);
+      }
+      return prev;
+    });
+  }, [leaderSlotsRange]);
 
   if (isStartup) return;
 
   return (
+    <SlotGroupContainer
+      firstLeader={renderSlotRange?.min}
+      lastLeader={renderSlotRange?.max}
+    />
+  );
+}
+
+interface SlotGroupContainerProps {
+  firstLeader?: number;
+  lastLeader?: number;
+}
+const SlotGroupContainer = memo(function SlotGroupContainer({
+  firstLeader,
+  lastLeader,
+}: SlotGroupContainerProps) {
+  const leaderSlots = useMemo(() => {
+    if (firstLeader == null || lastLeader == null) return;
+
+    const result = [];
+    for (let slot = firstLeader; slot <= lastLeader; slot += slotsPerLeader) {
+      result.push(slot);
+    }
+    return result;
+  }, [firstLeader, lastLeader]);
+
+  return (
     <Flex flexShrink="0" overflowX="hidden" position="relative" height="15px">
-      {postStartupLeaderSlots.map((slot) => (
+      {leaderSlots?.map((slot) => (
         <SlotGroupLabel key={slot} firstSlot={slot} />
       ))}
     </Flex>
   );
-}
+});
 
 interface SlotGroupLabelProps {
   firstSlot: number;
 }
-function SlotGroupLabel({ firstSlot }: SlotGroupLabelProps) {
+const SlotGroupLabel = memo(function SlotGroupLabel({
+  firstSlot,
+}: SlotGroupLabelProps) {
   const { peer, name, isLeader } = useSlotInfo(firstSlot);
   const slots = useMemo(() => {
     return Array.from({ length: slotsPerLeader }, (_, i) => firstSlot + i);
   }, [firstSlot]);
-
-  const skippedClusterSlots = useAtomValue(skippedClusterSlotsAtom);
-  const skippedSlots = useMemo(() => {
-    const skipped = new Set<number>();
-    for (const slot of slots) {
-      if (skippedClusterSlots.has(slot)) {
-        skipped.add(slot);
-      }
-    }
-    return skipped;
-  }, [slots, skippedClusterSlots]);
 
   return (
     <Flex
@@ -71,14 +128,13 @@ function SlotGroupLabel({ firstSlot }: SlotGroupLabelProps) {
         minHeight="0"
         minWidth="0"
         px="2px"
-        className={clsx(styles.slotGroupTopContainer, {
-          [styles.skipped]: skippedSlots.size > 0,
-        })}
+        className={styles.slotGroupTopContainer}
       >
         <Flex
           align="center"
           gap="4px"
           minWidth="0"
+          id={getSlotGroupNameId(firstSlot)}
           className={styles.slotGroupNameContainer}
         >
           <PeerIcon
@@ -99,13 +155,11 @@ function SlotGroupLabel({ firstSlot }: SlotGroupLabelProps) {
         {slots.map((slot) => (
           <div
             key={slot}
-            className={clsx(styles.slotBar, {
-              [styles.skipped]: skippedSlots.has(slot),
-            })}
+            className={styles.slotBar}
             id={getSlotLabelId(slot)}
           />
         ))}
       </Flex>
     </Flex>
   );
-}
+});

--- a/src/features/Overview/ShredsProgression/__tests__/shredsProgresionPlugin.test.ts
+++ b/src/features/Overview/ShredsProgression/__tests__/shredsProgresionPlugin.test.ts
@@ -14,7 +14,7 @@ describe("shreds progression plugin", () => {
         "11": [600, 800],
         "12": [800, 1100],
       } satisfies TsDeltasBySlot;
-      const groupLeaderSlots = [8, 12];
+      const groupLeaderSlots = { min: 8, max: 12 };
       expect(getGroupTsDeltas(slotTsDeltas, groupLeaderSlots)).toEqual({
         "8": [400, 800],
         "12": [800, undefined],
@@ -22,7 +22,7 @@ describe("shreds progression plugin", () => {
     });
 
     it("sets group label end to undefined if valid slots are missing / have undefined end", () => {
-      const groupLeaderSlots = [8, 12];
+      const groupLeaderSlots = { min: 8, max: 12 };
 
       expect(
         getGroupTsDeltas(
@@ -116,7 +116,7 @@ describe("shreds progression plugin", () => {
           "12": [800, 1200],
         });
 
-        const groupLeaderSlots = [8, 12];
+        const groupLeaderSlots = { min: 8, max: 12 };
         const groupTsDeltas = getGroupTsDeltas(slotTsDeltas, groupLeaderSlots);
         expect(groupTsDeltas).toEqual({
           "8": [0, 800],
@@ -182,7 +182,7 @@ describe("shreds progression plugin", () => {
           "12": [800, 1100],
         });
 
-        const groupLeaderSlots = [8, 12];
+        const groupLeaderSlots = { min: 8, max: 12 };
         const groupTsDeltas = getGroupTsDeltas(slotTsDeltas, groupLeaderSlots);
 
         expect(groupTsDeltas).toEqual({
@@ -246,7 +246,7 @@ describe("shreds progression plugin", () => {
           "12": [800, 1100],
         });
 
-        const groupLeaderSlots = [8, 12];
+        const groupLeaderSlots = { min: 8, max: 12 };
         const groupTsDeltas = getGroupTsDeltas(slotTsDeltas, groupLeaderSlots);
         expect(groupTsDeltas).toEqual({
           "8": [0, 800],
@@ -374,7 +374,7 @@ describe("shreds progression plugin", () => {
         "15": [520, 700],
       });
 
-      const groupLeaderSlots = [8, 12];
+      const groupLeaderSlots = { min: 8, max: 12 };
       const groupTsDeltas = getGroupTsDeltas(slotTsDeltas, groupLeaderSlots);
       expect(groupTsDeltas).toEqual({ "8": [0, 2000], "12": [300, 700] });
     });

--- a/src/features/Overview/ShredsProgression/atoms.ts
+++ b/src/features/Overview/ShredsProgression/atoms.ts
@@ -1,5 +1,4 @@
 import { atom } from "jotai";
-import { slotsPerLeader } from "../../../consts";
 import { getSlotGroupLeader } from "../../../utils";
 import { slotCaughtUpAtom } from "../../../api/atoms";
 import type { LiveShredsData } from "../../../api/worker/cache/shreds/types";
@@ -25,11 +24,10 @@ export const liveShredsPostStartupRangeAtom = atom((get) => {
  * */
 export const liveShredsPostStartupLeaderSlotsAtom = atom((get) => {
   const rangeAfterStartup = get(liveShredsPostStartupRangeAtom);
-  if (!rangeAfterStartup) return [];
+  if (!rangeAfterStartup) return;
 
-  const slots = [getSlotGroupLeader(rangeAfterStartup.min)];
-  while (slots[slots.length - 1] + slotsPerLeader - 1 < rangeAfterStartup.max) {
-    slots.push(getSlotGroupLeader(slots[slots.length - 1] + slotsPerLeader));
-  }
-  return slots;
+  return {
+    min: getSlotGroupLeader(rangeAfterStartup.min),
+    max: getSlotGroupLeader(rangeAfterStartup.max),
+  };
 });

--- a/src/features/Overview/ShredsProgression/shreds.module.css
+++ b/src/features/Overview/ShredsProgression/shreds.module.css
@@ -1,29 +1,22 @@
 .slot-group-label {
-  --group-x: -100000px;
-  --group-name-opacity: 0;
-
   opacity: 0.8;
   background-color: #080b13;
   border-radius: 2px;
   border: 1px solid #3c4652;
   border-top-width: 0;
   will-change: transform;
-  transform: translate(var(--group-x));
+  transform: translateX(-100000px);
 
   &.you {
     border: 1px solid #2a7edf;
   }
 
-  .slot-group-top-container {
+  & > .slot-group-top-container {
     width: 100%;
     background-color: #101318;
 
-    &.skipped {
-      background-color: var(--red-2);
-    }
-
     .slot-group-name-container {
-      opacity: var(--group-name-opacity);
+      opacity: 0;
       transition: opacity 0.6s;
       will-change: opacity;
 
@@ -38,14 +31,16 @@
     }
   }
 
+  &.skipped > .slot-group-top-container {
+    background-color: var(--red-2);
+  }
+
   .slot-bars-container {
     flex-shrink: 0;
     .slot-bar {
-      --slot-x: 0;
-
       position: absolute;
       will-change: transform;
-      transform: translate(var(--slot-x));
+      transform: translateX(0);
 
       height: 100%;
       border-radius: 3px;

--- a/src/features/Overview/ShredsProgression/shredsProgressionPlugin.ts
+++ b/src/features/Overview/ShredsProgression/shredsProgressionPlugin.ts
@@ -21,7 +21,13 @@ import {
 import { serverTimeMsAtom, skippedClusterSlotsAtom } from "../../../atoms";
 import { clamp, sum } from "lodash";
 import { ShredEvent } from "../../../api/entities";
-import { getSlotGroupLabelId, getSlotLabelId } from "./utils";
+import {
+  getSlotGroupLabelId,
+  getSlotGroupNameId,
+  getSlotLabelId,
+} from "./utils";
+import styles from "./shreds.module.css";
+
 import { slotsPerLeader } from "../../../consts";
 import { delayMs } from "../../../api/worker/cache/shreds/shredsCalc";
 import type {
@@ -30,6 +36,7 @@ import type {
 } from "../../../api/worker/cache/shreds/types";
 
 const store = getDefaultStore();
+
 export const shredsXScaleKey = "shredsXScaleKey";
 
 type Coordinates = [x: number, y: number, width?: number];
@@ -55,9 +62,27 @@ type XRange = {
   maxCssPos: number;
 };
 
+type LabelState = {
+  transformX: number;
+  width?: number;
+  opacity?: string;
+  isSkipped?: boolean;
+};
+
 export function shredsProgressionPlugin(
   isOnStartupScreen: boolean,
 ): uPlot.Plugin {
+  let prevLabels = {
+    groups: new Map<number, LabelState>(),
+    slots: new Map<number, LabelState>(),
+  };
+
+  // use to get new map values without creating a new map every update
+  let tempNewLabels: typeof prevLabels = {
+    groups: new Map(),
+    slots: new Map(),
+  };
+
   const prevTimeDiffs: number[] = [];
 
   /**
@@ -65,27 +90,21 @@ export function shredsProgressionPlugin(
    * "now" is adjusted using an avg diff of server time and real now ts to smooth out server msg delays.
    * We also delay "now" by one data update interval to prevent instability of right-most data.
    */
-  function getAdjustedNow() {
+  function getAdjustedNow(serverTimeMs: number) {
     // Use server time for chart axis
     // Use a rolling avg of the server time and client now diff.
     // If we get ws messages buffered and it results in a temporary high
     // diff, shred still move smoothly by using the avg
     const now = Date.now();
-    const serverTimeMs = store.get(serverTimeMsAtom);
 
-    if (serverTimeMs) {
-      const timeDiff = now - serverTimeMs;
-      prevTimeDiffs.push(timeDiff);
-      while (prevTimeDiffs.length > 20) {
-        prevTimeDiffs.shift();
-      }
+    const timeDiff = now - serverTimeMs;
+    prevTimeDiffs.push(timeDiff);
+    while (prevTimeDiffs.length > 100) {
+      prevTimeDiffs.shift();
     }
 
-    const timeDiffAvg = prevTimeDiffs.length
-      ? sum(prevTimeDiffs) / prevTimeDiffs.length
-      : undefined;
-    const adjustedTimeMs =
-      timeDiffAvg == null ? (serverTimeMs ?? now) : now - timeDiffAvg;
+    const timeDiffAvg = sum(prevTimeDiffs) / prevTimeDiffs.length;
+    const adjustedTimeMs = now - timeDiffAvg;
     return adjustedTimeMs - delayMs;
   }
 
@@ -96,6 +115,9 @@ export function shredsProgressionPlugin(
           if (isOnStartupScreen) {
             drawStartupChartAxes(u);
           }
+
+          const serverTimeMs = store.get(serverTimeMsAtom);
+          if (!serverTimeMs) return;
 
           const {
             slotsShreds: liveShreds,
@@ -127,7 +149,7 @@ export function shredsProgressionPlugin(
             if (!rangeAfterStartup) return;
           }
 
-          const adjustedNow = getAdjustedNow();
+          const adjustedNow = getAdjustedNow(serverTimeMs);
 
           const maxReferenceTs = adjustedNow - liveShreds.referenceTs;
           const tsSpan = maxXScale - minXScale;
@@ -253,9 +275,14 @@ export function shredsProgressionPlugin(
               rangeAfterStartup,
               liveShreds.slots,
               skippedSlotsCluster,
-              u,
               xRange,
+              prevLabels,
+              tempNewLabels,
             );
+            // switch map for reuse, don't create new maps each render
+            [prevLabels, tempNewLabels] = [tempNewLabels, prevLabels];
+            tempNewLabels.groups.clear();
+            tempNewLabels.slots.clear();
           }
         },
       ],
@@ -482,38 +509,62 @@ function updateLabels(
   },
   slots: SlotsShreds["slots"],
   skippedSlotsCluster: Set<number>,
-  u: uPlot,
   xRange: XRange,
+  prevLabels: {
+    groups: Map<number, LabelState>;
+    slots: Map<number, LabelState>;
+  },
+  newLabels: {
+    groups: Map<number, LabelState>;
+    slots: Map<number, LabelState>;
+  },
 ) {
   const slotBlocks = getSlotBlocks(slotRange, slots);
   const slotTsDeltas = estimateSlotTsDeltas(slotBlocks, skippedSlotsCluster);
-  const postStartupLeaderSlots = store.get(
-    liveShredsPostStartupLeaderSlotsAtom,
-  );
-  const groupTsDeltas = getGroupTsDeltas(slotTsDeltas, postStartupLeaderSlots);
+  const leaderSlotsRange = store.get(liveShredsPostStartupLeaderSlotsAtom);
+  if (!leaderSlotsRange) return;
 
-  for (let groupIdx = 0; groupIdx < postStartupLeaderSlots.length; groupIdx++) {
-    const leaderSlot = postStartupLeaderSlots[groupIdx];
+  const groupTsDeltas = getGroupTsDeltas(slotTsDeltas, leaderSlotsRange);
+  for (
+    let leaderSlot = leaderSlotsRange.min;
+    leaderSlot <= leaderSlotsRange.max;
+    leaderSlot += slotsPerLeader
+  ) {
     const leaderElId = getSlotGroupLabelId(leaderSlot);
     const leaderEl = document.getElementById(leaderElId);
     if (!leaderEl) continue;
 
     const groupRange = groupTsDeltas[leaderSlot];
-
     const groupPos = getPosFromTsDeltaRange(groupRange, xRange);
-    moveLabelPosition(true, groupPos, xRange.maxCssPos, leaderEl);
+
+    let isGroupSkipped = false;
+    for (let slot = leaderSlot; slot < leaderSlot + slotsPerLeader; slot++) {
+      if (skippedSlotsCluster.has(slot)) {
+        isGroupSkipped = true;
+        break;
+      }
+    }
+
+    moveLabelPosition(
+      true,
+      groupPos,
+      leaderEl,
+      leaderSlot,
+      prevLabels.groups,
+      newLabels.groups,
+      xRange.maxCssPos,
+      isGroupSkipped,
+    );
 
     for (
       let slotNumber = leaderSlot;
       slotNumber < leaderSlot + slotsPerLeader;
       slotNumber++
     ) {
-      const slotElId = getSlotLabelId(slotNumber);
-      const slotEl = document.getElementById(slotElId);
+      const slotEl = document.getElementById(getSlotLabelId(slotNumber));
       if (!slotEl) continue;
 
-      const slotRange = slotTsDeltas[slotNumber];
-      const slotPos = getPosFromTsDeltaRange(slotRange, xRange);
+      const slotPos = getPosFromTsDeltaRange(slotTsDeltas[slotNumber], xRange);
 
       // position slot relative to its slot group
       const relativeSlotPos =
@@ -521,7 +572,35 @@ function updateLabels(
           ? ([slotPos[0] - groupPos[0], slotPos[1]] satisfies Position)
           : undefined;
 
-      moveLabelPosition(false, relativeSlotPos, xRange.maxCssPos, slotEl);
+      moveLabelPosition(
+        false,
+        relativeSlotPos,
+        slotEl,
+        slotNumber,
+        prevLabels.slots,
+        newLabels.slots,
+        xRange.maxCssPos,
+        skippedSlotsCluster.has(slotNumber),
+      );
+    }
+  }
+
+  // Hide any labels that were visible last frame but are no longer in range
+  for (const slot of prevLabels.groups.keys()) {
+    if (newLabels.groups.has(slot)) continue;
+
+    const el = document.getElementById(getSlotGroupLabelId(slot));
+    if (el && prevLabels.groups.get(slot)?.transformX !== hiddenTransformX) {
+      el.style.transform = `translateX(${hiddenTransformX}px)`;
+    }
+  }
+
+  for (const slot of prevLabels.slots.keys()) {
+    if (newLabels.slots.has(slot)) continue;
+
+    const el = document.getElementById(getSlotLabelId(slot));
+    if (el && prevLabels.slots.get(slot)?.transformX !== hiddenTransformX) {
+      el.style.transform = `translateX(${hiddenTransformX}px)`;
     }
   }
 }
@@ -765,11 +844,15 @@ function splitRangeAmongSlots(
  */
 export function getGroupTsDeltas(
   slotTsDeltas: TsDeltasBySlot,
-  groupLeaderSlots: number[],
+  groupLeaderSlots: { min: number; max: number },
 ) {
   const tsDeltasByGroup: TsDeltasBySlot = {};
 
-  for (const leaderSlot of groupLeaderSlots) {
+  for (
+    let leaderSlot = groupLeaderSlots.min;
+    leaderSlot <= groupLeaderSlots.max;
+    leaderSlot += slotsPerLeader
+  ) {
     // filter to relevant slots
     const slotsWithWidths = Array.from(
       { length: slotsPerLeader },
@@ -837,39 +920,75 @@ function getPosFromTsDeltaRange(
   return [xStartPos, xEndPos - xStartPos];
 }
 
-/**
- * Update label element styles
- */
+// Large enough to cover the viewport for incomplete labels without redrawing every frame
+const hugeWidth = 100000;
+const hiddenTransformX = -hugeWidth;
+
 function moveLabelPosition(
   isGroup: boolean,
   position: Position | undefined,
-  maxXPos: number,
   el: HTMLElement,
+  slotNumber: number,
+  prevLabels: Map<number, LabelState>,
+  newLabels: Map<number, LabelState>,
+  maxVisibleXPos: number,
+  isSkipped: boolean,
 ) {
-  const groupBorderOffset = 1;
-  const xPosProp = isGroup ? "--group-x" : "--slot-x";
+  const borderOffset = isGroup ? 1 : 0;
+  const prevState = prevLabels.get(slotNumber);
 
-  const isVisible = !!position;
-  if (!isVisible) {
-    // hide
-    el.style.setProperty(xPosProp, "-100000px");
+  if (!position) {
+    // label hidden
+    const transformX = hiddenTransformX;
+    if (prevState?.transformX !== transformX) {
+      el.style.transform = `translateX(${transformX}px)`;
+    }
+    newLabels.set(slotNumber, { ...prevState, transformX });
     return;
   }
 
   const [xPos, width] = position;
-  el.style.setProperty(
-    xPosProp,
-    `${xPos - (isGroup ? groupBorderOffset : 0)}px`,
-  );
+  const transformX = xPos - borderOffset;
+  const newState = { ...prevState, transformX };
 
-  // If missing width, extend to max width (with extra px to hide right border)
-  const newWidth = width ?? maxXPos - xPos + 1;
-  el.style.width = `${newWidth + (isGroup ? groupBorderOffset * 2 : 0)}px`;
+  if (prevState?.transformX !== transformX) {
+    el.style.transform = `translateX(${transformX}px)`;
+  }
 
-  const isExtended = width == null;
+  if (width != null) {
+    const newWidth = width + borderOffset * 2;
+    if (prevState?.width !== newWidth) {
+      el.style.width = `${newWidth}px`;
+      newState.width = newWidth;
+    }
+  } else if (
+    // missing width, so label should extend to Infinity
+    !prevState?.width ||
+    // extend label again so its right edge is not visible. +1 to hide right border
+    newState.transformX + prevState.width < maxVisibleXPos + 1
+  ) {
+    const newWidth = hugeWidth;
+    if (prevState?.width !== newWidth) {
+      el.style.width = `${newWidth}px`;
+      newState.width = newWidth;
+    }
+  }
+
   if (isGroup) {
+    const nameEl = document.getElementById(getSlotGroupNameId(slotNumber));
     // Extended groups don't have a defined end, so we don't know where to center the name text.
     // Set to opacity 0, and transition to 1 when the group end becomes defined.
-    el.style.setProperty("--group-name-opacity", isExtended ? "0" : "1");
+    const opacity = width == null ? "0" : "1";
+    if (nameEl && prevState?.opacity !== opacity) {
+      newState.opacity = opacity;
+      nameEl.style.opacity = opacity;
+    }
   }
+
+  if (prevState?.isSkipped !== isSkipped) {
+    el.classList.toggle(styles.skipped, isSkipped);
+    newState.isSkipped = isSkipped;
+  }
+
+  newLabels.set(slotNumber, newState);
 }

--- a/src/features/Overview/ShredsProgression/utils.ts
+++ b/src/features/Overview/ShredsProgression/utils.ts
@@ -7,3 +7,7 @@ export function getSlotGroupLabelId(slot: number) {
 export function getSlotLabelId(slot: number) {
   return `slot-label-${slot}`;
 }
+
+export function getSlotGroupNameId(slot: number) {
+  return `slot-group-name-${getSlotGroupLeader(slot)}`;
+}


### PR DESCRIPTION
Changes:
- draw extra future labels to reduce frequency of react updates
- memo label components
- remove CSS vars, set el.style directly. Added id to name element, which has opacity change
- update leader range atom to store min and max instead of array
- only update el.style when value changes (track in prevLabels object)
- don't render chart if server time is missing
- avg 100 values instead of 20 for adjustedNow calc
- handle skipped label styling in plugin, not react component