### PR TITLE
feat: support for SIMD-255 shorter slot times

### DIFF
--- a/src/api/entities.ts
+++ b/src/api/entities.ts
@@ -700,6 +700,7 @@ export const epochNewSchema = z.object({
   staked_pubkeys: z.string().array(),
   staked_lamports: z.coerce.bigint().array(),
   leader_slots: z.number().array(),
+  target_slot_duration_nanos: z.number().optional(),
 });
 
 export const epochSchema = z.discriminatedUnion("key", [

--- a/src/features/Overview/SlotPerformance/TileSparkLine.tsx
+++ b/src/features/Overview/SlotPerformance/TileSparkLine.tsx
@@ -14,9 +14,10 @@ import {
 } from "./useTileSparkline";
 import styles from "./tileSparkline.module.css";
 import clsx from "clsx";
+import { useAtomValue } from "jotai";
+import { slotDurationAtom } from "../../../atoms";
+import { slotsPerLeader } from "../../../consts";
 
-// 4 slots worth
-const leaderGroupWindowMs = 400 * 4;
 const _updateIntervalMs = 80;
 
 interface TileParkLineProps {
@@ -35,11 +36,13 @@ export default function TileSparkLine({
   history,
   height = 24,
   background,
-  windowMs = leaderGroupWindowMs,
+  windowMs: windowMsProp,
   strokeWidth = strokeLineWidth,
   updateIntervalMs = _updateIntervalMs,
   tickMs,
 }: TileParkLineProps) {
+  const slotDuration = useAtomValue(slotDurationAtom);
+  const windowMs = windowMsProp ?? slotDuration * slotsPerLeader;
   const [svgRef, { width }] = useMeasure<SVGSVGElement>();
 
   const { scaledDataPoints, range, pxPerTick, chartTickMs, isLive } =

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/txnBarsPlugin.ts
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/txnBarsPlugin.ts
@@ -7,6 +7,7 @@ import type { MutableRefObject } from "react";
 import type { SlotTransactions } from "../../../../api/types";
 import { getDefaultStore } from "jotai";
 import { logRatio } from "../../../../mathUtils";
+import { slotDurationAtom } from "../../../../atoms";
 import { barCountAtom } from "./atoms";
 import { FilterEnum, stateColors, TxnState } from "./consts";
 import {
@@ -494,7 +495,8 @@ export function txnBarsPlugin(
                     const scaleDiff =
                       u.scales[banksXScaleKey].min != null &&
                       u.scales[banksXScaleKey].max != null
-                        ? 400_000_000 /
+                        ? (getDefaultStore().get(slotDurationAtom) *
+                            1_000_000) /
                           (u.scales[banksXScaleKey].max -
                             u.scales[banksXScaleKey].min)
                         : undefined;


### PR DESCRIPTION
- Use `slotDurationAtom` everywhere we need to.
- Bypass throttling the update of `estimatedSlotDuration` when the change is significant (>25ms), so that the `reduce_slot_time` feature gate updates are reflected immediately.