### PR TITLE
fix: gossip table colors

### DIFF
--- a/src/features/Gossip/PeerTable.tsx/peerTable.module.css
+++ b/src/features/Gossip/PeerTable.tsx/peerTable.module.css
@@ -7,14 +7,14 @@
   thead {
     tr {
       font-size: 12px;
-      color: var(--gossip-table-header-color);
+      color: var(--table-header-color);
     }
   }
 
   tbody {
     tr {
       font-size: 14px;
-      color: var(--gossip-table-body-color);
+      color: var(--table-body-color);
     }
   }
 }

--- a/src/features/Gossip/table.module.css
+++ b/src/features/Gossip/table.module.css
@@ -15,7 +15,7 @@
     th {
       font-size: 12px;
       font-weight: 400;
-      color: var(--gossip-table-header-color);
+      color: var(--table-header-color);
     }
   }
 
@@ -23,7 +23,7 @@
     th,
     td {
       font-size: 14px;
-      color: var(--gossip-table-body-color);
+      color: var(--table-body-color);
     }
   }
 


### PR DESCRIPTION
This fixes the colors for the gossip tables (currently the header and body text colors are the same).
These css variables got deleted, but weren't updated in the corresponding module files.