### PR TITLE
feat: custom virtual slots nav list

### DIFF
--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -413,6 +413,22 @@ export const nextLeaderSlotAtom = atom(
   },
 );
 
+export const yourLeaderSlotCountsAtom = atom<
+  { past: number; current: number; future: number } | undefined
+>((get) => {
+  const leaderSlots = get(leaderSlotsAtom);
+  if (!leaderSlots) return;
+
+  const isCurrentlyLeader = get(isCurrentlyLeaderAtom);
+  const current = isCurrentlyLeader ? 1 : 0;
+  const nextLeaderSlotIndex = get(nextLeaderSlotIndexAtom);
+
+  const future =
+    nextLeaderSlotIndex == null ? 0 : leaderSlots.length - nextLeaderSlotIndex;
+  const past = leaderSlots.length - current - future;
+  return { past, current, future };
+});
+
 export const nextEpochLeaderSlotAtom = atom((get) => {
   const leaderSlots = get(nextEpochLeaderSlotsAtom);
   if (!leaderSlots) return;

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -368,6 +368,16 @@ export const leaderSlotsAtom = atom((get) => {
   return getLeaderSlots(epoch, pubkey);
 });
 
+/**
+ * Set of your leader slots, in ascending order
+ */
+export const ascendingLeaderSlotsSetAtom = atom((get) => {
+  const leaderSlots = get(leaderSlotsAtom);
+  if (!leaderSlots) return;
+
+  return new Set(leaderSlots);
+});
+
 /** In order array of your leader slots (only first slot in group of 4) */
 export const nextEpochLeaderSlotsAtom = atom((get) => {
   const epoch = get(nextEpochAtom);

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const slotsPerLeader = 4;
-export const slotsListPinnedSlotOffset = 5;
+export const slotsListTopPaddingIndex = 5;
 export const scheduleUpcomingSlotsCount = 3;
 
 export const solDecimals = 4;

--- a/src/features/Navigation/ListItem.tsx
+++ b/src/features/Navigation/ListItem.tsx
@@ -1,0 +1,47 @@
+import { memo } from "react";
+import SlotsRenderer from "./SlotsRenderer";
+import type { ItemInfo } from "./utils";
+
+interface ItemsProps {
+  visibleItems: ItemInfo[];
+}
+export function MItems({ visibleItems }: ItemsProps) {
+  return visibleItems.map(({ slot, topOffset, bottomOffset, isPast }) => (
+    <MItem
+      key={slot}
+      slot={slot}
+      offset={isPast ? bottomOffset : topOffset}
+      isBottomOffset={isPast}
+    />
+  ));
+}
+
+interface ItemProps {
+  slot: number;
+  offset: number;
+  isBottomOffset: boolean;
+}
+export const MItem = memo(function Item({
+  slot,
+  offset,
+  isBottomOffset,
+}: ItemProps) {
+  const anchorStyle = isBottomOffset
+    ? { bottom: 0, transform: `translateY(-${offset}px)` }
+    : { top: 0, transform: `translateY(${offset}px)` };
+
+  return (
+    <div
+      id={`slot-${slot}`}
+      style={{
+        position: "absolute",
+        width: "100%",
+        ...anchorStyle,
+        // prevent browser snapping to document's pixel grid
+        willChange: "transform",
+      }}
+    >
+      <SlotsRenderer leaderSlotForGroup={slot} />
+    </div>
+  );
+});

--- a/src/features/Navigation/SlotsList.tsx
+++ b/src/features/Navigation/SlotsList.tsx
@@ -1,5 +1,6 @@
 import { useAtomValue } from "jotai";
 import {
+  ascendingLeaderSlotsSetAtom,
   currentSlotAtom,
   epochAtom,
   isCurrentlyLeaderAtom,
@@ -74,12 +75,18 @@ const MAllSlotsList = memo(function AllSlotsList({
 }: SlotsListProps) {
   const epoch = useAtomValue(epochAtom);
   const currentSlot = useAtomValue(currentSlotAtom);
-  const leaderSlots = useAtomValue(leaderSlotsAtom);
+  const ascendingLeaderSlotsSet = useAtomValue(ascendingLeaderSlotsSetAtom);
   const nextLeaderSlot = useAtomValue(nextLeaderSlotAtom);
 
   const slotsListProps = useMemo(
-    () => getAllSlotsListProps(epoch, currentSlot, leaderSlots, nextLeaderSlot),
-    [epoch, currentSlot, leaderSlots, nextLeaderSlot],
+    () =>
+      getAllSlotsListProps(
+        epoch,
+        currentSlot,
+        ascendingLeaderSlotsSet,
+        nextLeaderSlot,
+      ),
+    [epoch, currentSlot, ascendingLeaderSlotsSet, nextLeaderSlot],
   );
 
   if (!slotsListProps) return null;

--- a/src/features/Navigation/SlotsList.tsx
+++ b/src/features/Navigation/SlotsList.tsx
@@ -1,7 +1,7 @@
 import { useAtomValue } from "jotai";
 import {
   ascendingLeaderSlotsSetAtom,
-  currentSlotAtom,
+  currentLeaderSlotAtom,
   epochAtom,
   isCurrentlyLeaderAtom,
   leaderSlotsAtom,
@@ -9,6 +9,7 @@ import {
   nextLeaderSlotIndexAtom,
   SlotNavFilter,
   slotNavFilterAtom,
+  yourLeaderSlotCountsAtom,
 } from "../../atoms";
 import { Flex, Text } from "@radix-ui/themes";
 import { memo, useMemo, type CSSProperties } from "react";
@@ -18,6 +19,8 @@ import VirtualSlotsList from "./VirtualSlotsList";
 import { slotGroupCssVars, type SlotsIndexProps } from "./const";
 import { getAllSlotsListProps } from "./allSlotsUtils";
 import { getMySlotsListProps } from "./mySlotsUtils";
+import { useHeightDeltas } from "./useHeightDeltas";
+import { getOffsetHelpers, type OffsetHelpers } from "./utils";
 
 interface SlotsListProps {
   width: number;
@@ -37,14 +40,18 @@ export default function SlotsList({ width, height }: SlotsListProps) {
   );
 }
 
+interface InnerSlotsListProps {
+  heightDeltas: Map<number, number> | undefined;
+}
 const MInnerSlotsList = memo(function InnerSlotsList({
   width,
   height,
+  heightDeltas,
   itemsCount,
   getSlotAtIndex,
   getIndexForSlot,
-  offsetHelpers,
-}: SlotsIndexProps & SlotsListProps) {
+  listHelpers,
+}: InnerSlotsListProps & SlotsIndexProps & SlotsListProps) {
   const style: CSSProperties = useMemo(() => {
     return {
       ...slotGroupCssVars,
@@ -54,16 +61,25 @@ const MInnerSlotsList = memo(function InnerSlotsList({
     };
   }, [height, width]);
 
+  const offsetHelpers: OffsetHelpers = useMemo(
+    () =>
+      getOffsetHelpers(
+        listHelpers,
+        getIndexForSlot,
+        getSlotAtIndex,
+        itemsCount,
+      ),
+    [listHelpers, getIndexForSlot, getSlotAtIndex, itemsCount],
+  );
+
   return (
     <div style={style}>
       <ResetLive />
       <VirtualSlotsList
         visibleWidth={width}
         visibleHeight={height}
-        itemsCount={itemsCount}
-        getSlotAtIndex={getSlotAtIndex}
-        getIndexForSlot={getIndexForSlot}
         offsetHelpers={offsetHelpers}
+        heightDeltas={heightDeltas}
       />
     </div>
   );
@@ -74,24 +90,46 @@ const MAllSlotsList = memo(function AllSlotsList({
   height,
 }: SlotsListProps) {
   const epoch = useAtomValue(epochAtom);
-  const currentSlot = useAtomValue(currentSlotAtom);
+  const currentLeaderSlot = useAtomValue(currentLeaderSlotAtom);
   const ascendingLeaderSlotsSet = useAtomValue(ascendingLeaderSlotsSetAtom);
   const nextLeaderSlot = useAtomValue(nextLeaderSlotAtom);
+  const yourLeaderSlotCounts = useAtomValue(yourLeaderSlotCountsAtom);
 
   const slotsListProps = useMemo(
     () =>
       getAllSlotsListProps(
         epoch,
-        currentSlot,
+        currentLeaderSlot,
         ascendingLeaderSlotsSet,
         nextLeaderSlot,
+        yourLeaderSlotCounts,
       ),
-    [epoch, currentSlot, ascendingLeaderSlotsSet, nextLeaderSlot],
+    [
+      epoch,
+      currentLeaderSlot,
+      ascendingLeaderSlotsSet,
+      nextLeaderSlot,
+      yourLeaderSlotCounts,
+    ],
+  );
+
+  const heightDeltas = useHeightDeltas(
+    false,
+    currentLeaderSlot,
+    slotsListProps?.listHelpers?.yourNextLeaderSlot,
+    ascendingLeaderSlotsSet,
   );
 
   if (!slotsListProps) return null;
 
-  return <MInnerSlotsList width={width} height={height} {...slotsListProps} />;
+  return (
+    <MInnerSlotsList
+      width={width}
+      height={height}
+      {...slotsListProps}
+      heightDeltas={heightDeltas?.slotHeightDeltas}
+    />
+  );
 });
 
 const MMySlotsList = memo(function MySlotsList({
@@ -99,27 +137,40 @@ const MMySlotsList = memo(function MySlotsList({
   height,
 }: SlotsListProps) {
   const mySlots = useAtomValue(leaderSlotsAtom);
-  const currentSlot = useAtomValue(currentSlotAtom);
+  const ascendingLeaderSlotsSet = useAtomValue(ascendingLeaderSlotsSetAtom);
+  const currentLeaderSlot = useAtomValue(currentLeaderSlotAtom);
   const nextLeaderSlot = useAtomValue(nextLeaderSlotAtom);
   const isCurrentlyLeader = useAtomValue(isCurrentlyLeaderAtom);
   const nextLeaderSlotIndex = useAtomValue(nextLeaderSlotIndexAtom);
+  const yourLeaderSlotCounts = useAtomValue(yourLeaderSlotCountsAtom);
 
   const slotsListProps = useMemo(
     () =>
       getMySlotsListProps(
         mySlots,
-        currentSlot,
+        ascendingLeaderSlotsSet,
+        currentLeaderSlot,
         nextLeaderSlot,
         isCurrentlyLeader,
         nextLeaderSlotIndex,
+        yourLeaderSlotCounts,
       ),
     [
       mySlots,
-      currentSlot,
+      ascendingLeaderSlotsSet,
+      currentLeaderSlot,
       nextLeaderSlot,
       isCurrentlyLeader,
       nextLeaderSlotIndex,
+      yourLeaderSlotCounts,
     ],
+  );
+
+  const heightDeltas = useHeightDeltas(
+    true,
+    currentLeaderSlot,
+    slotsListProps?.listHelpers?.yourNextLeaderSlot,
+    ascendingLeaderSlotsSet,
   );
 
   if (!slotsListProps) return null;
@@ -141,5 +192,12 @@ const MMySlotsList = memo(function MySlotsList({
     );
   }
 
-  return <MInnerSlotsList width={width} height={height} {...slotsListProps} />;
+  return (
+    <MInnerSlotsList
+      width={width}
+      height={height}
+      {...slotsListProps}
+      heightDeltas={heightDeltas?.slotHeightDeltas}
+    />
+  );
 });

--- a/src/features/Navigation/SlotsList.tsx
+++ b/src/features/Navigation/SlotsList.tsx
@@ -1,36 +1,22 @@
-import { useAtomValue, useSetAtom } from "jotai";
+import { useAtomValue } from "jotai";
 import {
-  autoScrollAtom,
-  currentLeaderSlotAtom,
+  currentSlotAtom,
   epochAtom,
+  isCurrentlyLeaderAtom,
   leaderSlotsAtom,
+  nextLeaderSlotAtom,
+  nextLeaderSlotIndexAtom,
   SlotNavFilter,
   slotNavFilterAtom,
-  slotOverrideAtom,
 } from "../../atoms";
-import { Box, Flex, Text } from "@radix-ui/themes";
-import type { RefObject } from "react";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Flex, Text } from "@radix-ui/themes";
+import { memo, useMemo, type CSSProperties } from "react";
 import styles from "./slotsList.module.css";
-import { slotsListPinnedSlotOffset } from "../../consts";
-import { throttle } from "lodash";
-import SlotsRenderer, { MSlotsPlaceholder } from "./SlotsRenderer";
-import type { ScrollSeekConfiguration, VirtuosoHandle } from "react-virtuoso";
-import { Virtuoso } from "react-virtuoso";
 import ResetLive from "./ResetLive";
-import type { DebouncedState } from "use-debounce";
-import { useDebouncedCallback } from "use-debounce";
-import clsx from "clsx";
-import {
-  getAllSlotsListProps,
-  getMySlotsListProps,
-  type SlotsIndexProps,
-} from "./utils";
-
-const computeItemKey = (slot: number) => slot;
-
-// Add one future slot to prevent current leader transition from flickering
-const increaseViewportBy = { top: 24, bottom: 0 };
+import VirtualSlotsList from "./VirtualSlotsList";
+import { slotGroupCssVars, type SlotsIndexProps } from "./const";
+import { getAllSlotsListProps } from "./allSlotsUtils";
+import { getMySlotsListProps } from "./mySlotsUtils";
 
 interface SlotsListProps {
   width: number;
@@ -44,244 +30,90 @@ export default function SlotsList({ width, height }: SlotsListProps) {
   if (!epoch) return null;
 
   return navFilter === SlotNavFilter.MySlots ? (
-    <MySlotsList key={epoch.epoch} width={width} height={height} />
+    <MMySlotsList key={epoch.epoch} width={width} height={height} />
   ) : (
-    <AllSlotsList key={epoch.epoch} width={width} height={height} />
+    <MAllSlotsList key={epoch.epoch} width={width} height={height} />
   );
 }
 
-function InnerSlotsList({
+const MInnerSlotsList = memo(function InnerSlotsList({
   width,
   height,
   itemsCount,
   getSlotAtIndex,
   getIndexForSlot,
+  offsetHelpers,
 }: SlotsIndexProps & SlotsListProps) {
-  const listContainerRef = useRef<HTMLDivElement>(null);
-  const listRef = useRef<VirtuosoHandle>(null);
-  const visibleStartIndexRef = useRef<number | null>(null);
-
-  const [hideList, setHideList] = useState(true);
-  const [showPlaceholder, setShowPlaceholder] = useState(true);
-
-  useEffect(() => {
-    // initially hide list to
-    const timeout = setTimeout(() => {
-      setHideList(false);
-    }, 100);
-
-    return () => clearTimeout(timeout);
-  }, []);
-
-  const setSlotOverride = useSetAtom(slotOverrideAtom);
-
-  const debouncedScroll = useDebouncedCallback(() => {}, 100);
-
-  const { rangeChanged, scrollSeekConfiguration } = useMemo(() => {
-    const rangeChangedFn = ({ startIndex }: { startIndex: number }) => {
-      // account for increaseViewportBy
-      visibleStartIndexRef.current = startIndex + 1;
+  const style: CSSProperties = useMemo(() => {
+    return {
+      ...slotGroupCssVars,
+      position: "relative",
+      width,
+      height,
     };
-
-    const config: ScrollSeekConfiguration = {
-      enter: (velocity) => Math.abs(velocity) > 1500,
-      exit: (velocity) => Math.abs(velocity) < 500,
-      change: (_, range) => rangeChangedFn(range),
-    };
-    return { rangeChanged: rangeChangedFn, scrollSeekConfiguration: config };
-  }, [visibleStartIndexRef]);
-
-  // Setup user scroll handling
-  useEffect(() => {
-    if (!listContainerRef.current) return;
-    const container = listContainerRef.current;
-
-    const handleSlotOverride = throttle(
-      () => {
-        if (visibleStartIndexRef.current === null) return;
-
-        debouncedScroll();
-
-        const slotIndex = Math.min(
-          visibleStartIndexRef.current + slotsListPinnedSlotOffset,
-          itemsCount - 1,
-        );
-
-        const slot = getSlotAtIndex(slotIndex);
-        setSlotOverride(slot);
-      },
-      50,
-      { leading: true, trailing: true },
-    );
-
-    const handleScroll = () => {
-      handleSlotOverride();
-    };
-
-    container.addEventListener("wheel", handleScroll);
-    container.addEventListener("touchmove", handleScroll);
-
-    return () => {
-      container.removeEventListener("wheel", handleScroll);
-      container.removeEventListener("touchmove", handleScroll);
-    };
-  }, [
-    getSlotAtIndex,
-    debouncedScroll,
-    setSlotOverride,
-    itemsCount,
-    visibleStartIndexRef,
-  ]);
-
-  const getItemContent = useCallback(
-    (index: number) => {
-      const leader = getSlotAtIndex(index);
-      if (leader == null) return null;
-      return <SlotsRenderer leaderSlotForGroup={leader} />;
-    },
-    [getSlotAtIndex],
-  );
-
-  const totalListHeightChanged = useCallback(
-    (totalListHeight: number) => setShowPlaceholder(totalListHeight >= height),
-    [height],
-  );
+  }, [height, width]);
 
   return (
-    <Box
-      ref={listContainerRef}
-      position="relative"
-      width={`${width}px`}
-      height={`${height}px`}
-    >
-      <MRtAutoScroll listRef={listRef} getIndexForSlot={getIndexForSlot} />
-      <MSlotOverrideScroll
-        listRef={listRef}
-        getIndexForSlot={getIndexForSlot}
-        debouncedScroll={debouncedScroll}
-      />
-      {showPlaceholder && <MSlotsPlaceholder width={width} height={height} />}
+    <div style={style}>
       <ResetLive />
-      <Virtuoso
-        ref={listRef}
-        className={clsx(styles.slotsList, { [styles.hidden]: hideList })}
-        width={width}
-        height={height}
-        totalCount={itemsCount}
-        increaseViewportBy={increaseViewportBy}
-        // height of past slots that the user is most likely to scroll through
-        defaultItemHeight={42}
-        skipAnimationFrameInResizeObserver
-        computeItemKey={computeItemKey}
-        itemContent={getItemContent}
-        rangeChanged={rangeChanged}
-        components={{ ScrollSeekPlaceholder: MScrollSeekPlaceHolder }}
-        scrollSeekConfiguration={scrollSeekConfiguration}
-        totalListHeightChanged={totalListHeightChanged}
+      <VirtualSlotsList
+        visibleWidth={width}
+        visibleHeight={height}
+        itemsCount={itemsCount}
+        getSlotAtIndex={getSlotAtIndex}
+        getIndexForSlot={getIndexForSlot}
+        offsetHelpers={offsetHelpers}
       />
-    </Box>
+    </div>
   );
-}
-
-// Render nothing when scrolling quickly to improve performance
-const MScrollSeekPlaceHolder = memo(function ScrollSeekPlaceholder() {
-  return null;
 });
 
-interface RTAutoScrollProps {
-  listRef: RefObject<VirtuosoHandle>;
-  getIndexForSlot: (slot: number) => number | undefined;
-}
-const MRtAutoScroll = memo(function RTAutoScroll({
-  listRef,
-  getIndexForSlot,
-}: RTAutoScrollProps) {
-  const currentLeaderSlot = useAtomValue(currentLeaderSlotAtom);
-  const autoScroll = useAtomValue(autoScrollAtom);
-
-  useEffect(() => {
-    if (!autoScroll || currentLeaderSlot === undefined || !listRef.current)
-      return;
-
-    // scroll to new current leader slot
-    const slotIndex = getIndexForSlot(currentLeaderSlot);
-    const visibleStartIndex = slotIndex
-      ? Math.max(0, slotIndex - slotsListPinnedSlotOffset)
-      : 0;
-
-    listRef.current.scrollToIndex({
-      index: visibleStartIndex,
-      align: "start",
-    });
-  }, [autoScroll, currentLeaderSlot, getIndexForSlot, listRef]);
-
-  return null;
-});
-
-interface SlotOverrideScrollProps {
-  listRef: RefObject<VirtuosoHandle>;
-  getIndexForSlot: (slot: number) => number | undefined;
-  debouncedScroll: DebouncedState<() => void>;
-}
-const MSlotOverrideScroll = memo(function SlotOverrideScroll({
-  listRef,
-  getIndexForSlot,
-  debouncedScroll,
-}: SlotOverrideScrollProps) {
-  const rafIdRef = useRef<number | null>(null);
-  const slotOverride = useAtomValue(slotOverrideAtom);
-
-  useEffect(() => {
-    if (
-      slotOverride === undefined ||
-      !listRef.current ||
-      debouncedScroll.isPending()
-    ) {
-      return;
-    }
-
-    const slotIndex = getIndexForSlot(slotOverride);
-    const targetIndex = slotIndex
-      ? Math.max(0, slotIndex - slotsListPinnedSlotOffset)
-      : 0;
-
-    const prevRafId = rafIdRef.current;
-    rafIdRef.current = requestAnimationFrame(() => {
-      if (prevRafId !== null) {
-        cancelAnimationFrame(prevRafId);
-      }
-
-      listRef.current?.scrollToIndex({
-        index: targetIndex,
-        align: "start",
-      });
-    });
-
-    return () => {
-      if (rafIdRef.current !== null) {
-        cancelAnimationFrame(rafIdRef.current);
-        rafIdRef.current = null;
-      }
-    };
-  }, [getIndexForSlot, slotOverride, listRef, debouncedScroll]);
-
-  return null;
-});
-
-function AllSlotsList({ width, height }: SlotsListProps) {
+const MAllSlotsList = memo(function AllSlotsList({
+  width,
+  height,
+}: SlotsListProps) {
   const epoch = useAtomValue(epochAtom);
+  const currentSlot = useAtomValue(currentSlotAtom);
+  const leaderSlots = useAtomValue(leaderSlotsAtom);
+  const nextLeaderSlot = useAtomValue(nextLeaderSlotAtom);
 
-  const slotsListProps = useMemo(() => getAllSlotsListProps(epoch), [epoch]);
+  const slotsListProps = useMemo(
+    () => getAllSlotsListProps(epoch, currentSlot, leaderSlots, nextLeaderSlot),
+    [epoch, currentSlot, leaderSlots, nextLeaderSlot],
+  );
 
   if (!slotsListProps) return null;
 
-  return <InnerSlotsList width={width} height={height} {...slotsListProps} />;
-}
+  return <MInnerSlotsList width={width} height={height} {...slotsListProps} />;
+});
 
-function MySlotsList({ width, height }: SlotsListProps) {
+const MMySlotsList = memo(function MySlotsList({
+  width,
+  height,
+}: SlotsListProps) {
   const mySlots = useAtomValue(leaderSlotsAtom);
+  const currentSlot = useAtomValue(currentSlotAtom);
+  const nextLeaderSlot = useAtomValue(nextLeaderSlotAtom);
+  const isCurrentlyLeader = useAtomValue(isCurrentlyLeaderAtom);
+  const nextLeaderSlotIndex = useAtomValue(nextLeaderSlotIndexAtom);
 
-  const slotsListProps = useMemo(() => getMySlotsListProps(mySlots), [mySlots]);
+  const slotsListProps = useMemo(
+    () =>
+      getMySlotsListProps(
+        mySlots,
+        currentSlot,
+        nextLeaderSlot,
+        isCurrentlyLeader,
+        nextLeaderSlotIndex,
+      ),
+    [
+      mySlots,
+      currentSlot,
+      nextLeaderSlot,
+      isCurrentlyLeader,
+      nextLeaderSlotIndex,
+    ],
+  );
 
   if (!slotsListProps) return null;
 
@@ -302,5 +134,5 @@ function MySlotsList({ width, height }: SlotsListProps) {
     );
   }
 
-  return <InnerSlotsList width={width} height={height} {...slotsListProps} />;
-}
+  return <MInnerSlotsList width={width} height={height} {...slotsListProps} />;
+});

--- a/src/features/Navigation/SlotsRenderer.tsx
+++ b/src/features/Navigation/SlotsRenderer.tsx
@@ -34,7 +34,8 @@ import Progress from "../../components/Progress";
 interface SlotsRendererProps {
   leaderSlotForGroup: number;
 }
-export default function SlotsRenderer({
+
+const MSlotsRenderer = memo(function SlotsRenderer({
   leaderSlotForGroup,
 }: SlotsRendererProps) {
   const isScrolling = useAtomValue(isScrollingAtom);
@@ -54,7 +55,8 @@ export default function SlotsRenderer({
       isSelected={getIsGroupSelected(leaderSlotForGroup)}
     />
   );
-}
+});
+export default MSlotsRenderer;
 
 const MPlaceholder = memo(function Placeholder() {
   return <div className={styles.placeholder} />;

--- a/src/features/Navigation/SlotsRenderer.tsx
+++ b/src/features/Navigation/SlotsRenderer.tsx
@@ -101,7 +101,12 @@ function YourNextLeaderSlotGroup({ firstSlot }: { firstSlot: number }) {
   return (
     <Flex
       direction="column"
-      className={clsx(styles.slotGroup, styles.future, styles.you)}
+      className={clsx(
+        styles.slotGroup,
+        styles.future,
+        styles.you,
+        styles.nextYou,
+      )}
     >
       <Flex justify="between" gap="2px">
         <MSlotIconName slot={firstSlot} />

--- a/src/features/Navigation/VirtualSlotsList.tsx
+++ b/src/features/Navigation/VirtualSlotsList.tsx
@@ -1,0 +1,445 @@
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  autoScrollAtom,
+  currentLeaderSlotAtom,
+  slotOverrideAtom,
+} from "../../atoms";
+import type { PropsWithChildren, ReactNode, RefObject } from "react";
+import {
+  memo,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { slotsListTopPaddingIndex } from "../../consts";
+import { throttle } from "lodash";
+import SlotsRenderer, { MSlotsPlaceholder } from "./SlotsRenderer";
+import {
+  useDebouncedCallback,
+  useThrottledCallback,
+  type DebouncedState,
+} from "use-debounce";
+import { findMaxVisibleIdx, findMinVisibleIdx } from "./utils";
+import type { SlotsIndexProps } from "./const";
+
+const noop = () => {};
+
+const OVERSCAN = 20;
+const SCROLL_THROTTLE = 50;
+
+interface VirtualSlotsListProps extends SlotsIndexProps {
+  visibleWidth: number;
+  visibleHeight: number;
+}
+
+export default function VirtualSlotsList({
+  visibleWidth,
+  visibleHeight,
+  getSlotAtIndex,
+  getIndexForSlot,
+  itemsCount,
+  offsetHelpers,
+}: VirtualSlotsListProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const previousTotalHeightRef = useRef<number | undefined>();
+  const [scrollTop, setScrollTop] = useState<number | undefined>();
+
+  const throttledSetScrollTop = useThrottledCallback(
+    (value: number) => {
+      setScrollTop(value);
+    },
+    SCROLL_THROTTLE,
+    { trailing: true },
+  );
+
+  const calcHelpers = useMemo(
+    () =>
+      getCalcHelpers(
+        offsetHelpers,
+        getIndexForSlot,
+        getSlotAtIndex,
+        itemsCount,
+      ),
+    [offsetHelpers, getIndexForSlot, getSlotAtIndex, itemsCount],
+  );
+
+  // prevent visual shifting on height change as current slot progresses
+  useLayoutEffect(() => {
+    const newTotalHeight = calcHelpers?.totalHeight;
+    const previousTotalHeight = previousTotalHeightRef.current;
+    previousTotalHeightRef.current = newTotalHeight;
+
+    if (
+      !containerRef.current ||
+      previousTotalHeight == null ||
+      newTotalHeight == null ||
+      previousTotalHeight === newTotalHeight
+    )
+      return;
+
+    const currentSlotOffset = calcHelpers?.offsetSnapshotCurrentSlotOffset;
+
+    if (
+      currentSlotOffset == null ||
+      containerRef.current.scrollTop <= currentSlotOffset
+    )
+      return;
+
+    const newScrollTop =
+      containerRef.current.scrollTop + (newTotalHeight - previousTotalHeight);
+    containerRef.current.scrollTop = newScrollTop;
+    setScrollTop(newScrollTop);
+  }, [calcHelpers]);
+
+  const minVisibleIdx = useMemo(() => {
+    if (scrollTop == null) return;
+    return calcHelpers?.getMinVisibleIdx(scrollTop);
+  }, [calcHelpers, scrollTop]);
+
+  const maxVisibleIdx = useMemo(() => {
+    if (scrollTop == null) return;
+    return calcHelpers?.getMaxVisibleIdx(scrollTop, visibleHeight);
+  }, [calcHelpers, scrollTop, visibleHeight]);
+
+  const getPaddedSlotTopOffsetRef = useRef<
+    (slot: number) => number | undefined
+  >(() => undefined);
+  const getPaddedSlotAtOffsetRef = useRef<
+    (offset: number) => number | undefined
+  >(() => undefined);
+
+  getPaddedSlotTopOffsetRef.current = (slot: number) => {
+    return calcHelpers?.getPaddedSlotTopOffset(slot);
+  };
+
+  if (!calcHelpers) return;
+
+  const { totalHeight, getTopOffset, getPaddedSlotAtOffset } = calcHelpers;
+
+  getPaddedSlotAtOffsetRef.current = getPaddedSlotAtOffset;
+
+  return (
+    <>
+      {totalHeight >= visibleHeight && (
+        <MSlotsPlaceholder width={visibleWidth} height={visibleHeight} />
+      )}
+      <MScrollContainer
+        width={visibleWidth}
+        height={visibleHeight}
+        containerRef={containerRef}
+        onScrollTopChange={throttledSetScrollTop}
+        getPaddedSlotTopOffsetRef={getPaddedSlotTopOffsetRef}
+        getPaddedSlotAtOffsetRef={getPaddedSlotAtOffsetRef}
+      >
+        <div style={{ height: totalHeight, position: "relative" }}>
+          {minVisibleIdx != null && maxVisibleIdx != null && (
+            <MItems
+              minIdx={minVisibleIdx}
+              maxIdx={maxVisibleIdx}
+              getSlotAtIndex={getSlotAtIndex}
+              getTopOffset={getTopOffset}
+            />
+          )}
+        </div>
+      </MScrollContainer>
+    </>
+  );
+}
+
+function getCalcHelpers(
+  offsetHelpers: SlotsIndexProps["offsetHelpers"],
+  getIndexForSlot: SlotsIndexProps["getIndexForSlot"],
+  getSlotAtIndex: SlotsIndexProps["getSlotAtIndex"],
+  itemsCount: number,
+) {
+  if (!offsetHelpers) return;
+
+  const {
+    totalHeight,
+    offsetSnapshotCurrentSlot,
+    getSlotHeight,
+    getIndexTopOffset,
+  } = offsetHelpers;
+
+  const getPaddedSlotTopOffset = (slot: number) => {
+    const slotIdx = getIndexForSlot(slot);
+    if (slotIdx == null) return;
+
+    const topIdx = Math.max(0, slotIdx - slotsListTopPaddingIndex);
+    return getIndexTopOffset(topIdx);
+  };
+
+  const getPaddedSlotAtOffset = (offset: number) => {
+    const topIdxAtOffset = findMinVisibleIdx(
+      offset,
+      itemsCount,
+      getIndexTopOffset,
+    );
+    if (topIdxAtOffset == null) return;
+
+    const pinnedIdx = Math.min(
+      topIdxAtOffset + slotsListTopPaddingIndex,
+      itemsCount - 1,
+    );
+    return getSlotAtIndex(pinnedIdx);
+  };
+
+  const getTopOffset = (
+    idx: number,
+    prevSlot: number | null,
+    prevIdxOffset: number | null,
+  ) => {
+    if (prevIdxOffset == null || prevSlot == null) {
+      return getIndexTopOffset(idx);
+    }
+
+    const prevSlotHeight = getSlotHeight(prevSlot);
+    if (prevSlotHeight == null) return;
+
+    return prevIdxOffset + prevSlotHeight;
+  };
+
+  const getMinVisibleIdx = (scrollTop: number) => {
+    return findMinVisibleIdx(scrollTop, itemsCount, getIndexTopOffset);
+  };
+
+  const getMaxVisibleIdx = (scrollTop: number, visibleHeight: number) => {
+    return findMaxVisibleIdx(
+      scrollTop,
+      itemsCount,
+      visibleHeight,
+      getIndexTopOffset,
+    );
+  };
+
+  const offsetSnapshotCurrentSlotIdx = getIndexForSlot(
+    offsetSnapshotCurrentSlot,
+  );
+  const offsetSnapshotCurrentSlotOffset =
+    offsetSnapshotCurrentSlotIdx != null
+      ? getIndexTopOffset(offsetSnapshotCurrentSlotIdx)
+      : undefined;
+
+  return {
+    totalHeight,
+    offsetSnapshotCurrentSlotOffset,
+    getIndexTopOffset,
+    getPaddedSlotTopOffset,
+    getPaddedSlotAtOffset,
+    getTopOffset,
+    getMinVisibleIdx,
+    getMaxVisibleIdx,
+  };
+}
+
+interface ScrollContainerProps {
+  width: number;
+  height: number;
+  containerRef: RefObject<HTMLDivElement>;
+  getPaddedSlotTopOffsetRef: RefObject<(slot: number) => number | undefined>;
+  getPaddedSlotAtOffsetRef: RefObject<(offset: number) => number | undefined>;
+  onScrollTopChange: (scrollTop: number) => void;
+}
+const MScrollContainer = memo(function ScrollContainer({
+  width,
+  height,
+  containerRef,
+  getPaddedSlotTopOffsetRef: refreshAndGetPaddedSlotTopOffsetRef,
+  getPaddedSlotAtOffsetRef,
+  onScrollTopChange,
+  children,
+}: PropsWithChildren<ScrollContainerProps>) {
+  const setSlotOverride = useSetAtom(slotOverrideAtom);
+
+  /** prevent auto scroll during manual scroll */
+  const isManualScrolling = useDebouncedCallback(noop, 100);
+
+  // Track scrollTop
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const handler = () => {
+      onScrollTopChange(el.scrollTop);
+    };
+    el.addEventListener("scroll", handler, { passive: true });
+
+    return () => el.removeEventListener("scroll", handler);
+  }, [containerRef, onScrollTopChange]);
+
+  const scrollToSlotPinnedPosition = useCallback(
+    (slot: number) => {
+      const el = containerRef.current;
+      if (!el) return;
+
+      const offset = refreshAndGetPaddedSlotTopOffsetRef.current?.(slot);
+      if (offset == null) return;
+
+      el.scrollTop = offset;
+    },
+    [containerRef, refreshAndGetPaddedSlotTopOffsetRef],
+  );
+
+  // Handle manual sroll
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const updateSlotOverride = throttle(
+      () => {
+        isManualScrolling();
+
+        const slot = getPaddedSlotAtOffsetRef.current?.(container.scrollTop);
+        if (slot == null) return;
+
+        setSlotOverride(slot);
+      },
+      50,
+      { leading: true, trailing: true },
+    );
+
+    container.addEventListener("wheel", updateSlotOverride);
+    container.addEventListener("touchmove", updateSlotOverride);
+
+    return () => {
+      container.removeEventListener("wheel", updateSlotOverride);
+      container.removeEventListener("touchmove", updateSlotOverride);
+      updateSlotOverride.cancel();
+    };
+  }, [
+    containerRef,
+    isManualScrolling,
+    getPaddedSlotAtOffsetRef,
+    setSlotOverride,
+  ]);
+
+  return (
+    <>
+      <MRtAutoScroll scrollToSlotPinnedPosition={scrollToSlotPinnedPosition} />
+      <MScrollToSlotOverride
+        scrollToSlotPinnedPosition={scrollToSlotPinnedPosition}
+        isManualScrolling={isManualScrolling}
+      />
+      <div
+        ref={containerRef}
+        style={{
+          width,
+          height,
+          overflowY: "auto",
+          overflowX: "hidden",
+          scrollbarWidth: "none",
+          position: "relative",
+        }}
+      >
+        {children}
+      </div>
+    </>
+  );
+});
+
+interface RTAutoScrollProps {
+  scrollToSlotPinnedPosition: (slot: number) => void;
+}
+const MRtAutoScroll = memo(function RTAutoScroll({
+  scrollToSlotPinnedPosition,
+}: RTAutoScrollProps) {
+  const currentLeaderSlot = useAtomValue(currentLeaderSlotAtom);
+  const autoScroll = useAtomValue(autoScrollAtom);
+
+  useLayoutEffect(() => {
+    if (!autoScroll || currentLeaderSlot === undefined) return;
+    scrollToSlotPinnedPosition(currentLeaderSlot);
+  }, [autoScroll, currentLeaderSlot, scrollToSlotPinnedPosition]);
+
+  return null;
+});
+
+interface SlotOverrideScrollProps {
+  isManualScrolling: DebouncedState<() => void>;
+  scrollToSlotPinnedPosition: (slot: number) => void;
+}
+const MScrollToSlotOverride = memo(function SlotOverrideScroll({
+  isManualScrolling,
+  scrollToSlotPinnedPosition,
+}: SlotOverrideScrollProps) {
+  const rafIdRef = useRef<number | null>(null);
+  const slotOverride = useAtomValue(slotOverrideAtom);
+
+  useLayoutEffect(() => {
+    if (slotOverride === undefined || isManualScrolling.isPending()) {
+      return;
+    }
+
+    rafIdRef.current = requestAnimationFrame(() => {
+      scrollToSlotPinnedPosition(slotOverride);
+    });
+
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+    };
+  }, [isManualScrolling, scrollToSlotPinnedPosition, slotOverride]);
+
+  return null;
+});
+
+interface ItemsProps {
+  minIdx: number;
+  maxIdx: number;
+  getSlotAtIndex: (idx: number) => number | undefined;
+  getTopOffset: (
+    idx: number,
+    prevSlot: number | null,
+    prevIdxOffset: number | null,
+  ) => number | undefined;
+}
+const MItems = memo(function Items({
+  minIdx,
+  maxIdx,
+  getSlotAtIndex,
+  getTopOffset,
+}: ItemsProps) {
+  const items: ReactNode[] = [];
+
+  let prevIdxOffset = null;
+  let prevSlot = null;
+  for (let i = minIdx - OVERSCAN; i <= maxIdx + OVERSCAN; i++) {
+    const slot = getSlotAtIndex(i);
+    if (slot == null) continue;
+
+    // pass in all data so the list can use the optimal way to get offset
+    const offset = getTopOffset(i, prevSlot, prevIdxOffset);
+    if (offset == null) continue;
+
+    items.push(<MItem key={slot} slot={slot} offset={offset} />);
+    prevIdxOffset = offset;
+    prevSlot = slot;
+  }
+
+  return items;
+});
+
+interface ItemProps {
+  slot: number;
+  offset: number;
+}
+const MItem = memo(function Item({ slot, offset }: ItemProps) {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: 0,
+        transform: `translateY(${offset}px)`,
+        width: "100%",
+        // prevent browser snapping to document's pixel grid
+        willChange: "transform",
+      }}
+    >
+      <SlotsRenderer leaderSlotForGroup={slot} />
+    </div>
+  );
+});

--- a/src/features/Navigation/VirtualSlotsList.tsx
+++ b/src/features/Navigation/VirtualSlotsList.tsx
@@ -5,58 +5,47 @@ import {
   slotOverrideAtom,
 } from "../../atoms";
 import type { PropsWithChildren, RefObject } from "react";
-import {
-  memo,
-  useCallback,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { slotsListTopPaddingIndex } from "../../consts";
+import { memo, useCallback, useLayoutEffect, useRef, useState } from "react";
 import { throttle } from "lodash";
-import SlotsRenderer, { MSlotsPlaceholder } from "./SlotsRenderer";
+import { MSlotsPlaceholder } from "./SlotsRenderer";
 import {
   useDebouncedCallback,
   useThrottledCallback,
   type DebouncedState,
 } from "use-debounce";
 import {
-  findMinVisibleIdx,
-  getItemInfo,
-  getItemBelowInfo,
-  ItemType,
-  type BaseItemInfo,
+  type ItemInfo,
+  filterStillVisibleItems,
+  addVisibleItemsBelow,
+  getInitialVisibleItems,
+  addVisibleItemsAbove,
+  type OffsetHelpers,
 } from "./utils";
-import type { SlotsIndexProps } from "./const";
-import { getSlotGroupLeader } from "../../utils";
+import { MItems } from "./ListItem";
 
 const noop = () => {};
 
 const SCROLL_THROTTLE = 50;
 
-type VisibleItem = BaseItemInfo &
-  (
-    | { topOffset: number; type: ItemType.Future | ItemType.Current }
-    | { topOffset?: number; type: ItemType.Past }
-  );
-
-interface VirtualSlotsListProps extends SlotsIndexProps {
+interface VirtualSlotsListProps {
   visibleWidth: number;
   visibleHeight: number;
+  offsetHelpers: OffsetHelpers;
+  heightDeltas: Map<number, number> | undefined;
 }
 
 export default function VirtualSlotsList({
   visibleWidth,
   visibleHeight,
-  getSlotAtIndex,
-  getIndexForSlot,
-  itemsCount,
   offsetHelpers,
+  heightDeltas,
 }: VirtualSlotsListProps) {
-  const visibleItemsRef = useRef<VisibleItem[]>();
+  const visibleItemsRef = useRef<{
+    currentSlot: number;
+    yourNextLeaderSlot: number | undefined;
+    items: ItemInfo[];
+  }>();
   const containerRef = useRef<HTMLDivElement>(null);
-  const previousTotalHeightRef = useRef<number | undefined>();
   const [scrollTop, setScrollTop] = useState<number | undefined>();
 
   const throttledSetScrollTop = useThrottledCallback(
@@ -67,72 +56,107 @@ export default function VirtualSlotsList({
     { trailing: true },
   );
 
-  const calcHelpers = useMemo(
-    () =>
-      getCalcHelpers(
-        offsetHelpers,
-        getIndexForSlot,
-        getSlotAtIndex,
-        itemsCount,
-      ),
-    [offsetHelpers, getIndexForSlot, getSlotAtIndex, itemsCount],
-  );
-
-  // prevent visual shifting on height change as current slot progresses
-  useLayoutEffect(() => {
-    const newTotalHeight = calcHelpers?.totalHeight;
-    const previousTotalHeight = previousTotalHeightRef.current;
-    previousTotalHeightRef.current = newTotalHeight;
-
-    if (
-      !containerRef.current ||
-      previousTotalHeight == null ||
-      newTotalHeight == null ||
-      previousTotalHeight === newTotalHeight
-    )
-      return;
-
-    const currentSlotOffset = calcHelpers?.offsetSnapshotCurrentSlotOffset;
-
-    if (
-      currentSlotOffset == null ||
-      containerRef.current.scrollTop <= currentSlotOffset
-    )
-      return;
-
-    const newScrollTop =
-      containerRef.current.scrollTop + (newTotalHeight - previousTotalHeight);
-    containerRef.current.scrollTop = newScrollTop;
-    setScrollTop(newScrollTop);
-  }, [calcHelpers]);
-
-  if (scrollTop != null && calcHelpers != null && offsetHelpers != null) {
-    const visibleItems: VisibleItem[] = [];
+  if (scrollTop != null && offsetHelpers != null && containerRef.current) {
     const endVisibleOffset = scrollTop + visibleHeight;
+    const setVisibleItems = (
+      value: NonNullable<typeof visibleItemsRef.current>,
+    ) => {
+      visibleItemsRef.current = value;
+    };
 
-    const firstIdx = calcHelpers.getMinVisibleIdx(scrollTop);
-    const currentLeaderSlot = getSlotGroupLeader(
-      offsetHelpers.offsetSnapshotCurrentSlot,
-    );
-    let currentItem = getItemInfo(
-      firstIdx,
-      getSlotAtIndex,
-      calcHelpers.getIndexTopOffset,
-      offsetHelpers.getSlotHeight,
-      offsetHelpers.totalHeight,
-      currentLeaderSlot,
-    );
+    if (visibleItemsRef.current && heightDeltas && containerRef.current) {
+      const topItem = visibleItemsRef.current.items[0];
+      const prevTopOffset = topItem.topOffset;
+      // if visible items are still in the visible range, use those
+      if (heightDeltas.size) {
+        const heightDeltaEntries = [...heightDeltas.entries()];
+        for (const item of visibleItemsRef.current.items) {
+          offsetHelpers.updateItem(
+            item,
+            heightDeltaEntries,
+            offsetHelpers.offsetSnapshotCurrentSlot,
+          );
+        }
+      }
 
-    while (currentItem && currentItem.topOffset < endVisibleOffset) {
-      visibleItems.push(currentItem);
-      currentItem = getItemBelowInfo(
-        currentItem,
-        getSlotAtIndex,
-        offsetHelpers.getSlotHeight,
-        currentLeaderSlot,
+      const topOffsetDelta = topItem.topOffset - prevTopOffset;
+      const elScrollTop = containerRef.current.scrollTop;
+      const effectiveScrollTop = elScrollTop + topOffsetDelta;
+      const effectiveEndVisibleOffset = effectiveScrollTop + visibleHeight;
+
+      // scroll to prevent visual shift if only the area above visible window grew
+      if (topOffsetDelta) {
+        containerRef.current.scrollTop = effectiveScrollTop;
+        setScrollTop(effectiveScrollTop);
+      }
+
+      const visibleItems = filterStillVisibleItems(
+        visibleItemsRef.current.items,
+        effectiveScrollTop,
+        visibleHeight,
       );
+
+      if (visibleItems.length) {
+        const prevItem = offsetHelpers.getItemAbove(visibleItems[0]);
+        addVisibleItemsAbove(
+          prevItem,
+          visibleItems,
+          effectiveScrollTop,
+          offsetHelpers.getItemAbove,
+        );
+
+        const nextItem = offsetHelpers.getItemBelow(
+          visibleItems[visibleItems.length - 1],
+        );
+        addVisibleItemsBelow(
+          nextItem,
+          visibleItems,
+          effectiveEndVisibleOffset,
+          offsetHelpers.getItemBelow,
+        );
+
+        setVisibleItems({
+          currentSlot: offsetHelpers.offsetSnapshotCurrentSlot,
+          yourNextLeaderSlot: offsetHelpers.yourNextLeaderSlot,
+          items: visibleItems,
+        });
+      } else {
+        const visibleItems = getInitialVisibleItems(
+          effectiveScrollTop,
+          endVisibleOffset,
+          offsetHelpers.getItemBelow,
+          offsetHelpers.getFirstVisibleItem,
+        );
+        if (!visibleItems.length) {
+          visibleItemsRef.current = undefined;
+        } else {
+          setVisibleItems({
+            currentSlot: offsetHelpers.offsetSnapshotCurrentSlot,
+            yourNextLeaderSlot: offsetHelpers.yourNextLeaderSlot,
+            // topOffsetRange: visibleItems.length ? visibleItems[0].topOffset, visibleItems[] : undefined
+            items: visibleItems,
+          });
+        }
+      }
+    } else {
+      const visibleItems = getInitialVisibleItems(
+        scrollTop,
+        endVisibleOffset,
+        offsetHelpers.getItemBelow,
+        offsetHelpers.getFirstVisibleItem,
+      );
+      if (!visibleItems.length) {
+        visibleItemsRef.current = undefined;
+      } else {
+        setVisibleItems({
+          currentSlot: offsetHelpers.offsetSnapshotCurrentSlot,
+          yourNextLeaderSlot: offsetHelpers.yourNextLeaderSlot,
+          items: visibleItems,
+        });
+      }
     }
-    visibleItemsRef.current = visibleItems;
+
+    heightDeltas?.clear();
   }
 
   const getPaddedSlotTopOffsetRef = useRef<
@@ -143,12 +167,12 @@ export default function VirtualSlotsList({
   >(() => undefined);
 
   getPaddedSlotTopOffsetRef.current = (slot: number) => {
-    return calcHelpers?.getPaddedSlotTopOffset(slot);
+    return offsetHelpers?.getPaddedSlotTopOffset(slot);
   };
 
-  if (!calcHelpers) return;
+  if (!offsetHelpers) return;
 
-  const { totalHeight, getPaddedSlotAtOffset } = calcHelpers;
+  const { totalHeight, getPaddedSlotAtOffset } = offsetHelpers;
 
   getPaddedSlotAtOffsetRef.current = getPaddedSlotAtOffset;
 
@@ -167,88 +191,12 @@ export default function VirtualSlotsList({
       >
         <div style={{ height: totalHeight, position: "relative" }}>
           {visibleItemsRef.current != null && (
-            <MItems visibleItems={visibleItemsRef.current} />
+            <MItems visibleItems={visibleItemsRef.current.items} />
           )}
         </div>
       </MScrollContainer>
     </>
   );
-}
-
-function getCalcHelpers(
-  offsetHelpers: SlotsIndexProps["offsetHelpers"],
-  getIndexForSlot: SlotsIndexProps["getIndexForSlot"],
-  getSlotAtIndex: SlotsIndexProps["getSlotAtIndex"],
-  itemsCount: number,
-) {
-  if (!offsetHelpers) return;
-
-  const {
-    totalHeight,
-    offsetSnapshotCurrentSlot,
-    getSlotHeight,
-    getIndexTopOffset,
-  } = offsetHelpers;
-
-  const getPaddedSlotTopOffset = (slot: number) => {
-    const slotIdx = getIndexForSlot(slot);
-    if (slotIdx == null) return;
-
-    const topIdx = Math.max(0, slotIdx - slotsListTopPaddingIndex);
-    return getIndexTopOffset(topIdx);
-  };
-
-  const getPaddedSlotAtOffset = (offset: number) => {
-    const topIdxAtOffset = findMinVisibleIdx(
-      offset,
-      itemsCount,
-      getIndexTopOffset,
-    );
-    if (topIdxAtOffset == null) return;
-
-    const pinnedIdx = Math.min(
-      topIdxAtOffset + slotsListTopPaddingIndex,
-      itemsCount - 1,
-    );
-    return getSlotAtIndex(pinnedIdx);
-  };
-
-  const getTopOffset = (
-    idx: number,
-    prevSlot: number | null,
-    prevIdxOffset: number | null,
-  ) => {
-    if (prevIdxOffset == null || prevSlot == null) {
-      return getIndexTopOffset(idx);
-    }
-
-    const prevSlotHeight = getSlotHeight(prevSlot);
-    if (prevSlotHeight == null) return;
-
-    return prevIdxOffset + prevSlotHeight;
-  };
-
-  const getMinVisibleIdx = (scrollTop: number) => {
-    return findMinVisibleIdx(scrollTop, itemsCount, getIndexTopOffset);
-  };
-
-  const offsetSnapshotCurrentSlotIdx = getIndexForSlot(
-    offsetSnapshotCurrentSlot,
-  );
-  const offsetSnapshotCurrentSlotOffset =
-    offsetSnapshotCurrentSlotIdx != null
-      ? getIndexTopOffset(offsetSnapshotCurrentSlotIdx)
-      : undefined;
-
-  return {
-    totalHeight,
-    offsetSnapshotCurrentSlotOffset,
-    getIndexTopOffset,
-    getPaddedSlotTopOffset,
-    getPaddedSlotAtOffset,
-    getTopOffset,
-    getMinVisibleIdx,
-  };
 }
 
 interface ScrollContainerProps {
@@ -402,44 +350,4 @@ const MScrollToSlotOverride = memo(function SlotOverrideScroll({
   }, [isManualScrolling, scrollToSlotPinnedPosition, slotOverride]);
 
   return null;
-});
-
-interface ItemsProps {
-  visibleItems: VisibleItem[];
-}
-const MItems = memo(function Items({ visibleItems }: ItemsProps) {
-  console.log("visibleItems", visibleItems);
-  return visibleItems.map(({ slot, topOffset, bottomOffset, type }) => (
-    <MItem
-      key={slot}
-      slot={slot}
-      offset={type === ItemType.Past ? bottomOffset : topOffset}
-      isBottomOffset={type === ItemType.Past}
-    />
-  ));
-});
-
-interface ItemProps {
-  slot: number;
-  offset: number;
-  isBottomOffset: boolean;
-}
-const MItem = memo(function Item({ slot, offset, isBottomOffset }: ItemProps) {
-  const anchorStyle = isBottomOffset
-    ? { bottom: 0, transform: `translateY(-${offset}px)` }
-    : { top: 0, transform: `translateY(${offset}px)` };
-
-  return (
-    <div
-      style={{
-        position: "absolute",
-        width: "100%",
-        ...anchorStyle,
-        // prevent browser snapping to document's pixel grid
-        willChange: "transform",
-      }}
-    >
-      <SlotsRenderer leaderSlotForGroup={slot} />
-    </div>
-  );
 });

--- a/src/features/Navigation/VirtualSlotsList.tsx
+++ b/src/features/Navigation/VirtualSlotsList.tsx
@@ -4,7 +4,7 @@ import {
   currentLeaderSlotAtom,
   slotOverrideAtom,
 } from "../../atoms";
-import type { PropsWithChildren, ReactNode, RefObject } from "react";
+import type { PropsWithChildren, RefObject } from "react";
 import {
   memo,
   useCallback,
@@ -21,13 +21,25 @@ import {
   useThrottledCallback,
   type DebouncedState,
 } from "use-debounce";
-import { findMaxVisibleIdx, findMinVisibleIdx } from "./utils";
+import {
+  findMinVisibleIdx,
+  getItemInfo,
+  getItemBelowInfo,
+  ItemType,
+  type BaseItemInfo,
+} from "./utils";
 import type { SlotsIndexProps } from "./const";
+import { getSlotGroupLeader } from "../../utils";
 
 const noop = () => {};
 
-const OVERSCAN = 20;
 const SCROLL_THROTTLE = 50;
+
+type VisibleItem = BaseItemInfo &
+  (
+    | { topOffset: number; type: ItemType.Future | ItemType.Current }
+    | { topOffset?: number; type: ItemType.Past }
+  );
 
 interface VirtualSlotsListProps extends SlotsIndexProps {
   visibleWidth: number;
@@ -42,6 +54,7 @@ export default function VirtualSlotsList({
   itemsCount,
   offsetHelpers,
 }: VirtualSlotsListProps) {
+  const visibleItemsRef = useRef<VisibleItem[]>();
   const containerRef = useRef<HTMLDivElement>(null);
   const previousTotalHeightRef = useRef<number | undefined>();
   const [scrollTop, setScrollTop] = useState<number | undefined>();
@@ -93,15 +106,34 @@ export default function VirtualSlotsList({
     setScrollTop(newScrollTop);
   }, [calcHelpers]);
 
-  const minVisibleIdx = useMemo(() => {
-    if (scrollTop == null) return;
-    return calcHelpers?.getMinVisibleIdx(scrollTop);
-  }, [calcHelpers, scrollTop]);
+  if (scrollTop != null && calcHelpers != null && offsetHelpers != null) {
+    const visibleItems: VisibleItem[] = [];
+    const endVisibleOffset = scrollTop + visibleHeight;
 
-  const maxVisibleIdx = useMemo(() => {
-    if (scrollTop == null) return;
-    return calcHelpers?.getMaxVisibleIdx(scrollTop, visibleHeight);
-  }, [calcHelpers, scrollTop, visibleHeight]);
+    const firstIdx = calcHelpers.getMinVisibleIdx(scrollTop);
+    const currentLeaderSlot = getSlotGroupLeader(
+      offsetHelpers.offsetSnapshotCurrentSlot,
+    );
+    let currentItem = getItemInfo(
+      firstIdx,
+      getSlotAtIndex,
+      calcHelpers.getIndexTopOffset,
+      offsetHelpers.getSlotHeight,
+      offsetHelpers.totalHeight,
+      currentLeaderSlot,
+    );
+
+    while (currentItem && currentItem.topOffset < endVisibleOffset) {
+      visibleItems.push(currentItem);
+      currentItem = getItemBelowInfo(
+        currentItem,
+        getSlotAtIndex,
+        offsetHelpers.getSlotHeight,
+        currentLeaderSlot,
+      );
+    }
+    visibleItemsRef.current = visibleItems;
+  }
 
   const getPaddedSlotTopOffsetRef = useRef<
     (slot: number) => number | undefined
@@ -116,7 +148,7 @@ export default function VirtualSlotsList({
 
   if (!calcHelpers) return;
 
-  const { totalHeight, getTopOffset, getPaddedSlotAtOffset } = calcHelpers;
+  const { totalHeight, getPaddedSlotAtOffset } = calcHelpers;
 
   getPaddedSlotAtOffsetRef.current = getPaddedSlotAtOffset;
 
@@ -134,13 +166,8 @@ export default function VirtualSlotsList({
         getPaddedSlotAtOffsetRef={getPaddedSlotAtOffsetRef}
       >
         <div style={{ height: totalHeight, position: "relative" }}>
-          {minVisibleIdx != null && maxVisibleIdx != null && (
-            <MItems
-              minIdx={minVisibleIdx}
-              maxIdx={maxVisibleIdx}
-              getSlotAtIndex={getSlotAtIndex}
-              getTopOffset={getTopOffset}
-            />
+          {visibleItemsRef.current != null && (
+            <MItems visibleItems={visibleItemsRef.current} />
           )}
         </div>
       </MScrollContainer>
@@ -205,15 +232,6 @@ function getCalcHelpers(
     return findMinVisibleIdx(scrollTop, itemsCount, getIndexTopOffset);
   };
 
-  const getMaxVisibleIdx = (scrollTop: number, visibleHeight: number) => {
-    return findMaxVisibleIdx(
-      scrollTop,
-      itemsCount,
-      visibleHeight,
-      getIndexTopOffset,
-    );
-  };
-
   const offsetSnapshotCurrentSlotIdx = getIndexForSlot(
     offsetSnapshotCurrentSlot,
   );
@@ -230,7 +248,6 @@ function getCalcHelpers(
     getPaddedSlotAtOffset,
     getTopOffset,
     getMinVisibleIdx,
-    getMaxVisibleIdx,
   };
 }
 
@@ -388,53 +405,36 @@ const MScrollToSlotOverride = memo(function SlotOverrideScroll({
 });
 
 interface ItemsProps {
-  minIdx: number;
-  maxIdx: number;
-  getSlotAtIndex: (idx: number) => number | undefined;
-  getTopOffset: (
-    idx: number,
-    prevSlot: number | null,
-    prevIdxOffset: number | null,
-  ) => number | undefined;
+  visibleItems: VisibleItem[];
 }
-const MItems = memo(function Items({
-  minIdx,
-  maxIdx,
-  getSlotAtIndex,
-  getTopOffset,
-}: ItemsProps) {
-  const items: ReactNode[] = [];
-
-  let prevIdxOffset = null;
-  let prevSlot = null;
-  for (let i = minIdx - OVERSCAN; i <= maxIdx + OVERSCAN; i++) {
-    const slot = getSlotAtIndex(i);
-    if (slot == null) continue;
-
-    // pass in all data so the list can use the optimal way to get offset
-    const offset = getTopOffset(i, prevSlot, prevIdxOffset);
-    if (offset == null) continue;
-
-    items.push(<MItem key={slot} slot={slot} offset={offset} />);
-    prevIdxOffset = offset;
-    prevSlot = slot;
-  }
-
-  return items;
+const MItems = memo(function Items({ visibleItems }: ItemsProps) {
+  console.log("visibleItems", visibleItems);
+  return visibleItems.map(({ slot, topOffset, bottomOffset, type }) => (
+    <MItem
+      key={slot}
+      slot={slot}
+      offset={type === ItemType.Past ? bottomOffset : topOffset}
+      isBottomOffset={type === ItemType.Past}
+    />
+  ));
 });
 
 interface ItemProps {
   slot: number;
   offset: number;
+  isBottomOffset: boolean;
 }
-const MItem = memo(function Item({ slot, offset }: ItemProps) {
+const MItem = memo(function Item({ slot, offset, isBottomOffset }: ItemProps) {
+  const anchorStyle = isBottomOffset
+    ? { bottom: 0, transform: `translateY(-${offset}px)` }
+    : { top: 0, transform: `translateY(${offset}px)` };
+
   return (
     <div
       style={{
         position: "absolute",
-        top: 0,
-        transform: `translateY(${offset}px)`,
         width: "100%",
+        ...anchorStyle,
         // prevent browser snapping to document's pixel grid
         willChange: "transform",
       }}

--- a/src/features/Navigation/__tests__/utils.test.ts
+++ b/src/features/Navigation/__tests__/utils.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { getAllSlotsListProps } from "../allSlotsUtils";
 import { getMySlotsListProps } from "../mySlotsUtils";
@@ -20,6 +21,7 @@ describe("navigation utils", () => {
         undefined,
         undefined,
         undefined,
+        { past: 0, current: 0, future: 0 },
       );
 
       expect(result).not.toBeUndefined();
@@ -46,6 +48,7 @@ describe("navigation utils", () => {
         undefined,
         undefined,
         undefined,
+        { past: 0, current: 0, future: 0 },
       );
       expect(result).toBeUndefined();
     });
@@ -57,8 +60,10 @@ describe("navigation utils", () => {
         [4, 12, 20, 40, 44, 48],
         undefined,
         undefined,
+        undefined,
         false,
         undefined,
+        { past: 0, current: 0, future: 0 },
       );
 
       expect(result).not.toBeUndefined();

--- a/src/features/Navigation/__tests__/utils.test.ts
+++ b/src/features/Navigation/__tests__/utils.test.ts
@@ -1,20 +1,26 @@
 import { describe, it, expect } from "vitest";
-import { getAllSlotsListProps, getMySlotsListProps } from "../utils";
+import { getAllSlotsListProps } from "../allSlotsUtils";
+import { getMySlotsListProps } from "../mySlotsUtils";
 
 describe("navigation utils", () => {
   describe("getAllSlotsListProps", () => {
     it("gets correct values", () => {
-      const result = getAllSlotsListProps({
-        epoch: 1,
-        start_time_nanos: null,
-        end_time_nanos: null,
-        start_slot: 4,
-        end_slot: 15,
-        excluded_stake_lamports: 0n,
-        staked_pubkeys: [],
-        staked_lamports: [],
-        leader_slots: [],
-      });
+      const result = getAllSlotsListProps(
+        {
+          epoch: 1,
+          start_time_nanos: null,
+          end_time_nanos: null,
+          start_slot: 4,
+          end_slot: 15,
+          excluded_stake_lamports: 0n,
+          staked_pubkeys: [],
+          staked_lamports: [],
+          leader_slots: [],
+        },
+        undefined,
+        undefined,
+        undefined,
+      );
 
       expect(result).not.toBeUndefined();
       const { itemsCount, getSlotAtIndex, getIndexForSlot } = result!;
@@ -35,14 +41,14 @@ describe("navigation utils", () => {
     });
 
     it("handles undefined epoch", () => {
-      const result = getAllSlotsListProps(undefined);
+      const result = getAllSlotsListProps(undefined, undefined, undefined, undefined);
       expect(result).toBeUndefined();
     });
   });
 
   describe("getMySlotsListProps", () => {
     it("gets correct values and gives the index for the closest smaller my slot leader", () => {
-      const result = getMySlotsListProps([4, 12, 20, 40, 44, 48]);
+      const result = getMySlotsListProps([4, 12, 20, 40, 44, 48], undefined, undefined, false, undefined);
 
       expect(result).not.toBeUndefined();
       const { itemsCount, getSlotAtIndex, getIndexForSlot } = result!;

--- a/src/features/Navigation/__tests__/utils.test.ts
+++ b/src/features/Navigation/__tests__/utils.test.ts
@@ -41,14 +41,25 @@ describe("navigation utils", () => {
     });
 
     it("handles undefined epoch", () => {
-      const result = getAllSlotsListProps(undefined, undefined, undefined, undefined);
+      const result = getAllSlotsListProps(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      );
       expect(result).toBeUndefined();
     });
   });
 
   describe("getMySlotsListProps", () => {
     it("gets correct values and gives the index for the closest smaller my slot leader", () => {
-      const result = getMySlotsListProps([4, 12, 20, 40, 44, 48], undefined, undefined, false, undefined);
+      const result = getMySlotsListProps(
+        [4, 12, 20, 40, 44, 48],
+        undefined,
+        undefined,
+        false,
+        undefined,
+      );
 
       expect(result).not.toBeUndefined();
       const { itemsCount, getSlotAtIndex, getIndexForSlot } = result!;

--- a/src/features/Navigation/allSlotsUtils.ts
+++ b/src/features/Navigation/allSlotsUtils.ts
@@ -17,7 +17,7 @@ import { getHeightSum, type Counts } from "./utils";
 export function getAllSlotsOffsetHelpers(
   epoch: Epoch,
   currentSlot: number,
-  leaderSlots: number[],
+  ascendingLeaderSlotsSet: Set<number>,
   nextLeaderSlot: number | undefined,
   getSlotAtIndex: (index: number) => number | undefined,
 ): OffsetHelpers {
@@ -30,7 +30,7 @@ export function getAllSlotsOffsetHelpers(
     lastLeaderSlot,
     currentLeaderSlot,
     nextLeaderSlot,
-    leaderSlots,
+    ascendingLeaderSlotsSet,
   );
   const totalHeight = getHeightSum(counts);
 
@@ -44,7 +44,7 @@ export function getAllSlotsOffsetHelpers(
       lastLeaderSlot,
       currentLeaderSlot,
       nextLeaderSlot,
-      leaderSlots,
+      ascendingLeaderSlotsSet,
     );
     return getHeightSum(counts);
   };
@@ -58,7 +58,7 @@ export function getAllSlotsOffsetHelpers(
 
   const getSlotHeight = (anySlot: number) => {
     const slot = getSlotGroupLeader(anySlot);
-    const isYours = leaderSlots.includes(slot);
+    const isYours = ascendingLeaderSlotsSet.has(slot);
     if (slot < currentLeaderSlot)
       return isYours ? YOUR_PAST_HEIGHT : OTHER_PAST_HEIGHT;
     if (slot === currentLeaderSlot)
@@ -92,7 +92,7 @@ export function getAllSlotsOffsetHelpers(
 export function getAllSlotsListProps(
   epoch: Epoch | undefined,
   currentSlot: number | undefined,
-  leaderSlots: number[] | undefined,
+  ascendingLeaderSlotsSet: Set<number> | undefined,
   nextLeaderSlot: number | undefined,
 ): SlotsIndexProps | undefined {
   if (!epoch) return;
@@ -111,11 +111,11 @@ export function getAllSlotsListProps(
   };
 
   const offsetHelpers =
-    currentSlot != null && leaderSlots != null
+    currentSlot != null && ascendingLeaderSlotsSet != null
       ? getAllSlotsOffsetHelpers(
           epoch,
           currentSlot,
-          leaderSlots,
+          ascendingLeaderSlotsSet,
           nextLeaderSlot,
           getSlotAtIndex,
         )
@@ -134,13 +134,13 @@ function getTypeCounts(
   maxLeaderSlot: number,
   currentLeaderSlot: number,
   yourNextLeaderSlot: number | undefined,
-  leaderSlots: number[],
+  ascendingLeaderSlotsSet: Set<number>,
 ): Counts {
   let yourPastCount = 0;
   let yourCurrentCount = 0;
   let yourNextFutureCount = 0;
   let yourNonNextFutureCount = 0;
-  for (const slot of leaderSlots) {
+  for (const slot of ascendingLeaderSlotsSet) {
     if (slot < minLeaderSlot) continue;
     if (slot > maxLeaderSlot) break;
 

--- a/src/features/Navigation/allSlotsUtils.ts
+++ b/src/features/Navigation/allSlotsUtils.ts
@@ -2,37 +2,30 @@ import type { Epoch } from "../../api/types";
 import { slotsPerLeader } from "../../consts";
 import { getSlotGroupLeader } from "../../utils";
 import {
-  OTHER_CURRENT_HEIGHT,
-  OTHER_FUTURE_HEIGHT,
-  OTHER_PAST_HEIGHT,
-  YOUR_CURRENT_HEIGHT,
-  YOUR_NEXT_LEADER_HEIGHT,
-  YOUR_NON_NEXT_FUTURE_HEIGHT,
-  YOUR_PAST_HEIGHT,
-  type OffsetHelpers,
+  ItemHeightType,
+  itemHeightByType,
+  type ListHelpers,
   type SlotsIndexProps,
 } from "./const";
 import { getHeightSum, type Counts } from "./utils";
 
-export function getAllSlotsOffsetHelpers(
+export function getAllSlotsListHelpers(
   epoch: Epoch,
-  currentSlot: number,
+  currentLeaderSlot: number,
   ascendingLeaderSlotsSet: Set<number>,
-  nextLeaderSlot: number | undefined,
+  yourNextLeaderSlot: number | undefined,
+  yourLeaderSlotCounts: { past: number; current: number; future: number },
   getSlotAtIndex: (index: number) => number | undefined,
-): OffsetHelpers {
+): ListHelpers {
   const firstLeaderSlot = getSlotGroupLeader(epoch.start_slot);
   const lastLeaderSlot = getSlotGroupLeader(epoch.end_slot);
-  const currentLeaderSlot = getSlotGroupLeader(currentSlot);
 
-  const counts = getTypeCounts(
+  const totalHeight = getTotalHeight(
+    yourLeaderSlotCounts,
     firstLeaderSlot,
     lastLeaderSlot,
     currentLeaderSlot,
-    nextLeaderSlot,
-    ascendingLeaderSlotsSet,
   );
-  const totalHeight = getHeightSum(counts);
 
   const getSlotTopOffset = (slot: number) => {
     const leaderSlot = getSlotGroupLeader(slot);
@@ -43,7 +36,7 @@ export function getAllSlotsOffsetHelpers(
       slotAbove,
       lastLeaderSlot,
       currentLeaderSlot,
-      nextLeaderSlot,
+      yourNextLeaderSlot,
       ascendingLeaderSlotsSet,
     );
     return getHeightSum(counts);
@@ -56,32 +49,22 @@ export function getAllSlotsOffsetHelpers(
     return getSlotTopOffset(slot);
   };
 
-  const getSlotHeight = (anySlot: number) => {
-    const slot = getSlotGroupLeader(anySlot);
-    const isYours = ascendingLeaderSlotsSet.has(slot);
-    if (slot < currentLeaderSlot)
-      return isYours ? YOUR_PAST_HEIGHT : OTHER_PAST_HEIGHT;
-    if (slot === currentLeaderSlot)
-      return isYours ? YOUR_CURRENT_HEIGHT : OTHER_CURRENT_HEIGHT;
-    if (!isYours) return OTHER_FUTURE_HEIGHT;
-    return slot === nextLeaderSlot
-      ? YOUR_NEXT_LEADER_HEIGHT
-      : YOUR_NON_NEXT_FUTURE_HEIGHT;
-  };
-
-  const getIndexHeight = (index: number) => {
-    const slot = getSlotAtIndex(index);
-    if (slot == null) return;
-    return getSlotHeight(slot);
-  };
+  const getSlotHeight = (slotGroupLeader: number): number =>
+    itemHeightByType[
+      getSlotHeightType(
+        slotGroupLeader,
+        ascendingLeaderSlotsSet,
+        currentLeaderSlot,
+        yourNextLeaderSlot,
+      )
+    ];
 
   return {
     totalHeight,
-    offsetSnapshotCurrentSlot: currentSlot,
-    getSlotTopOffset,
+    offsetSnapshotCurrentSlot: currentLeaderSlot,
+    yourNextLeaderSlot: yourNextLeaderSlot,
     getSlotHeight,
     getIndexTopOffset,
-    getIndexHeight,
   };
 }
 
@@ -91,11 +74,14 @@ export function getAllSlotsOffsetHelpers(
  */
 export function getAllSlotsListProps(
   epoch: Epoch | undefined,
-  currentSlot: number | undefined,
+  currentLeaderSlot: number | undefined,
   ascendingLeaderSlotsSet: Set<number> | undefined,
   nextLeaderSlot: number | undefined,
+  yourLeaderSlotCounts:
+    | { past: number; current: number; future: number }
+    | undefined,
 ): SlotsIndexProps | undefined {
-  if (!epoch) return;
+  if (!epoch || !yourLeaderSlotCounts) return;
 
   const numSlotsInEpoch = epoch.end_slot - epoch.start_slot + 1;
   const itemsCount = Math.ceil(numSlotsInEpoch / slotsPerLeader);
@@ -110,13 +96,14 @@ export function getAllSlotsListProps(
     return getSlotGroupLeader(epoch.end_slot - index * slotsPerLeader);
   };
 
-  const offsetHelpers =
-    currentSlot != null && ascendingLeaderSlotsSet != null
-      ? getAllSlotsOffsetHelpers(
+  const listHelpers =
+    currentLeaderSlot != null && ascendingLeaderSlotsSet != null
+      ? getAllSlotsListHelpers(
           epoch,
-          currentSlot,
+          currentLeaderSlot,
           ascendingLeaderSlotsSet,
           nextLeaderSlot,
+          yourLeaderSlotCounts,
           getSlotAtIndex,
         )
       : undefined;
@@ -125,8 +112,75 @@ export function getAllSlotsListProps(
     getSlotAtIndex,
     getIndexForSlot,
     itemsCount,
-    offsetHelpers,
+    listHelpers,
   };
+}
+
+function getTypeCountsWithYourSlots(
+  yourPastCount: number,
+  yourCurrentCount: number,
+  yourNextFutureCount: number,
+  yourNonNextFutureCount: number,
+  minLeaderSlot: number,
+  maxLeaderSlot: number,
+  currentLeaderSlot: number,
+) {
+  const yourFutureCount = yourNextFutureCount + yourNonNextFutureCount;
+  const totalCount = (maxLeaderSlot - minLeaderSlot) / slotsPerLeader + 1;
+  const { totalPastCount, totalCurrentCount, totalFutureCount } =
+    currentLeaderSlot < minLeaderSlot
+      ? {
+          totalPastCount: 0,
+          totalCurrentCount: 0,
+          totalFutureCount: totalCount,
+        }
+      : currentLeaderSlot > maxLeaderSlot
+        ? {
+            totalPastCount: totalCount,
+            totalCurrentCount: 0,
+            totalFutureCount: 0,
+          }
+        : {
+            totalPastCount:
+              (currentLeaderSlot - minLeaderSlot) / slotsPerLeader,
+            totalCurrentCount: 1,
+            totalFutureCount:
+              (maxLeaderSlot - currentLeaderSlot) / slotsPerLeader,
+          };
+
+  return {
+    [ItemHeightType.OtherPast]: totalPastCount - yourPastCount,
+    [ItemHeightType.OtherCurrent]: totalCurrentCount - yourCurrentCount,
+    [ItemHeightType.OtherFuture]: totalFutureCount - yourFutureCount,
+    [ItemHeightType.YourPast]: yourPastCount,
+    [ItemHeightType.YourCurrent]: yourCurrentCount,
+    [ItemHeightType.YourNextLeader]: yourNextFutureCount,
+    [ItemHeightType.YourNonNextFuture]: yourNonNextFutureCount,
+  };
+}
+
+function getTotalHeight(
+  yourLeaderSlotCounts: { past: number; current: number; future: number },
+  minLeaderSlot: number,
+  maxLeaderSlot: number,
+  currentLeaderSlot: number,
+) {
+  const yourPastCount = yourLeaderSlotCounts.past;
+  const yourCurrentCount = yourLeaderSlotCounts.current;
+  const yourNextFutureCount = yourLeaderSlotCounts.future > 0 ? 1 : 0;
+  const yourNonNextFutureCount =
+    yourLeaderSlotCounts.future - yourNextFutureCount;
+
+  const counts = getTypeCountsWithYourSlots(
+    yourPastCount,
+    yourCurrentCount,
+    yourNextFutureCount,
+    yourNonNextFutureCount,
+    minLeaderSlot,
+    maxLeaderSlot,
+    currentLeaderSlot,
+  );
+  return getHeightSum(counts);
 }
 
 function getTypeCounts(
@@ -155,37 +209,35 @@ function getTypeCounts(
     }
   }
 
-  const yourFutureCount = yourNextFutureCount + yourNonNextFutureCount;
-
-  const totalCount = (maxLeaderSlot - minLeaderSlot) / slotsPerLeader + 1;
-  const { totalPastCount, totalCurrentCount, totalFutureCount } =
-    currentLeaderSlot < minLeaderSlot
-      ? {
-          totalPastCount: 0,
-          totalCurrentCount: 0,
-          totalFutureCount: totalCount,
-        }
-      : currentLeaderSlot > maxLeaderSlot
-        ? {
-            totalPastCount: totalCount,
-            totalCurrentCount: 0,
-            totalFutureCount: 0,
-          }
-        : {
-            totalPastCount:
-              (currentLeaderSlot - minLeaderSlot) / slotsPerLeader,
-            totalCurrentCount: 1,
-            totalFutureCount:
-              (maxLeaderSlot - currentLeaderSlot) / slotsPerLeader,
-          };
-
-  return {
-    otherPastCount: totalPastCount - yourPastCount,
-    otherCurrentCount: totalCurrentCount - yourCurrentCount,
-    otherFutureCount: totalFutureCount - yourFutureCount,
+  return getTypeCountsWithYourSlots(
     yourPastCount,
     yourCurrentCount,
     yourNextFutureCount,
     yourNonNextFutureCount,
-  };
+    minLeaderSlot,
+    maxLeaderSlot,
+    currentLeaderSlot,
+  );
+}
+
+function getSlotHeightType(
+  slotGroupleader: number,
+  yourLeaderSlotsSet: Set<number>,
+  currentLeaderSlot: number,
+  yourNextLeaderSlot: number | undefined,
+): ItemHeightType {
+  const isYours = yourLeaderSlotsSet.has(slotGroupleader);
+
+  if (slotGroupleader < currentLeaderSlot) {
+    return isYours ? ItemHeightType.YourPast : ItemHeightType.OtherPast;
+  }
+  if (slotGroupleader === currentLeaderSlot) {
+    return isYours ? ItemHeightType.YourCurrent : ItemHeightType.OtherCurrent;
+  }
+  if (slotGroupleader === yourNextLeaderSlot) {
+    return ItemHeightType.YourNextLeader;
+  }
+  return isYours
+    ? ItemHeightType.YourNonNextFuture
+    : ItemHeightType.OtherFuture;
 }

--- a/src/features/Navigation/allSlotsUtils.ts
+++ b/src/features/Navigation/allSlotsUtils.ts
@@ -1,0 +1,191 @@
+import type { Epoch } from "../../api/types";
+import { slotsPerLeader } from "../../consts";
+import { getSlotGroupLeader } from "../../utils";
+import {
+  OTHER_CURRENT_HEIGHT,
+  OTHER_FUTURE_HEIGHT,
+  OTHER_PAST_HEIGHT,
+  YOUR_CURRENT_HEIGHT,
+  YOUR_NEXT_LEADER_HEIGHT,
+  YOUR_NON_NEXT_FUTURE_HEIGHT,
+  YOUR_PAST_HEIGHT,
+  type OffsetHelpers,
+  type SlotsIndexProps,
+} from "./const";
+import { getHeightSum, type Counts } from "./utils";
+
+export function getAllSlotsOffsetHelpers(
+  epoch: Epoch,
+  currentSlot: number,
+  leaderSlots: number[],
+  nextLeaderSlot: number | undefined,
+  getSlotAtIndex: (index: number) => number | undefined,
+): OffsetHelpers {
+  const firstLeaderSlot = getSlotGroupLeader(epoch.start_slot);
+  const lastLeaderSlot = getSlotGroupLeader(epoch.end_slot);
+  const currentLeaderSlot = getSlotGroupLeader(currentSlot);
+
+  const counts = getTypeCounts(
+    firstLeaderSlot,
+    lastLeaderSlot,
+    currentLeaderSlot,
+    nextLeaderSlot,
+    leaderSlots,
+  );
+  const totalHeight = getHeightSum(counts);
+
+  const getSlotTopOffset = (slot: number) => {
+    const leaderSlot = getSlotGroupLeader(slot);
+
+    if (leaderSlot === lastLeaderSlot) return 0;
+    const slotAbove = leaderSlot + slotsPerLeader;
+    const counts = getTypeCounts(
+      slotAbove,
+      lastLeaderSlot,
+      currentLeaderSlot,
+      nextLeaderSlot,
+      leaderSlots,
+    );
+    return getHeightSum(counts);
+  };
+
+  const getIndexTopOffset = (index: number) => {
+    if (index === 0) return 0;
+    const slot = getSlotAtIndex(index);
+    if (slot == null) return;
+    return getSlotTopOffset(slot);
+  };
+
+  const getSlotHeight = (anySlot: number) => {
+    const slot = getSlotGroupLeader(anySlot);
+    const isYours = leaderSlots.includes(slot);
+    if (slot < currentLeaderSlot)
+      return isYours ? YOUR_PAST_HEIGHT : OTHER_PAST_HEIGHT;
+    if (slot === currentLeaderSlot)
+      return isYours ? YOUR_CURRENT_HEIGHT : OTHER_CURRENT_HEIGHT;
+    if (!isYours) return OTHER_FUTURE_HEIGHT;
+    return slot === nextLeaderSlot
+      ? YOUR_NEXT_LEADER_HEIGHT
+      : YOUR_NON_NEXT_FUTURE_HEIGHT;
+  };
+
+  const getIndexHeight = (index: number) => {
+    const slot = getSlotAtIndex(index);
+    if (slot == null) return;
+    return getSlotHeight(slot);
+  };
+
+  return {
+    totalHeight,
+    offsetSnapshotCurrentSlot: currentSlot,
+    getSlotTopOffset,
+    getSlotHeight,
+    getIndexTopOffset,
+    getIndexHeight,
+  };
+}
+
+/**
+ * Get props for slots list, where the list of items are comprised of
+ * the leader slots in the current epoch, in descending order
+ */
+export function getAllSlotsListProps(
+  epoch: Epoch | undefined,
+  currentSlot: number | undefined,
+  leaderSlots: number[] | undefined,
+  nextLeaderSlot: number | undefined,
+): SlotsIndexProps | undefined {
+  if (!epoch) return;
+
+  const numSlotsInEpoch = epoch.end_slot - epoch.start_slot + 1;
+  const itemsCount = Math.ceil(numSlotsInEpoch / slotsPerLeader);
+
+  const getIndexForSlot = (slot: number) => {
+    if (slot < epoch.start_slot || slot > epoch.end_slot) return;
+    return Math.trunc((epoch.end_slot - slot) / slotsPerLeader);
+  };
+
+  const getSlotAtIndex = (index: number) => {
+    if (index < 0 || index >= itemsCount) return;
+    return getSlotGroupLeader(epoch.end_slot - index * slotsPerLeader);
+  };
+
+  const offsetHelpers =
+    currentSlot != null && leaderSlots != null
+      ? getAllSlotsOffsetHelpers(
+          epoch,
+          currentSlot,
+          leaderSlots,
+          nextLeaderSlot,
+          getSlotAtIndex,
+        )
+      : undefined;
+
+  return {
+    getSlotAtIndex,
+    getIndexForSlot,
+    itemsCount,
+    offsetHelpers,
+  };
+}
+
+function getTypeCounts(
+  minLeaderSlot: number,
+  maxLeaderSlot: number,
+  currentLeaderSlot: number,
+  yourNextLeaderSlot: number | undefined,
+  leaderSlots: number[],
+): Counts {
+  let yourPastCount = 0;
+  let yourCurrentCount = 0;
+  let yourNextFutureCount = 0;
+  let yourNonNextFutureCount = 0;
+  for (const slot of leaderSlots) {
+    if (slot < minLeaderSlot) continue;
+    if (slot > maxLeaderSlot) break;
+
+    if (slot < currentLeaderSlot) {
+      yourPastCount++;
+    } else if (slot === currentLeaderSlot) {
+      yourCurrentCount++;
+    } else if (slot === yourNextLeaderSlot) {
+      yourNextFutureCount++;
+    } else {
+      yourNonNextFutureCount++;
+    }
+  }
+
+  const yourFutureCount = yourNextFutureCount + yourNonNextFutureCount;
+
+  const totalCount = (maxLeaderSlot - minLeaderSlot) / slotsPerLeader + 1;
+  const { totalPastCount, totalCurrentCount, totalFutureCount } =
+    currentLeaderSlot < minLeaderSlot
+      ? {
+          totalPastCount: 0,
+          totalCurrentCount: 0,
+          totalFutureCount: totalCount,
+        }
+      : currentLeaderSlot > maxLeaderSlot
+        ? {
+            totalPastCount: totalCount,
+            totalCurrentCount: 0,
+            totalFutureCount: 0,
+          }
+        : {
+            totalPastCount:
+              (currentLeaderSlot - minLeaderSlot) / slotsPerLeader,
+            totalCurrentCount: 1,
+            totalFutureCount:
+              (maxLeaderSlot - currentLeaderSlot) / slotsPerLeader,
+          };
+
+  return {
+    otherPastCount: totalPastCount - yourPastCount,
+    otherCurrentCount: totalCurrentCount - yourCurrentCount,
+    otherFutureCount: totalFutureCount - yourFutureCount,
+    yourPastCount,
+    yourCurrentCount,
+    yourNextFutureCount,
+    yourNonNextFutureCount,
+  };
+}

--- a/src/features/Navigation/atoms.ts
+++ b/src/features/Navigation/atoms.ts
@@ -52,7 +52,7 @@ export const getSlotGroupTypeAtom = atom((get) => {
 
 export const getIsGroupSelectedAtom = atom((get) => {
   const selectedSlot = get(selectedSlotAtom);
-  return function isGroupSelected(slot: number) {
+  return function getIsGroupSelected(slot: number) {
     if (selectedSlot == null) return false;
     return areInSameGroup(slot, selectedSlot);
   };

--- a/src/features/Navigation/const.ts
+++ b/src/features/Navigation/const.ts
@@ -1,3 +1,4 @@
+import { kebabCase } from "lodash";
 import type { CSSProperties } from "react";
 
 // heights including padding
@@ -10,44 +11,65 @@ export const YOUR_CURRENT_HEIGHT = 57;
 export const YOUR_NEXT_LEADER_HEIGHT = 33;
 export const YOUR_NON_NEXT_FUTURE_HEIGHT = 28;
 
+export enum ItemHeightType {
+  OtherPast = "OtherPast",
+  OtherCurrent = "OtherCurrent",
+  OtherFuture = "OtherFuture",
+  YourPast = "YourPast",
+  YourCurrent = "YourCurrent",
+  YourNextLeader = "YourNextLeader",
+  YourNonNextFuture = "YourNonNextFuture",
+  NotInList = "NotInList",
+}
+
+export const itemHeightByType: Record<ItemHeightType, number> = {
+  [ItemHeightType.OtherPast]: OTHER_PAST_HEIGHT,
+  [ItemHeightType.OtherCurrent]: OTHER_CURRENT_HEIGHT,
+  [ItemHeightType.OtherFuture]: OTHER_FUTURE_HEIGHT,
+  [ItemHeightType.YourPast]: YOUR_PAST_HEIGHT,
+  [ItemHeightType.YourCurrent]: YOUR_CURRENT_HEIGHT,
+  [ItemHeightType.YourNextLeader]: YOUR_NEXT_LEADER_HEIGHT,
+  [ItemHeightType.YourNonNextFuture]: YOUR_NON_NEXT_FUTURE_HEIGHT,
+  [ItemHeightType.NotInList]: 0,
+};
+
 const SLOT_GROUP_PADDING_BOTTOM = 5;
 
-const allHeights = [
-  OTHER_PAST_HEIGHT,
-  OTHER_CURRENT_HEIGHT,
-  OTHER_FUTURE_HEIGHT,
-  YOUR_PAST_HEIGHT,
-  YOUR_CURRENT_HEIGHT,
-  YOUR_NEXT_LEADER_HEIGHT,
-  YOUR_NON_NEXT_FUTURE_HEIGHT,
-];
+const getCssVarName = (type: ItemHeightType) => {
+  const kebab = kebabCase(type);
+  return `--${kebab}-slot-group-height`;
+};
 
-export const slotGroupCssVars = {
-  "--slot-group-padding-bottom": `${SLOT_GROUP_PADDING_BOTTOM}px`,
-  "--other-past-slot-group-height": `${OTHER_PAST_HEIGHT - SLOT_GROUP_PADDING_BOTTOM}px`,
-  "--other-current-slot-group-height": `${OTHER_CURRENT_HEIGHT - SLOT_GROUP_PADDING_BOTTOM}px`,
-  "--other-future-slot-group-height": `${OTHER_FUTURE_HEIGHT - SLOT_GROUP_PADDING_BOTTOM}px`,
-  "--your-past-slot-group-height": `${YOUR_PAST_HEIGHT - SLOT_GROUP_PADDING_BOTTOM}px`,
-  "--your-current-slot-group-height": `${YOUR_CURRENT_HEIGHT - SLOT_GROUP_PADDING_BOTTOM}px`,
-  "--your-next-leader-slot-group-height": `${YOUR_NEXT_LEADER_HEIGHT - SLOT_GROUP_PADDING_BOTTOM}px`,
-  "--your-non-next-future-slot-group-height": `${YOUR_NON_NEXT_FUTURE_HEIGHT - SLOT_GROUP_PADDING_BOTTOM}px`,
-} as CSSProperties;
+export const slotGroupCssVars = Object.entries(itemHeightByType).reduce<
+  Record<string, string>
+>(
+  (acc, [type, height]) => {
+    if (type === ItemHeightType.NotInList) return acc;
 
+    acc[getCssVarName(type as ItemHeightType)] =
+      `${height - SLOT_GROUP_PADDING_BOTTOM}px`;
+    return acc;
+  },
+  {
+    "--slot-group-padding-bottom": `${SLOT_GROUP_PADDING_BOTTOM}px`,
+  },
+) as CSSProperties;
+
+const allHeights = Object.values(itemHeightByType).filter((v) => v !== 0);
 export const MIN_GROUP_HEIGHT = Math.min(...allHeights);
 export const MAX_GROUP_HEIGHT = Math.max(...allHeights);
 
-export interface OffsetHelpers {
+export interface ListHelpers {
   totalHeight: number;
   offsetSnapshotCurrentSlot: number;
-  getSlotTopOffset: (slot: number) => number | undefined;
-  getSlotHeight: (slot: number) => number | undefined;
+  yourNextLeaderSlot: number | undefined;
+  getSlotHeight: (slot: number) => number;
   getIndexTopOffset: (index: number) => number | undefined;
-  getIndexHeight: (index: number) => number | undefined;
 }
 
 export interface SlotsIndexProps {
   getSlotAtIndex: (index: number) => number | undefined;
   getIndexForSlot: (slot: number) => number | undefined;
   itemsCount: number;
-  offsetHelpers: OffsetHelpers | undefined;
+  listHelpers: ListHelpers | undefined;
 }

--- a/src/features/Navigation/const.ts
+++ b/src/features/Navigation/const.ts
@@ -1,0 +1,53 @@
+import type { CSSProperties } from "react";
+
+// heights including padding
+export const OTHER_PAST_HEIGHT = 42;
+export const OTHER_CURRENT_HEIGHT = 55;
+export const OTHER_FUTURE_HEIGHT = 26;
+
+export const YOUR_PAST_HEIGHT = 44;
+export const YOUR_CURRENT_HEIGHT = 57;
+export const YOUR_NEXT_LEADER_HEIGHT = 33;
+export const YOUR_NON_NEXT_FUTURE_HEIGHT = 28;
+
+const SLOT_GROUP_PADDING_BOTTOM = 5;
+
+const allHeights = [
+  OTHER_PAST_HEIGHT,
+  OTHER_CURRENT_HEIGHT,
+  OTHER_FUTURE_HEIGHT,
+  YOUR_PAST_HEIGHT,
+  YOUR_CURRENT_HEIGHT,
+  YOUR_NEXT_LEADER_HEIGHT,
+  YOUR_NON_NEXT_FUTURE_HEIGHT,
+];
+
+export const slotGroupCssVars = {
+  "--slot-group-padding-bottom": `${SLOT_GROUP_PADDING_BOTTOM}px`,
+  "--other-past-slot-group-height": `${OTHER_PAST_HEIGHT - SLOT_GROUP_PADDING_BOTTOM}px`,
+  "--other-current-slot-group-height": `${OTHER_CURRENT_HEIGHT - SLOT_GROUP_PADDING_BOTTOM}px`,
+  "--other-future-slot-group-height": `${OTHER_FUTURE_HEIGHT - SLOT_GROUP_PADDING_BOTTOM}px`,
+  "--your-past-slot-group-height": `${YOUR_PAST_HEIGHT - SLOT_GROUP_PADDING_BOTTOM}px`,
+  "--your-current-slot-group-height": `${YOUR_CURRENT_HEIGHT - SLOT_GROUP_PADDING_BOTTOM}px`,
+  "--your-next-leader-slot-group-height": `${YOUR_NEXT_LEADER_HEIGHT - SLOT_GROUP_PADDING_BOTTOM}px`,
+  "--your-non-next-future-slot-group-height": `${YOUR_NON_NEXT_FUTURE_HEIGHT - SLOT_GROUP_PADDING_BOTTOM}px`,
+} as CSSProperties;
+
+export const MIN_GROUP_HEIGHT = Math.min(...allHeights);
+export const MAX_GROUP_HEIGHT = Math.max(...allHeights);
+
+export interface OffsetHelpers {
+  totalHeight: number;
+  offsetSnapshotCurrentSlot: number;
+  getSlotTopOffset: (slot: number) => number | undefined;
+  getSlotHeight: (slot: number) => number | undefined;
+  getIndexTopOffset: (index: number) => number | undefined;
+  getIndexHeight: (index: number) => number | undefined;
+}
+
+export interface SlotsIndexProps {
+  getSlotAtIndex: (index: number) => number | undefined;
+  getIndexForSlot: (slot: number) => number | undefined;
+  itemsCount: number;
+  offsetHelpers: OffsetHelpers | undefined;
+}

--- a/src/features/Navigation/mySlotsUtils.ts
+++ b/src/features/Navigation/mySlotsUtils.ts
@@ -1,34 +1,23 @@
 import { sortedIndex } from "lodash";
 import { getSlotGroupLeader } from "../../utils";
 import {
-  YOUR_CURRENT_HEIGHT,
-  YOUR_NEXT_LEADER_HEIGHT,
-  YOUR_NON_NEXT_FUTURE_HEIGHT,
-  YOUR_PAST_HEIGHT,
-  type OffsetHelpers,
+  ItemHeightType,
+  itemHeightByType,
+  type ListHelpers,
   type SlotsIndexProps,
 } from "./const";
 import { getHeightSum, type Counts } from "./utils";
 
-export function getMySlotsOffsetHelpers(
+export function getMySlotsListHelpers(
   mySlots: number[],
-  currentSlot: number,
-  nextLeaderSlot: number | undefined,
+  ascendingLeaderSlotsSet: Set<number>,
+  currentLeaderSlot: number,
+  yourNextLeaderSlot: number | undefined,
   isCurrentlyLeader: boolean,
   nextLeaderSlotIndex: number | undefined,
-  getSlotAtIndex: (index: number) => number | undefined,
-  getClosestIndexForSlot: (slot: number) => number,
-): OffsetHelpers {
-  const currentLeaderSlot = getSlotGroupLeader(currentSlot);
-
-  const counts = getTypeCountsForLeaderIndices(
-    0,
-    mySlots.length - 1,
-    isCurrentlyLeader,
-    nextLeaderSlotIndex,
-    mySlots.length,
-  );
-  const totalHeight = getHeightSum(counts);
+  yourLeaderSlotCounts: { past: number; current: number; future: number },
+): ListHelpers {
+  const totalHeight = getTotalHeight(yourLeaderSlotCounts);
 
   const getIndexTopOffset = (index: number) => {
     if (index === 0) return 0;
@@ -37,7 +26,7 @@ export function getMySlotsOffsetHelpers(
     const leaderStartIdx = mySlots.length - index;
     const leaderEndIdx = mySlots.length - 1;
 
-    const countsAbove = getTypeCountsForLeaderIndices(
+    const countsAbove = getTypeCountsForRange(
       leaderStartIdx,
       leaderEndIdx,
       isCurrentlyLeader,
@@ -48,33 +37,22 @@ export function getMySlotsOffsetHelpers(
     return getHeightSum(countsAbove);
   };
 
-  const getSlotTopOffset = (slot: number) => {
-    const idx = getClosestIndexForSlot(slot);
-    return getIndexTopOffset(idx);
-  };
-
-  const getSlotHeight = (yourSlot: number) => {
-    const slot = getSlotGroupLeader(yourSlot);
-    if (slot < currentLeaderSlot) return YOUR_PAST_HEIGHT;
-    if (slot === currentLeaderSlot) return YOUR_CURRENT_HEIGHT;
-    return slot === nextLeaderSlot
-      ? YOUR_NEXT_LEADER_HEIGHT
-      : YOUR_NON_NEXT_FUTURE_HEIGHT;
-  };
-
-  const getIndexHeight = (index: number) => {
-    const slot = getSlotAtIndex(index);
-    if (slot == null) return;
-    return getSlotHeight(slot);
-  };
+  const getSlotHeight = (slotGroupLeader: number): number =>
+    itemHeightByType[
+      getSlotHeightType(
+        slotGroupLeader,
+        ascendingLeaderSlotsSet,
+        currentLeaderSlot,
+        yourNextLeaderSlot,
+      )
+    ];
 
   return {
     totalHeight,
-    offsetSnapshotCurrentSlot: currentSlot,
-    getSlotTopOffset,
+    offsetSnapshotCurrentSlot: currentLeaderSlot,
+    yourNextLeaderSlot: yourNextLeaderSlot,
     getSlotHeight,
     getIndexTopOffset,
-    getIndexHeight,
   };
 }
 
@@ -84,12 +62,16 @@ export function getMySlotsOffsetHelpers(
  */
 export function getMySlotsListProps(
   mySlots: number[] | undefined,
-  currentSlot: number | undefined,
+  ascendingLeaderSlotsSet: Set<number> | undefined,
+  currentLeaderSlot: number | undefined,
   nextLeaderSlot: number | undefined,
   isCurrentlyLeader: boolean,
   nextLeaderSlotIndex: number | undefined,
+  yourLeaderSlotCounts:
+    | { past: number; current: number; future: number }
+    | undefined,
 ): SlotsIndexProps | undefined {
-  if (mySlots == null) return;
+  if (mySlots == null || !yourLeaderSlotCounts) return;
 
   // Optimized index lookup of My slots
   const slotToIndexMapping = mySlots.reduce<Record<number, number>>(
@@ -117,16 +99,16 @@ export function getMySlotsListProps(
     );
   };
 
-  const offsetHelpers =
-    currentSlot != null
-      ? getMySlotsOffsetHelpers(
+  const listHelpers =
+    currentLeaderSlot != null && ascendingLeaderSlotsSet != null
+      ? getMySlotsListHelpers(
           mySlots,
-          currentSlot,
+          ascendingLeaderSlotsSet,
+          currentLeaderSlot,
           nextLeaderSlot,
           isCurrentlyLeader,
           nextLeaderSlotIndex,
-          getSlotAtIndex,
-          getClosestIndexForSlot,
+          yourLeaderSlotCounts,
         )
       : undefined;
 
@@ -134,11 +116,28 @@ export function getMySlotsListProps(
     getSlotAtIndex,
     getIndexForSlot: getClosestIndexForSlot,
     itemsCount: mySlots.length,
-    offsetHelpers,
+    listHelpers,
   };
 }
 
-function getTypeCountsForLeaderIndices(
+function getTotalHeight(yourLeaderSlotCounts: {
+  past: number;
+  current: number;
+  future: number;
+}): number {
+  const nextFutureCount = yourLeaderSlotCounts.future > 0 ? 1 : 0;
+  const nonNextFutureCount = yourLeaderSlotCounts.future - nextFutureCount;
+
+  const counts = {
+    [ItemHeightType.YourPast]: yourLeaderSlotCounts.past,
+    [ItemHeightType.YourCurrent]: yourLeaderSlotCounts.current,
+    [ItemHeightType.YourNextLeader]: nextFutureCount,
+    [ItemHeightType.YourNonNextFuture]: nonNextFutureCount,
+  };
+  return getHeightSum(counts);
+}
+
+function getTypeCountsForRange(
   startLeadersIdx: number,
   endLeadersIdx: number,
   isCurrentlyLeader: boolean,
@@ -169,13 +168,10 @@ function getTypeCountsForLeaderIndices(
   const nonNextFutureCount = futureCount - nextFutureCount;
 
   return {
-    otherPastCount: 0,
-    otherCurrentCount: 0,
-    otherFutureCount: 0,
-    yourPastCount: pastCount,
-    yourCurrentCount: currentCount,
-    yourNextFutureCount: nextFutureCount,
-    yourNonNextFutureCount: nonNextFutureCount,
+    [ItemHeightType.YourPast]: pastCount,
+    [ItemHeightType.YourCurrent]: currentCount,
+    [ItemHeightType.YourNextLeader]: nextFutureCount,
+    [ItemHeightType.YourNonNextFuture]: nonNextFutureCount,
   };
 }
 
@@ -195,4 +191,18 @@ function isCurrentLeaderAndInRange(
   if (currentIndex < 0) return false;
 
   return currentIndex >= startIdx && currentIndex <= endIdx;
+}
+
+function getSlotHeightType(
+  slotGroupleader: number,
+  yourLeaderSlotsSet: Set<number>,
+  currentLeaderSlot: number,
+  yourNextLeaderSlot: number | undefined,
+): ItemHeightType {
+  if (yourLeaderSlotsSet.has(slotGroupleader)) return ItemHeightType.NotInList;
+  if (slotGroupleader < currentLeaderSlot) return ItemHeightType.YourPast;
+  if (slotGroupleader === currentLeaderSlot) return ItemHeightType.YourCurrent;
+  if (slotGroupleader === yourNextLeaderSlot)
+    return ItemHeightType.YourNextLeader;
+  return ItemHeightType.YourNonNextFuture;
 }

--- a/src/features/Navigation/mySlotsUtils.ts
+++ b/src/features/Navigation/mySlotsUtils.ts
@@ -1,0 +1,190 @@
+import { sortedIndex } from "lodash";
+import { getSlotGroupLeader } from "../../utils";
+import {
+  YOUR_CURRENT_HEIGHT,
+  YOUR_NEXT_LEADER_HEIGHT,
+  YOUR_NON_NEXT_FUTURE_HEIGHT,
+  YOUR_PAST_HEIGHT,
+  type OffsetHelpers,
+  type SlotsIndexProps,
+} from "./const";
+import { getHeightSum, type Counts } from "./utils";
+
+export function getMySlotsOffsetHelpers(
+  mySlots: number[],
+  currentSlot: number,
+  nextLeaderSlot: number | undefined,
+  isCurrentlyLeader: boolean,
+  nextLeaderSlotIndex: number | undefined,
+  getSlotAtIndex: (index: number) => number | undefined,
+  getClosestIndexForSlot: (slot: number) => number,
+): OffsetHelpers {
+  const currentLeaderSlot = getSlotGroupLeader(currentSlot);
+
+  const counts = getTypeCountsForLeaderIndices(
+    0,
+    mySlots.length - 1,
+    isCurrentlyLeader,
+    nextLeaderSlotIndex,
+  );
+  const totalHeight = getHeightSum(counts);
+
+  const getIndexTopOffset = (index: number) => {
+    if (index === 0) return 0;
+
+    // list shows leader slots in reverse
+    const leaderStartIdx = mySlots.length - index;
+    const leaderEndIdx = mySlots.length - 1;
+
+    const countsAbove = getTypeCountsForLeaderIndices(
+      leaderStartIdx,
+      leaderEndIdx,
+      isCurrentlyLeader,
+      nextLeaderSlotIndex,
+    );
+
+    return getHeightSum(countsAbove);
+  };
+
+  const getSlotTopOffset = (slot: number) => {
+    const idx = getClosestIndexForSlot(slot);
+    return getIndexTopOffset(idx);
+  };
+
+  const getSlotHeight = (yourSlot: number) => {
+    const slot = getSlotGroupLeader(yourSlot);
+    if (slot < currentLeaderSlot) return YOUR_PAST_HEIGHT;
+    if (slot === currentLeaderSlot) return YOUR_CURRENT_HEIGHT;
+    return slot === nextLeaderSlot
+      ? YOUR_NEXT_LEADER_HEIGHT
+      : YOUR_NON_NEXT_FUTURE_HEIGHT;
+  };
+
+  const getIndexHeight = (index: number) => {
+    const slot = getSlotAtIndex(index);
+    if (slot == null) return;
+    return getSlotHeight(slot);
+  };
+
+  return {
+    totalHeight,
+    offsetSnapshotCurrentSlot: currentSlot,
+    getSlotTopOffset,
+    getSlotHeight,
+    getIndexTopOffset,
+    getIndexHeight,
+  };
+}
+
+/**
+ * Get props for my slots list, where the list of items are comprised of
+ * my leader slots in the current epoch, in descending order
+ */
+export function getMySlotsListProps(
+  mySlots: number[] | undefined,
+  currentSlot: number | undefined,
+  nextLeaderSlot: number | undefined,
+  isCurrentlyLeader: boolean,
+  nextLeaderSlotIndex: number | undefined,
+): SlotsIndexProps | undefined {
+  if (mySlots == null) return;
+
+  // Optimized index lookup of My slots
+  const slotToIndexMapping = mySlots.reduce<Record<number, number>>(
+    (acc, slot, index) => {
+      acc[slot] = mySlots.length - index - 1;
+      return acc;
+    },
+    {},
+  );
+
+  const getSlotAtIndex = (index: number) => mySlots[mySlots.length - index - 1];
+
+  /**
+   * In the items (desc value) array, get:
+   *   - the exact slot index, or
+   *   - the index of closest, smaller my slot leader, or if unavailable,
+   *   - index 0
+   */
+  const getClosestIndexForSlot = (slot: number) => {
+    if (slot >= mySlots[mySlots.length - 1]) return 0;
+
+    return (
+      slotToIndexMapping[getSlotGroupLeader(slot)] ??
+      mySlots.length - sortedIndex(mySlots, slot) - 1
+    );
+  };
+
+  const offsetHelpers =
+    currentSlot != null
+      ? getMySlotsOffsetHelpers(
+          mySlots,
+          currentSlot,
+          nextLeaderSlot,
+          isCurrentlyLeader,
+          nextLeaderSlotIndex,
+          getSlotAtIndex,
+          getClosestIndexForSlot,
+        )
+      : undefined;
+
+  return {
+    getSlotAtIndex,
+    getIndexForSlot: getClosestIndexForSlot,
+    itemsCount: mySlots.length,
+    offsetHelpers,
+  };
+}
+
+function getTypeCountsForLeaderIndices(
+  startLeadersIdx: number,
+  endLeadersIdx: number,
+  isCurrentlyLeader: boolean,
+  nextLeaderSlotIndex: number | undefined,
+): Counts {
+  const totalCount = endLeadersIdx - startLeadersIdx + 1;
+  const futureCount =
+    nextLeaderSlotIndex == null || nextLeaderSlotIndex > endLeadersIdx
+      ? 0
+      : nextLeaderSlotIndex < startLeadersIdx
+        ? totalCount
+        : endLeadersIdx - nextLeaderSlotIndex + 1;
+
+  const notFutureCount = totalCount - futureCount;
+  const currentCount = isCurrentLeaderAndInRange(
+    startLeadersIdx,
+    endLeadersIdx,
+    nextLeaderSlotIndex,
+    isCurrentlyLeader,
+  )
+    ? 1
+    : 0;
+  const pastCount = notFutureCount - currentCount;
+
+  const nextFutureCount = futureCount > 0 ? 1 : 0;
+  const nonNextFutureCount = futureCount - nextFutureCount;
+
+  return {
+    otherPastCount: 0,
+    otherCurrentCount: 0,
+    otherFutureCount: 0,
+    yourPastCount: pastCount,
+    yourCurrentCount: currentCount,
+    yourNextFutureCount: nextFutureCount,
+    yourNonNextFutureCount: nonNextFutureCount,
+  };
+}
+
+function isCurrentLeaderAndInRange(
+  startIdx: number,
+  endIdx: number,
+  nextLeaderSlotIndex: number | undefined,
+  isCurrentlyLeader: boolean,
+) {
+  if (!isCurrentlyLeader || nextLeaderSlotIndex == null) return false;
+
+  const currentIndex = nextLeaderSlotIndex - 1;
+  if (currentIndex < 0) return false;
+
+  return currentIndex >= startIdx && currentIndex <= endIdx;
+}

--- a/src/features/Navigation/mySlotsUtils.ts
+++ b/src/features/Navigation/mySlotsUtils.ts
@@ -26,6 +26,7 @@ export function getMySlotsOffsetHelpers(
     mySlots.length - 1,
     isCurrentlyLeader,
     nextLeaderSlotIndex,
+    mySlots.length,
   );
   const totalHeight = getHeightSum(counts);
 
@@ -41,6 +42,7 @@ export function getMySlotsOffsetHelpers(
       leaderEndIdx,
       isCurrentlyLeader,
       nextLeaderSlotIndex,
+      mySlots.length,
     );
 
     return getHeightSum(countsAbove);
@@ -141,6 +143,7 @@ function getTypeCountsForLeaderIndices(
   endLeadersIdx: number,
   isCurrentlyLeader: boolean,
   nextLeaderSlotIndex: number | undefined,
+  totalLeadersCount: number,
 ): Counts {
   const totalCount = endLeadersIdx - startLeadersIdx + 1;
   const futureCount =
@@ -156,6 +159,7 @@ function getTypeCountsForLeaderIndices(
     endLeadersIdx,
     nextLeaderSlotIndex,
     isCurrentlyLeader,
+    totalLeadersCount,
   )
     ? 1
     : 0;
@@ -180,10 +184,14 @@ function isCurrentLeaderAndInRange(
   endIdx: number,
   nextLeaderSlotIndex: number | undefined,
   isCurrentlyLeader: boolean,
+  totalLeadersCount: number,
 ) {
-  if (!isCurrentlyLeader || nextLeaderSlotIndex == null) return false;
+  if (!isCurrentlyLeader) return false;
 
-  const currentIndex = nextLeaderSlotIndex - 1;
+  const currentIndex =
+    nextLeaderSlotIndex != null
+      ? nextLeaderSlotIndex - 1
+      : totalLeadersCount - 1;
   if (currentIndex < 0) return false;
 
   return currentIndex >= startIdx && currentIndex <= endIdx;

--- a/src/features/Navigation/slotsRenderer.module.css
+++ b/src/features/Navigation/slotsRenderer.module.css
@@ -1,5 +1,5 @@
 .slot-group-container {
-  padding-bottom: 5px;
+  padding-bottom: var(--slot-group-padding-bottom);
   background: var(--slot-nav-background-color);
 }
 
@@ -18,6 +18,7 @@
 }
 
 .future {
+  height: var(--other-future-slot-group-height);
   padding: 3px;
   background: var(--slots-list-future-slot-background-color);
   color: var(--slots-list-future-slot-color);
@@ -26,14 +27,20 @@
   }
 
   &.you {
+    height: var(--your-non-next-future-slot-group-height);
     border: solid var(--slots-list-not-processed-my-slots-border-color);
     border-width: 2px 1px 1px 1px;
     padding: 2px 3px 3px 3px;
     background: var(--slots-list-my-slot-background-color);
+
+    &.next-you {
+      height: var(--your-next-leader-slot-group-height);
+    }
   }
 }
 
 .current {
+  height: var(--other-current-slot-group-height);
   padding: 2px;
   border: 1px solid var(--container-border-color);
   background-color: var(--container-background-color);
@@ -49,6 +56,7 @@
   }
 
   &.you {
+    height: var(--your-current-slot-group-height);
     border-width: 3px 1px 1px 1px;
     border-color: var(--slots-list-my-slots-selected-border-color);
   }
@@ -61,6 +69,7 @@
 }
 
 .past {
+  height: var(--other-past-slot-group-height);
   padding: 3px;
   color: var(--slots-list-past-slot-color);
 
@@ -69,6 +78,7 @@
   }
 
   &.you {
+    height: var(--your-past-slot-group-height);
     background: var(--slots-list-my-slot-background-color);
 
     &.processed {

--- a/src/features/Navigation/useHeightDeltas.ts
+++ b/src/features/Navigation/useHeightDeltas.ts
@@ -1,0 +1,133 @@
+import { useRef } from "react";
+import { slotsPerLeader } from "../../consts";
+import { itemHeightByType, ItemHeightType } from "./const";
+
+/**
+ * Keep track of height deltas as currentLeaderSlot increments by one
+ */
+export function useHeightDeltas(
+  yourSlotsOnly: boolean,
+  currentLeaderSlot: number | undefined,
+  yourNextLeaderSlot: number | undefined,
+  yourLeaderSlotsSet: Set<number> | undefined,
+) {
+  const prevYourLeaderSlotsSetRef = useRef<Set<number> | undefined>(
+    yourLeaderSlotsSet,
+  );
+  const prevCurrentLeaderSlotRef = useRef<number | undefined>();
+  const prevYourNextLeaderSlotRef = useRef<number | undefined>();
+  const slotHeightDeltasRef = useRef<Map<number, number>>();
+
+  if (yourLeaderSlotsSet == null) return;
+
+  // reset refs if leader set changes (e.g. on epoch change)
+  if (prevYourLeaderSlotsSetRef.current !== yourLeaderSlotsSet) {
+    prevYourLeaderSlotsSetRef.current = yourLeaderSlotsSet;
+    prevCurrentLeaderSlotRef.current = undefined;
+    prevYourNextLeaderSlotRef.current = undefined;
+    slotHeightDeltasRef.current = undefined;
+  }
+
+  const prevCurrent = prevCurrentLeaderSlotRef.current;
+  const prevNextLeader = prevYourNextLeaderSlotRef.current;
+
+  if (currentLeaderSlot == null) return;
+
+  if (prevCurrent == null) {
+    prevCurrentLeaderSlotRef.current = currentLeaderSlot;
+    prevYourNextLeaderSlotRef.current = yourNextLeaderSlot;
+    return;
+  }
+
+  if (currentLeaderSlot > prevCurrent + slotsPerLeader) {
+    // we missed some changes. reset state
+    slotHeightDeltasRef.current = undefined;
+    prevCurrentLeaderSlotRef.current = currentLeaderSlot;
+    prevYourNextLeaderSlotRef.current = yourNextLeaderSlot;
+    return;
+  }
+
+  if (prevCurrent === currentLeaderSlot) {
+    return {
+      slotHeightDeltas: slotHeightDeltasRef.current,
+    };
+  }
+
+  if (prevNextLeader != null && prevNextLeader !== yourNextLeaderSlot) {
+    // previous your next leader -> (your) current
+    slotHeightDeltasRef.current = getUpdatedDeltas(
+      slotHeightDeltasRef.current,
+      prevNextLeader,
+      itemHeightByType[ItemHeightType.YourCurrent] -
+        itemHeightByType[ItemHeightType.YourNextLeader],
+    );
+
+    if (yourNextLeaderSlot != null) {
+      // future (your) slot -> your next leader
+      slotHeightDeltasRef.current = getUpdatedDeltas(
+        slotHeightDeltasRef.current,
+        yourNextLeaderSlot,
+        itemHeightByType[ItemHeightType.YourNextLeader] -
+          itemHeightByType[ItemHeightType.YourNonNextFuture],
+      );
+    }
+  } else if (!yourSlotsOnly) {
+    // future (not your) slot -> (not your) current
+    // ignore change for only your slots list, because this slot is not in the list
+    slotHeightDeltasRef.current = getUpdatedDeltas(
+      slotHeightDeltasRef.current,
+      currentLeaderSlot,
+      itemHeightByType[ItemHeightType.OtherCurrent] -
+        itemHeightByType[ItemHeightType.OtherFuture],
+    );
+  }
+
+  const wasPrevCurrentYours = yourLeaderSlotsSet.has(prevCurrent);
+  if (wasPrevCurrentYours) {
+    // prev (your) current -> (your) past
+    slotHeightDeltasRef.current = getUpdatedDeltas(
+      slotHeightDeltasRef.current,
+      prevCurrent,
+      itemHeightByType[ItemHeightType.YourPast] -
+        itemHeightByType[ItemHeightType.YourCurrent],
+    );
+  } else if (!yourSlotsOnly) {
+    // prev (not your) current -> (not your) past
+    slotHeightDeltasRef.current = getUpdatedDeltas(
+      slotHeightDeltasRef.current,
+      prevCurrent,
+      itemHeightByType[ItemHeightType.OtherPast] -
+        itemHeightByType[ItemHeightType.OtherCurrent],
+    );
+  }
+
+  prevCurrentLeaderSlotRef.current = currentLeaderSlot;
+  prevYourNextLeaderSlotRef.current = yourNextLeaderSlot;
+
+  return {
+    slotHeightDeltas: slotHeightDeltasRef.current,
+  };
+}
+
+/**
+ * Update slot delta value. If a value already exists for this slot,
+ * the new value is the sum of previour + incoming delta
+ */
+function getUpdatedDeltas(
+  _deltasMap: Map<number, number> | undefined,
+  slot: number,
+  delta: number,
+) {
+  const deltasMap = _deltasMap ?? new Map<number, number>();
+
+  const prevDelta = deltasMap.get(slot);
+  const newDelta = prevDelta == null ? delta : prevDelta + delta;
+
+  if (newDelta === 0) {
+    deltasMap.delete(slot);
+  } else {
+    deltasMap.set(slot, newDelta);
+  }
+
+  return deltasMap;
+}

--- a/src/features/Navigation/utils.ts
+++ b/src/features/Navigation/utils.ts
@@ -67,32 +67,106 @@ export function findMinVisibleIdx(
   return lo;
 }
 
+export enum ItemType {
+  Past,
+  Current,
+  Future,
+}
+
+function getItemType(slot: number, currentSlot: number) {
+  if (slot < currentSlot) return ItemType.Past;
+  if (slot === currentSlot) return ItemType.Current;
+  return ItemType.Future;
+}
+
+export interface BaseItemInfo {
+  idx: number;
+  slot: number;
+  bottomOffset: number;
+  height: number;
+  type: ItemType;
+}
+export interface ItemInfo extends BaseItemInfo {
+  topOffset: number;
+  type: ItemType;
+}
+
+export function getItemInfo(
+  idx: number | undefined,
+  getSlotAtIndex: (idx: number) => number | undefined,
+  getIndexTopOffset: (idx: number) => number | undefined,
+  getSlotHeight: (slot: number) => number | undefined,
+  totalListHeight: number,
+  currentLeaderSlot: number,
+): ItemInfo | undefined {
+  if (idx == null) return;
+
+  const slot = getSlotAtIndex(idx);
+  if (slot == null) return;
+
+  const topOffset = getIndexTopOffset(idx);
+  if (topOffset == null) return;
+
+  const height = getSlotHeight(slot);
+  if (height == null) return;
+
+  return {
+    idx,
+    slot,
+    topOffset,
+    bottomOffset: totalListHeight - topOffset - height,
+    height,
+    type: getItemType(slot, currentLeaderSlot),
+  };
+}
+
+export function getItemBelowInfo(
+  currentItem: ItemInfo,
+  getSlotAtIndex: (idx: number) => number | undefined,
+  getSlotHeight: (slot: number) => number | undefined,
+  currentLeaderSlot: number,
+): ItemInfo | undefined {
+  const idx = currentItem.idx + 1;
+  const slot = getSlotAtIndex(idx);
+  if (slot == null) return;
+  const topOffset = currentItem.topOffset + currentItem.height;
+  const height = getSlotHeight(slot);
+  if (height == null) return;
+  const bottomOffset = currentItem.bottomOffset - height;
+
+  return {
+    idx,
+    slot,
+    topOffset,
+    bottomOffset,
+    height,
+    type: getItemType(slot, currentLeaderSlot),
+  };
+}
+
+export interface OffsetType {
+  offset: number;
+  isBottomOffset: boolean;
+}
+
 /**
- * Find last item whose bottom offset is <= scrollBottom
+ * Position past slots are offset from the bottom, and others from the top
+ * to minimize position changes when current slot progresses.
  */
-export function findMaxVisibleIdx(
-  scrollTop: number,
-  totalCount: number,
-  visibleHeight: number,
-  getTopOffsetAtIdx: (idx: number) => number | undefined,
-) {
-  const scrollBottom = scrollTop + visibleHeight;
-
-  let lo = Math.max(0, Math.floor(scrollBottom / MAX_GROUP_HEIGHT));
-  let hi = Math.min(
-    totalCount - 1,
-    Math.max(lo, Math.ceil(scrollBottom / MIN_GROUP_HEIGHT)),
-  );
-  while (lo < hi) {
-    const mid = (lo + hi + 1) >> 1;
-    const offsetAtIndex = getTopOffsetAtIdx(mid);
-    if (offsetAtIndex == null) return;
-
-    if (offsetAtIndex <= scrollBottom) {
-      lo = mid;
-    } else {
-      hi = mid - 1;
-    }
+export function getSlotOffsetType(
+  currentSlot: number,
+  slot: number,
+  topOffset: number,
+  totalHeight: number,
+): OffsetType {
+  if (slot < currentSlot) {
+    return {
+      offset: totalHeight - topOffset,
+      isBottomOffset: true,
+    };
   }
-  return lo;
+  return {
+    offset: topOffset,
+    isBottomOffset: false,
+  };
 }

--- a/src/features/Navigation/utils.ts
+++ b/src/features/Navigation/utils.ts
@@ -1,81 +1,98 @@
-import { sortedIndex } from "lodash";
-import type { Epoch } from "../../api/types";
-import { slotsPerLeader } from "../../consts";
-import { getSlotGroupLeader } from "../../utils";
+import {
+  YOUR_PAST_HEIGHT,
+  OTHER_PAST_HEIGHT,
+  YOUR_CURRENT_HEIGHT,
+  OTHER_CURRENT_HEIGHT,
+  OTHER_FUTURE_HEIGHT,
+  YOUR_NEXT_LEADER_HEIGHT,
+  YOUR_NON_NEXT_FUTURE_HEIGHT,
+  MAX_GROUP_HEIGHT,
+  MIN_GROUP_HEIGHT,
+} from "./const";
 
-export interface SlotsIndexProps {
-  getSlotAtIndex: (index: number) => number | undefined;
-  getIndexForSlot: (slot: number) => number | undefined;
-  itemsCount: number;
+export interface Counts {
+  otherPastCount: number;
+  otherCurrentCount: number;
+  otherFutureCount: number;
+  yourPastCount: number;
+  yourCurrentCount: number;
+  yourNextFutureCount: number;
+  yourNonNextFutureCount: number;
 }
 
-/**
- * Get props for slots list, where the list of items are comprised of
- * the leader slots in the current epoch, in descending order
- */
-export function getAllSlotsListProps(
-  epoch: Epoch | undefined,
-): SlotsIndexProps | undefined {
-  if (!epoch) return;
-
-  const numSlotsInEpoch = epoch.end_slot - epoch.start_slot + 1;
-  const itemsCount = Math.ceil(numSlotsInEpoch / slotsPerLeader);
-
-  const getIndexForSlot = (slot: number) => {
-    if (slot < epoch.start_slot || slot > epoch.end_slot) return;
-    return Math.trunc((epoch.end_slot - slot) / slotsPerLeader);
-  };
-
-  const getSlotAtIndex = (index: number) => {
-    if (index < 0 || index >= itemsCount) return;
-    return getSlotGroupLeader(epoch.end_slot - index * slotsPerLeader);
-  };
-
-  return {
-    getSlotAtIndex,
-    getIndexForSlot,
-    itemsCount,
-  };
-}
-
-/**
- * Get props for my slots list, where the list of items are comprised of
- * my leader slots in the current epoch, in descending order
- */
-export function getMySlotsListProps(
-  mySlots: number[] | undefined,
-): SlotsIndexProps | undefined {
-  if (mySlots == null) return;
-
-  // Optimized index lookup of My slots
-  const slotToIndexMapping = mySlots.reduce<Record<number, number>>(
-    (acc, slot, index) => {
-      acc[slot] = mySlots.length - index - 1;
-      return acc;
-    },
-    {},
+export function getHeightSum({
+  otherPastCount,
+  otherCurrentCount,
+  otherFutureCount,
+  yourPastCount,
+  yourCurrentCount,
+  yourNextFutureCount,
+  yourNonNextFutureCount,
+}: Counts) {
+  return (
+    otherPastCount * OTHER_PAST_HEIGHT +
+    otherCurrentCount * OTHER_CURRENT_HEIGHT +
+    otherFutureCount * OTHER_FUTURE_HEIGHT +
+    yourPastCount * YOUR_PAST_HEIGHT +
+    yourCurrentCount * YOUR_CURRENT_HEIGHT +
+    yourNextFutureCount * YOUR_NEXT_LEADER_HEIGHT +
+    yourNonNextFutureCount * YOUR_NON_NEXT_FUTURE_HEIGHT
   );
+}
 
-  const getSlotAtIndex = (index: number) => mySlots[mySlots.length - index - 1];
+/**
+ * Find first item whose top offset is >= scrollTop
+ */
+export function findMinVisibleIdx(
+  scrollTop: number,
+  totalCount: number,
+  getTopOffsetAtIdx: (idx: number) => number | undefined,
+) {
+  let lo = Math.max(0, Math.floor(scrollTop / MAX_GROUP_HEIGHT));
+  let hi = Math.min(
+    totalCount - 1,
+    Math.max(lo, Math.ceil(scrollTop / MIN_GROUP_HEIGHT)),
+  );
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    const offsetAtIdx = getTopOffsetAtIdx(mid);
+    if (offsetAtIdx == null) return;
 
-  /**
-   * In the items (desc value) array, get:
-   *   - the exact slot index, or
-   *   - the index of closest, smaller my slot leader, or if unavailable,
-   *   - index 0
-   */
-  const getClosestIndexForSlot = (slot: number) => {
-    if (slot >= mySlots[mySlots.length - 1]) return 0;
+    if (offsetAtIdx <= scrollTop) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return lo;
+}
 
-    return (
-      slotToIndexMapping[getSlotGroupLeader(slot)] ??
-      mySlots.length - sortedIndex(mySlots, slot) - 1
-    );
-  };
+/**
+ * Find last item whose bottom offset is <= scrollBottom
+ */
+export function findMaxVisibleIdx(
+  scrollTop: number,
+  totalCount: number,
+  visibleHeight: number,
+  getTopOffsetAtIdx: (idx: number) => number | undefined,
+) {
+  const scrollBottom = scrollTop + visibleHeight;
 
-  return {
-    getSlotAtIndex,
-    getIndexForSlot: getClosestIndexForSlot,
-    itemsCount: mySlots.length,
-  };
+  let lo = Math.max(0, Math.floor(scrollBottom / MAX_GROUP_HEIGHT));
+  let hi = Math.min(
+    totalCount - 1,
+    Math.max(lo, Math.ceil(scrollBottom / MIN_GROUP_HEIGHT)),
+  );
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    const offsetAtIndex = getTopOffsetAtIdx(mid);
+    if (offsetAtIndex == null) return;
+
+    if (offsetAtIndex <= scrollBottom) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return lo;
 }

--- a/src/features/Navigation/utils.ts
+++ b/src/features/Navigation/utils.ts
@@ -1,43 +1,15 @@
-import {
-  YOUR_PAST_HEIGHT,
-  OTHER_PAST_HEIGHT,
-  YOUR_CURRENT_HEIGHT,
-  OTHER_CURRENT_HEIGHT,
-  OTHER_FUTURE_HEIGHT,
-  YOUR_NEXT_LEADER_HEIGHT,
-  YOUR_NON_NEXT_FUTURE_HEIGHT,
-  MAX_GROUP_HEIGHT,
-  MIN_GROUP_HEIGHT,
-} from "./const";
+import { slotsListTopPaddingIndex } from "../../consts";
+import type { ItemHeightType, SlotsIndexProps } from "./const";
+import { MAX_GROUP_HEIGHT, MIN_GROUP_HEIGHT, itemHeightByType } from "./const";
 
-export interface Counts {
-  otherPastCount: number;
-  otherCurrentCount: number;
-  otherFutureCount: number;
-  yourPastCount: number;
-  yourCurrentCount: number;
-  yourNextFutureCount: number;
-  yourNonNextFutureCount: number;
-}
+export type Counts = Partial<Record<ItemHeightType, number>>;
 
-export function getHeightSum({
-  otherPastCount,
-  otherCurrentCount,
-  otherFutureCount,
-  yourPastCount,
-  yourCurrentCount,
-  yourNextFutureCount,
-  yourNonNextFutureCount,
-}: Counts) {
-  return (
-    otherPastCount * OTHER_PAST_HEIGHT +
-    otherCurrentCount * OTHER_CURRENT_HEIGHT +
-    otherFutureCount * OTHER_FUTURE_HEIGHT +
-    yourPastCount * YOUR_PAST_HEIGHT +
-    yourCurrentCount * YOUR_CURRENT_HEIGHT +
-    yourNextFutureCount * YOUR_NEXT_LEADER_HEIGHT +
-    yourNonNextFutureCount * YOUR_NON_NEXT_FUTURE_HEIGHT
-  );
+export function getHeightSum(counts: Counts) {
+  let sum = 0;
+  for (const [type, count] of Object.entries(counts)) {
+    sum += count * itemHeightByType[type as ItemHeightType];
+  }
+  return sum;
 }
 
 /**
@@ -67,37 +39,24 @@ export function findMinVisibleIdx(
   return lo;
 }
 
-export enum ItemType {
-  Past,
-  Current,
-  Future,
-}
-
-function getItemType(slot: number, currentSlot: number) {
-  if (slot < currentSlot) return ItemType.Past;
-  if (slot === currentSlot) return ItemType.Current;
-  return ItemType.Future;
-}
-
 export interface BaseItemInfo {
   idx: number;
   slot: number;
   bottomOffset: number;
   height: number;
-  type: ItemType;
+  isPast: boolean;
 }
 export interface ItemInfo extends BaseItemInfo {
   topOffset: number;
-  type: ItemType;
 }
 
 export function getItemInfo(
   idx: number | undefined,
+  currentLeaderSlot: number,
   getSlotAtIndex: (idx: number) => number | undefined,
   getIndexTopOffset: (idx: number) => number | undefined,
   getSlotHeight: (slot: number) => number | undefined,
   totalListHeight: number,
-  currentLeaderSlot: number,
 ): ItemInfo | undefined {
   if (idx == null) return;
 
@@ -116,57 +75,222 @@ export function getItemInfo(
     topOffset,
     bottomOffset: totalListHeight - topOffset - height,
     height,
-    type: getItemType(slot, currentLeaderSlot),
+    isPast: slot < currentLeaderSlot,
   };
 }
 
 export function getItemBelowInfo(
   currentItem: ItemInfo,
+  currentLeaderSlot: number,
   getSlotAtIndex: (idx: number) => number | undefined,
   getSlotHeight: (slot: number) => number | undefined,
-  currentLeaderSlot: number,
 ): ItemInfo | undefined {
   const idx = currentItem.idx + 1;
   const slot = getSlotAtIndex(idx);
   if (slot == null) return;
+
   const topOffset = currentItem.topOffset + currentItem.height;
   const height = getSlotHeight(slot);
+
   if (height == null) return;
   const bottomOffset = currentItem.bottomOffset - height;
-
   return {
     idx,
     slot,
     topOffset,
     bottomOffset,
     height,
-    type: getItemType(slot, currentLeaderSlot),
+    isPast: slot < currentLeaderSlot,
   };
 }
 
-export interface OffsetType {
-  offset: number;
-  isBottomOffset: boolean;
-}
+export function getItemAboveInfo(
+  currentItem: ItemInfo,
+  currentLeaderSlot: number,
+  getSlotAtIndex: (idx: number) => number | undefined,
+  getSlotHeight: (slot: number) => number | undefined,
+): ItemInfo | undefined {
+  const idx = currentItem.idx - 1;
+  const slot = getSlotAtIndex(idx);
+  if (slot == null) return;
 
-/**
- * Position past slots are offset from the bottom, and others from the top
- * to minimize position changes when current slot progresses.
- */
-export function getSlotOffsetType(
-  currentSlot: number,
-  slot: number,
-  topOffset: number,
-  totalHeight: number,
-): OffsetType {
-  if (slot < currentSlot) {
-    return {
-      offset: totalHeight - topOffset,
-      isBottomOffset: true,
-    };
-  }
+  const height = getSlotHeight(slot);
+  if (height == null) return;
+
+  const topOffset = currentItem.topOffset - height;
+  const bottomOffset = currentItem.bottomOffset + currentItem.height;
   return {
-    offset: topOffset,
-    isBottomOffset: false,
+    idx,
+    slot,
+    topOffset,
+    bottomOffset,
+    height,
+    isPast: slot < currentLeaderSlot,
   };
 }
+
+export function filterStillVisibleItems(
+  items: ItemInfo[],
+  scrollTop: number,
+  visibleHeight: number,
+) {
+  const visibleTop = scrollTop;
+  const visibleBottom = scrollTop + visibleHeight;
+
+  const stillVisible: ItemInfo[] = [];
+  for (const item of items) {
+    const itemTop = item.topOffset;
+    const itemBottom = item.topOffset + item.height;
+
+    if (itemTop < visibleBottom && itemBottom > visibleTop) {
+      stillVisible.push(item);
+    }
+  }
+  return stillVisible;
+}
+
+export function addVisibleItemsBelow(
+  _nextItem: ItemInfo | undefined,
+  visibleItems: ItemInfo[],
+  endVisibleOffset: number,
+  getItemBelow: (currentItem: ItemInfo) => ItemInfo | undefined,
+) {
+  let nextItem = _nextItem;
+  while (nextItem && nextItem.topOffset < endVisibleOffset) {
+    visibleItems.push(nextItem);
+    nextItem = getItemBelow(nextItem);
+  }
+  return visibleItems;
+}
+
+export function addVisibleItemsAbove(
+  _prevItem: ItemInfo | undefined,
+  visibleItems: ItemInfo[],
+  scrollTop: number,
+  getItemAbove: (currentItem: ItemInfo) => ItemInfo | undefined,
+) {
+  let prevItem = _prevItem;
+  while (prevItem && prevItem.topOffset + prevItem.height >= scrollTop) {
+    visibleItems.unshift(prevItem);
+    prevItem = getItemAbove(prevItem);
+  }
+  return visibleItems;
+}
+
+export function getInitialVisibleItems(
+  scrollTop: number,
+  endVisibleOffset: number,
+  getItemBelow: (currentItem: ItemInfo) => ItemInfo | undefined,
+  getFirstVisibleItem: (scrollTop: number) => ItemInfo | undefined,
+) {
+  const visibleItems: ItemInfo[] = [];
+  const nextItem = getFirstVisibleItem(scrollTop);
+
+  addVisibleItemsBelow(nextItem, visibleItems, endVisibleOffset, getItemBelow);
+  return visibleItems;
+}
+
+export function getOffsetHelpers(
+  listHelpers: SlotsIndexProps["listHelpers"],
+  getIndexForSlot: SlotsIndexProps["getIndexForSlot"],
+  getSlotAtIndex: SlotsIndexProps["getSlotAtIndex"],
+  itemsCount: number,
+) {
+  if (!listHelpers) return;
+
+  const {
+    totalHeight,
+    offsetSnapshotCurrentSlot,
+    yourNextLeaderSlot,
+    getSlotHeight,
+    getIndexTopOffset,
+  } = listHelpers;
+
+  const getPaddedSlotTopOffset = (slot: number) => {
+    const slotIdx = getIndexForSlot(slot);
+    if (slotIdx == null) return;
+
+    const topIdx = Math.max(0, slotIdx - slotsListTopPaddingIndex);
+    return getIndexTopOffset(topIdx);
+  };
+
+  const getPaddedSlotAtOffset = (offset: number) => {
+    const topIdxAtOffset = findMinVisibleIdx(
+      offset,
+      itemsCount,
+      getIndexTopOffset,
+    );
+    if (topIdxAtOffset == null) return;
+
+    const pinnedIdx = Math.min(
+      topIdxAtOffset + slotsListTopPaddingIndex,
+      itemsCount - 1,
+    );
+    return getSlotAtIndex(pinnedIdx);
+  };
+
+  const getMinVisibleIdx = (scrollTop: number) => {
+    return findMinVisibleIdx(scrollTop, itemsCount, getIndexTopOffset);
+  };
+
+  const getFirstVisibleItem = (scrollTop: number) => {
+    const firstIdx = getMinVisibleIdx(scrollTop);
+    return getItemInfo(
+      firstIdx,
+      offsetSnapshotCurrentSlot,
+      getSlotAtIndex,
+      getIndexTopOffset,
+      getSlotHeight,
+      totalHeight,
+    );
+  };
+
+  const getItemBelow = (currentItem: ItemInfo) => {
+    return getItemBelowInfo(
+      currentItem,
+      offsetSnapshotCurrentSlot,
+      getSlotAtIndex,
+      getSlotHeight,
+    );
+  };
+
+  const getItemAbove = (currentItem: ItemInfo) => {
+    return getItemAboveInfo(
+      currentItem,
+      offsetSnapshotCurrentSlot,
+      getSlotAtIndex,
+      getSlotHeight,
+    );
+  };
+
+  const updateItem = (
+    item: ItemInfo,
+    heightDeltaEntries: [slot: number, delta: number][],
+    currentLeaderSlot: number,
+  ) => {
+    item.isPast = item.slot < currentLeaderSlot;
+    for (const [slot, delta] of heightDeltaEntries) {
+      if (slot > item.slot) {
+        item.topOffset += delta;
+      } else if (slot === item.slot) {
+        item.height += delta;
+      } else {
+        item.bottomOffset += delta;
+      }
+    }
+  };
+
+  return {
+    totalHeight,
+    offsetSnapshotCurrentSlot,
+    yourNextLeaderSlot,
+    getPaddedSlotTopOffset,
+    getPaddedSlotAtOffset,
+    getFirstVisibleItem,
+    getItemBelow,
+    getItemAbove,
+    updateItem,
+  };
+}
+
+export type OffsetHelpers = ReturnType<typeof getOffsetHelpers>;


### PR DESCRIPTION
- Create a custom virtual slots list to improve nav performance
- Note: list height changes every time current slot increments. If looking at past slots only, we don't want a visual shift so we adjust the scrollTop manually to see the same items