### PR TITLE
fix: stop live sparkline if data doesn't reach right edge

### DIFF
--- a/src/features/Overview/SlotPerformance/useTileSparkline.ts
+++ b/src/features/Overview/SlotPerformance/useTileSparkline.ts
@@ -203,6 +203,14 @@ export function useScaledDataPoints({
         return;
       }
 
+      // In live mode, if the last data point is more than
+      // (tickBufferCount - 1) ticks behind tEnd, it will slide past
+      // the right edge of the sparkline svg, leaving a gap.
+      // Skip this render to prevent the gap.
+      const lastDataPoint = data[data.length - 1];
+      const rightEdgeTs = tEnd - tickMs * (tickBufferCount - 1);
+      if (!isStatic && lastDataPoint && lastDataPoint.ts < rightEdgeTs) return;
+
       const tStart = tEnd - windowMs;
       const scale = width / windowMs;
 


### PR DESCRIPTION
The dataWindow and sparkline ticking occur independently of each other. This means if the dataWindow updating falls behind the rightmost-edge of the sparkline ticking (performance.now() when live), a gap will appear between the end of the sparkline and the right edge of the sparkline area. Instead of rendering the next tick, which will show the gap, skip this render.