### PR TITLE
chore: temporarily revert shreds web worker cache use

### DIFF
--- a/src/api/useSetAtomWsData.ts
+++ b/src/api/useSetAtomWsData.ts
@@ -6,10 +6,9 @@ import type {
   FromWorkerMessage,
   HistoryArrayKey,
   KeyedValuesWithHistory,
-  LiveShredsItem,
   WsEntity,
 } from "./worker/types";
-import { isEmaObjectKey, liveShredsKey } from "./worker/types";
+import { isEmaObjectKey } from "./worker/types";
 import { DateTime } from "luxon";
 import { useInterval } from "react-use";
 import { useThrottledCallback, useDebouncedCallback } from "use-debounce";
@@ -36,7 +35,8 @@ import {
   deleteSupermajorityDeltaEntriesAtom,
   resetSupermajorityAtom,
 } from "../atoms";
-import { liveShredsDataAtom } from "../features/Overview/ShredsProgression/atoms";
+import { shredsAtoms } from "../features/Overview/ShredsProgression/atoms";
+import { xRangeMs } from "./worker/cache/shreds/shredsCalc";
 import { rateLiveWaterfallAtom } from "../features/Overview/SlotPerformance/atoms";
 import {
   addTurbineSlotsAtom,
@@ -165,18 +165,6 @@ export function useSetAtomWsData() {
     ],
   );
 
-  const setLiveShreds = useSetAtom(liveShredsDataAtom);
-  const updateLiveShredsObject = useCallback(
-    ({ key, data }: LiveShredsItem) => {
-      switch (key) {
-        case liveShredsKey:
-          setLiveShreds(data);
-          break;
-      }
-    },
-    [setLiveShreds],
-  );
-
   const onMessage = useCallback(
     (msg: FromWorkerMessage) => {
       switch (msg.type) {
@@ -213,20 +201,9 @@ export function useSetAtomWsData() {
             updateEmaHistoryObject(item);
           }
           break;
-        case "liveShredsObject":
-          for (const item of msg.items) {
-            updateLiveShredsObject(item);
-          }
-          break;
       }
     },
-    [
-      setSocketState,
-      updateAtoms,
-      updateHistoryArray,
-      updateEmaHistoryObject,
-      updateLiveShredsObject,
-    ],
+    [setSocketState, updateAtoms, updateHistoryArray, updateEmaHistoryObject],
   );
 
   useServerMessages(onMessage);
@@ -440,6 +417,8 @@ function useUpdateAtoms() {
     optimisticallyConfirmedSlotAtom,
   );
   const setSlotCaughtUp = useSetAtom(slotCaughtUpAtom);
+
+  const addLiveShreds = useSetAtom(shredsAtoms.addShredEvents);
 
   const setLiveProgramCache = useSetAtom(liveProgramCacheAtom);
 
@@ -731,7 +710,7 @@ function useUpdateAtoms() {
               break;
             }
             case "live_shreds": {
-              // processed by web worker
+              addLiveShreds(value);
               break;
             }
             case "late_votes_history": {
@@ -769,6 +748,7 @@ function useUpdateAtoms() {
       }
     },
     [
+      addLiveShreds,
       addRepairSlot,
       addRepairSlots,
       addSkippedClusterSlots,
@@ -861,6 +841,14 @@ function useUpdateAtoms() {
   const isSocketDisconnected =
     useAtomValue(socketStateAtom) === SocketState.Disconnected;
 
+  const deleteLiveShreds = useSetAtom(shredsAtoms.deleteSlots);
+
+  useEffect(() => {
+    if (isSocketDisconnected) {
+      deleteLiveShreds(isSocketDisconnected, isStartup);
+    }
+  }, [deleteLiveShreds, isSocketDisconnected, isStartup]);
+
   const resetTurbineSlots = useSetAtom(resetTurbineSlotsAtom);
   const resetRepairSlots = useSetAtom(resetRepairSlotsAtom);
   useEffect(() => {
@@ -869,6 +857,13 @@ function useUpdateAtoms() {
       resetRepairSlots();
     }
   }, [isStartup, resetRepairSlots, resetTurbineSlots]);
+
+  useInterval(
+    () => {
+      deleteLiveShreds(isSocketDisconnected, isStartup);
+    },
+    isStartup ? 1_000 : xRangeMs / 4,
+  );
 
   const deleteSupermajorityDeltaEntries = useSetAtom(
     deleteSupermajorityDeltaEntriesAtom,

--- a/src/api/worker/cache/consts.ts
+++ b/src/api/worker/cache/consts.ts
@@ -5,5 +5,3 @@ export const gossipHealthHistoryBufferMs = 5_000;
 export const overviewPublishIntervalMs = 500;
 export const overviewRenderWindowMs = 60_000;
 export const overviewHistoryBufferMs = 5_000;
-
-export const shredsPublishIntervalMs = 50;

--- a/src/api/worker/messageHandler.ts
+++ b/src/api/worker/messageHandler.ts
@@ -13,7 +13,6 @@ import {
   overviewPublishIntervalMs,
   overviewRenderWindowMs,
   overviewHistoryBufferMs,
-  shredsPublishIntervalMs,
 } from "./cache/consts";
 import { gossipHealthEmaFields } from "../atoms";
 import {
@@ -22,8 +21,6 @@ import {
   type HistoryArrayKey,
   type WsEntity,
 } from "./types";
-import { createShredsCache } from "./cache/shreds/shredsCache";
-import type { PublisherOptions } from "./cache/batchPublisher";
 
 const gossipHealthEmaOptions: EmaHistoryObjectCacheOptions = {
   halfLifeMs: 5_000,
@@ -42,10 +39,6 @@ const tileTimerOptions: HistoryArrayOptions = {
 const networkMetricsOptions: HistoryArrayOptions = {
   publishIntervalMs: overviewPublishIntervalMs,
   historyWindowMs: overviewRenderWindowMs + overviewHistoryBufferMs,
-};
-
-const liveShredsOptions: PublisherOptions = {
-  publishIntervalMs: shredsPublishIntervalMs,
 };
 
 function isEntry<
@@ -69,23 +62,12 @@ export function createMessageHandler(post: (msg: FromWorkerMessage) => void) {
 
   let validatorState = { ...defaultValidatorState };
 
-  function getValidatorState() {
-    return validatorState;
-  }
-
-  const liveShredsCache = createShredsCache(
-    liveShredsOptions,
-    (items) => post({ type: "liveShredsObject", items }),
-    getValidatorState,
-  );
-
   return {
     onConnectionChange(msg: {
       type: "connected" | "connecting" | "disconnected";
     }): void {
       if (msg.type !== "connected") {
         validatorState = { ...defaultValidatorState };
-        liveShredsCache.resetDataAndUnsubscribe();
       }
       post(msg);
     },
@@ -136,10 +118,6 @@ export function createMessageHandler(post: (msg: FromWorkerMessage) => void) {
       if (isEntry(item, "summary", "live_tile_timers")) {
         historyArrayCache.subscribe("tileTimers", tileTimerOptions);
         historyArrayCache.update("tileTimers", item.value);
-      }
-
-      if (isEntry(item, "slot", "live_shreds")) {
-        liveShredsCache.subscribeAndAdd(item.value);
       }
     },
   };

--- a/src/api/worker/types.ts
+++ b/src/api/worker/types.ts
@@ -60,10 +60,6 @@ export type FromWorkerMessage =
   | {
       type: "emaHistoryObject";
       items: EmaObjectItem<Record<string, number>, string>[];
-    }
-  | {
-      type: "liveShredsObject";
-      items: LiveShredsItem[];
     };
 
 export interface EmaItem {

--- a/src/features/Overview/ShredsProgression/__tests__/atoms.test.tsx
+++ b/src/features/Overview/ShredsProgression/__tests__/atoms.test.tsx
@@ -1,0 +1,575 @@
+import { expect, describe, it, afterEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { createLiveShredsAtoms } from "../atoms";
+import { Provider } from "jotai";
+import type { PropsWithChildren } from "react";
+import { ShredEvent } from "../../../../api/entities";
+import {
+  xRangeMs,
+  delayMs,
+} from "../../../../api/worker/cache/shreds/shredsCalc";
+import { nsPerMs } from "../../../../consts";
+
+const emptyStoreWrapper = ({ children }: PropsWithChildren) => (
+  <Provider>{children}</Provider>
+);
+
+describe("live shreds atoms with reference ts and ts deltas", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("adds live shred events for single shred, replacing duplicates with min ts and ignoring unsupported event types", () => {
+    const atoms = createLiveShredsAtoms();
+
+    const { result } = renderHook(
+      () => {
+        const slotsShreds = useAtomValue(atoms.slotsShreds);
+        const range = useAtomValue(atoms.range);
+        const addShredEvents = useSetAtom(atoms.addShredEvents);
+        return { slotsShreds, range, addShredEvents };
+      },
+      { wrapper: emptyStoreWrapper },
+    );
+
+    // initial state
+    expect(result.current.slotsShreds).toBeUndefined();
+    expect(result.current.range).toBeUndefined();
+
+    // add initial shreds
+    act(() => {
+      result.current.addShredEvents({
+        reference_slot: 2000,
+        reference_ts: 123_000_000n,
+        slot_delta: [3, 3, 3, 3, 3, 3, 3],
+        shred_idx: [2, null, 2, 2, null, 2, 1],
+        event: [
+          ShredEvent.shred_received_repair,
+          ShredEvent.slot_complete,
+          ShredEvent.shred_repair_request,
+          ShredEvent.shred_repair_request,
+          ShredEvent.slot_complete,
+          ShredEvent.shred_replayed,
+          99999, // unsupported event type
+        ],
+        event_ts_delta: [
+          2_000_030, 4_123_456, 5_678_234, 8_000_000, 3_234_123, 7_345_456,
+        ],
+      });
+    });
+
+    expect(result.current.slotsShreds).toEqual({
+      referenceTs: 123,
+      slots: new Map([
+        [
+          2003,
+          {
+            minEventTsDelta: 2,
+            maxEventTsDelta: 8,
+            completionTsDelta: 3,
+            shreds: [undefined, undefined, [6, undefined, 2, 7]],
+          },
+        ],
+      ]),
+    });
+    expect(result.current.range).toEqual({
+      min: 2003,
+      max: 2003,
+    });
+
+    act(() => {
+      result.current.addShredEvents({
+        reference_slot: 2002,
+        reference_ts: 124_100_000n,
+        slot_delta: [1, 0, 1],
+        shred_idx: [2, 1, 2],
+        event: [
+          ShredEvent.shred_repair_request,
+          ShredEvent.shred_received_turbine,
+          ShredEvent.shred_replayed,
+        ],
+        event_ts_delta: [1_000_030, 5_123_345, 2_345_231],
+      });
+    });
+
+    // uses inital reference ts
+    // update shred events with min ts
+    expect(result.current.slotsShreds).toEqual({
+      referenceTs: 123,
+      slots: new Map([
+        [
+          2002,
+          {
+            minEventTsDelta: 6,
+            maxEventTsDelta: 6,
+            shreds: [undefined, [undefined, 6]],
+          },
+        ],
+        [
+          2003,
+          {
+            minEventTsDelta: 2,
+            maxEventTsDelta: 8,
+            completionTsDelta: 3,
+            shreds: [undefined, undefined, [2, undefined, 2, 3]],
+          },
+        ],
+      ]),
+    });
+    expect(result.current.range).toEqual({
+      min: 2002,
+      max: 2003,
+    });
+  });
+
+  it("keeps track of min completed slot number when multiple slots are completed in one received ws message", () => {
+    const atoms = createLiveShredsAtoms();
+
+    const { result } = renderHook(
+      () => {
+        const slotsShreds = useAtomValue(atoms.slotsShreds);
+        const range = useAtomValue(atoms.range);
+        const addShredEvents = useSetAtom(atoms.addShredEvents);
+        const minCompletedSlot = useAtomValue(atoms.minCompletedSlot);
+        return { slotsShreds, range, addShredEvents, minCompletedSlot };
+      },
+      { wrapper: emptyStoreWrapper },
+    );
+
+    // initial state
+    expect(result.current.slotsShreds).toBeUndefined();
+    expect(result.current.range).toBeUndefined();
+    expect(result.current.minCompletedSlot).toBeUndefined();
+
+    // add initial shreds
+    act(() => {
+      result.current.addShredEvents({
+        reference_slot: 2000,
+        reference_ts: 123_000_000n,
+        slot_delta: [3, 3, 4, 4],
+        shred_idx: [2, null, 1, null],
+        event: [
+          ShredEvent.shred_received_turbine,
+          ShredEvent.slot_complete,
+          ShredEvent.shred_received_turbine,
+          ShredEvent.slot_complete,
+        ],
+        event_ts_delta: [2_000_030, 4_123_456, 5_678_234, 8_000_000],
+      });
+    });
+
+    expect(result.current.slotsShreds).toEqual({
+      referenceTs: 123,
+      slots: new Map([
+        [
+          2003,
+          {
+            minEventTsDelta: 2,
+            maxEventTsDelta: 4,
+            completionTsDelta: 4,
+            shreds: [undefined, undefined, [undefined, 2]],
+          },
+        ],
+        [
+          2004,
+          {
+            minEventTsDelta: 6,
+            maxEventTsDelta: 8,
+            completionTsDelta: 8,
+            shreds: [undefined, [undefined, 6]],
+          },
+        ],
+      ]),
+    });
+    expect(result.current.range).toEqual({
+      min: 2003,
+      max: 2004,
+    });
+
+    expect(result.current.minCompletedSlot).toBe(2003);
+
+    act(() => {
+      result.current.addShredEvents({
+        reference_slot: 2002,
+        reference_ts: 124_100_000n,
+        slot_delta: [0, 0],
+        shred_idx: [0, null],
+        event: [ShredEvent.shred_received_turbine, ShredEvent.slot_complete],
+        event_ts_delta: [1_000_030, 2_123_345],
+      });
+    });
+
+    expect(result.current.slotsShreds).toEqual({
+      referenceTs: 123,
+      slots: new Map([
+        [
+          2002,
+          {
+            minEventTsDelta: 2,
+            maxEventTsDelta: 3,
+            completionTsDelta: 3,
+            shreds: [[undefined, 2]],
+          },
+        ],
+        [
+          2003,
+          {
+            minEventTsDelta: 2,
+            maxEventTsDelta: 4,
+            completionTsDelta: 4,
+            shreds: [undefined, undefined, [undefined, 2]],
+          },
+        ],
+        [
+          2004,
+          {
+            minEventTsDelta: 6,
+            maxEventTsDelta: 8,
+            completionTsDelta: 8,
+            shreds: [undefined, [undefined, 6]],
+          },
+        ],
+      ]),
+    });
+    expect(result.current.range).toEqual({
+      min: 2002,
+      max: 2004,
+    });
+
+    expect(result.current.minCompletedSlot).toBe(2002);
+  });
+
+  it("for non-startup: deletes slot numbers before max completed slot number that was completed before chart min X", () => {
+    vi.useFakeTimers({
+      toFake: ["Date"],
+    });
+    const chartRangeMs = xRangeMs + delayMs;
+    const date = new Date(chartRangeMs);
+    vi.setSystemTime(date);
+
+    const atoms = createLiveShredsAtoms();
+
+    const { result } = renderHook(
+      () => {
+        const slotsShreds = useAtomValue(atoms.slotsShreds);
+        const range = useAtomValue(atoms.range);
+        const addShredEvents = useSetAtom(atoms.addShredEvents);
+        const deleteSlots = useSetAtom(atoms.deleteSlots);
+        return {
+          slotsShreds,
+          range,
+          addShredEvents,
+          deleteSlots,
+        };
+      },
+      { wrapper: emptyStoreWrapper },
+    );
+
+    const events = [
+      {
+        slot: 0,
+        ts: -nsPerMs,
+        e: ShredEvent.shred_repair_request,
+      },
+      {
+        slot: 1,
+        ts: nsPerMs,
+        e: ShredEvent.slot_complete,
+      },
+      {
+        slot: 2,
+        // this will be deleted even if it has an event in chart range,
+        // because a slot number larger than it is marked as completed and before chart min x
+        ts: nsPerMs,
+        e: ShredEvent.shred_repair_request,
+      },
+      {
+        // max slot number that is complete before chart min X
+        // keep this and delete all slot numbers before it
+        slot: 3,
+        ts: -nsPerMs,
+        e: ShredEvent.slot_complete,
+      },
+      {
+        slot: 4,
+        // threshold of not being deleted
+        ts: 0,
+        e: ShredEvent.slot_complete,
+      },
+      {
+        slot: 6,
+        ts: 2 * nsPerMs,
+        e: ShredEvent.shred_repair_request,
+      },
+    ];
+
+    // add initial shreds
+    act(() => {
+      result.current.addShredEvents({
+        reference_slot: 0,
+        reference_ts: 0n,
+        slot_delta: Object.values(events).map((v) => v.slot),
+        shred_idx: Object.values(events).map((v) => 0),
+        event: Object.values(events).map((v) => v.e),
+        event_ts_delta: Object.values(events).map((v) => v.ts),
+      });
+    });
+
+    expect(result.current.slotsShreds).toEqual({
+      referenceTs: 0,
+      slots: new Map([
+        [0, { shreds: [[-1]], minEventTsDelta: -1, maxEventTsDelta: -1 }],
+        [
+          1,
+          {
+            shreds: [],
+            minEventTsDelta: 1,
+            maxEventTsDelta: 1,
+            completionTsDelta: 1,
+          },
+        ],
+        [2, { shreds: [[1]], minEventTsDelta: 1, maxEventTsDelta: 1 }],
+        [
+          3,
+          {
+            shreds: [],
+            minEventTsDelta: -1,
+            maxEventTsDelta: -1,
+            completionTsDelta: -1,
+          },
+        ],
+        [
+          4,
+          {
+            shreds: [],
+            minEventTsDelta: 0,
+            maxEventTsDelta: 0,
+            completionTsDelta: 0,
+          },
+        ],
+        [
+          6,
+          {
+            shreds: [[2]],
+            minEventTsDelta: 2,
+            maxEventTsDelta: 2,
+          },
+        ],
+      ]),
+    });
+    expect(result.current.range).toEqual({
+      min: 0,
+      max: 6,
+    });
+
+    // delete old slots
+    act(() => {
+      result.current.deleteSlots(false, false);
+    });
+
+    expect(result.current.slotsShreds).toEqual({
+      referenceTs: 0,
+      slots: new Map([
+        [
+          3,
+          {
+            shreds: [],
+            minEventTsDelta: -1,
+            maxEventTsDelta: -1,
+            completionTsDelta: -1,
+          },
+        ],
+        [
+          4,
+          {
+            shreds: [],
+            minEventTsDelta: 0,
+            maxEventTsDelta: 0,
+            completionTsDelta: 0,
+          },
+        ],
+        [
+          6,
+          {
+            shreds: [[2]],
+            minEventTsDelta: 2,
+            maxEventTsDelta: 2,
+          },
+        ],
+      ]),
+    });
+    expect(result.current.range).toEqual({
+      min: 3,
+      max: 6,
+    });
+
+    // delete all
+    act(() => {
+      result.current.deleteSlots(true, false);
+    });
+
+    expect(result.current.slotsShreds).toBeUndefined();
+    expect(result.current.range).toBeUndefined();
+  });
+
+  it("for startup: deletes slots with events before chart x range", () => {
+    vi.useFakeTimers({
+      toFake: ["Date"],
+    });
+    const chartRangeMs = xRangeMs + delayMs;
+    const date = new Date(chartRangeMs);
+    vi.setSystemTime(date);
+
+    const atoms = createLiveShredsAtoms();
+
+    const { result } = renderHook(
+      () => {
+        const slotsShreds = useAtomValue(atoms.slotsShreds);
+        const range = useAtomValue(atoms.range);
+        const addShredEvents = useSetAtom(atoms.addShredEvents);
+        const deleteSlots = useSetAtom(atoms.deleteSlots);
+        return {
+          slotsShreds,
+          range,
+          addShredEvents,
+          deleteSlots,
+        };
+      },
+      { wrapper: emptyStoreWrapper },
+    );
+
+    const events = [
+      {
+        slot: 0,
+        // deleted
+        ts: -nsPerMs,
+        e: ShredEvent.shred_repair_request,
+      },
+      {
+        slot: 1,
+        // not deleted
+        ts: nsPerMs,
+        e: ShredEvent.slot_complete,
+      },
+      {
+        slot: 2,
+        // not deleted
+        ts: nsPerMs,
+        e: ShredEvent.shred_repair_request,
+      },
+      {
+        // deleted
+        slot: 3,
+        ts: -nsPerMs,
+        e: ShredEvent.slot_complete,
+      },
+      {
+        slot: 4,
+        // threshold of not being deleted
+        ts: 0,
+        e: ShredEvent.slot_complete,
+      },
+    ];
+
+    // add initial shreds
+    act(() => {
+      result.current.addShredEvents({
+        reference_slot: 0,
+        reference_ts: 0n,
+        slot_delta: Object.values(events).map((v) => v.slot),
+        shred_idx: Object.values(events).map((v) => 0),
+        event: Object.values(events).map((v) => v.e),
+        event_ts_delta: Object.values(events).map((v) => v.ts),
+      });
+    });
+
+    expect(result.current.slotsShreds).toEqual({
+      referenceTs: 0,
+      slots: new Map([
+        [0, { shreds: [[-1]], minEventTsDelta: -1, maxEventTsDelta: -1 }],
+        [
+          1,
+          {
+            shreds: [],
+            minEventTsDelta: 1,
+            maxEventTsDelta: 1,
+            completionTsDelta: 1,
+          },
+        ],
+        [2, { shreds: [[1]], minEventTsDelta: 1, maxEventTsDelta: 1 }],
+        [
+          3,
+          {
+            shreds: [],
+            minEventTsDelta: -1,
+            maxEventTsDelta: -1,
+            completionTsDelta: -1,
+          },
+        ],
+        [
+          4,
+          {
+            shreds: [],
+            minEventTsDelta: 0,
+            maxEventTsDelta: 0,
+            completionTsDelta: 0,
+          },
+        ],
+      ]),
+    });
+    expect(result.current.range).toEqual({
+      min: 0,
+      max: 4,
+    });
+
+    // delete old slots
+    act(() => {
+      result.current.deleteSlots(false, true);
+    });
+
+    expect(result.current.slotsShreds).toEqual({
+      referenceTs: 0,
+      slots: new Map([
+        [
+          1,
+          {
+            shreds: [],
+            minEventTsDelta: 1,
+            maxEventTsDelta: 1,
+            completionTsDelta: 1,
+          },
+        ],
+        [
+          2,
+          {
+            shreds: [[1]],
+            minEventTsDelta: 1,
+            maxEventTsDelta: 1,
+          },
+        ],
+        [
+          4,
+          {
+            shreds: [],
+            minEventTsDelta: 0,
+            maxEventTsDelta: 0,
+            completionTsDelta: 0,
+          },
+        ],
+      ]),
+    });
+    expect(result.current.range).toEqual({
+      min: 1,
+      max: 4,
+    });
+
+    // delete all
+    act(() => {
+      result.current.deleteSlots(true, true);
+    });
+
+    expect(result.current.slotsShreds).toBeUndefined();
+    expect(result.current.range).toBeUndefined();
+  });
+});

--- a/src/features/Overview/ShredsProgression/atoms.ts
+++ b/src/features/Overview/ShredsProgression/atoms.ts
@@ -1,23 +1,289 @@
 import { atom } from "jotai";
+import type { LiveShreds } from "../../../api/types";
+import { ShredEvent } from "../../../api/entities";
+import { delayMs, xRangeMs } from "../../../api/worker/cache/shreds/shredsCalc";
+import { nsPerMs, slotsPerLeader } from "../../../consts";
 import { getSlotGroupLeader } from "../../../utils";
+import { serverTimeMsAtom } from "../../../atoms";
 import { slotCaughtUpAtom } from "../../../api/atoms";
-import type { LiveShredsData } from "../../../api/worker/cache/shreds/types";
 
-export const liveShredsDataAtom = atom<LiveShredsData>();
+type ShredEventTsDeltaMs = number | undefined;
+/**
+ * Array of <event ts delta in ms>.
+ * Array index, i corresponds to the shred event type.
+ * The ts delta is relative to the referenceTs.
+ */
+export type ShredEventTsDeltas = ShredEventTsDeltaMs[];
 
-export const liveShredsPostStartupRangeAtom = atom((get) => {
-  const range = get(liveShredsDataAtom)?.range;
-  const slotCaughtUp = get(slotCaughtUpAtom);
-  if (!range || slotCaughtUp == null) return;
+export type Slot = {
+  shreds: (ShredEventTsDeltas | undefined)[];
+  /**
+   * earliest event (start) of the slot
+   */
+  minEventTsDelta?: number;
+  maxEventTsDelta?: number;
+  completionTsDelta?: number;
+};
 
-  // no slots after startup
-  if (slotCaughtUp + 1 > range.max) return;
+export type SlotsShreds = {
+  referenceTs: number;
+  // slot number to Slot
+  slots: Map<number, Slot>;
+};
 
+export interface LiveShredsData {
+  minCompletedSlot?: number;
+  range?: { min: number; max: number };
+  slotsShreds?: SlotsShreds;
+}
+
+/**
+ * Store live shreds
+ * Use reference / delta slot number and timestamp to minimize memory usage
+ */
+export function createLiveShredsAtoms() {
+  const _minCompletedSlotAtom = atom<number>();
+  const _liveShredsAtom = atom<SlotsShreds>();
+  const _slotRangeAtom = atom<{
+    min: number;
+    max: number;
+  }>();
+  const rangeAfterStartupAtom = atom((get) => {
+    const range = get(_slotRangeAtom);
+    const slotCaughtUp = get(slotCaughtUpAtom);
+    if (!range || slotCaughtUp == null) return;
+
+    // no slots after startup
+    if (slotCaughtUp + 1 > range.max) return;
+
+    return {
+      min: Math.max(slotCaughtUp + 1, range.min),
+      max: range.max,
+    };
+  });
   return {
-    min: Math.max(slotCaughtUp + 1, range.min),
-    max: range.max,
+    /**
+     * min completed slot we've seen since we started collecting data
+     */
+    minCompletedSlot: atom((get) => get(_minCompletedSlotAtom)),
+    range: atom((get) => get(_slotRangeAtom)),
+    rangeAfterStartup: rangeAfterStartupAtom,
+    /**
+     *  leader slots after startup, used for labels
+     * */
+    groupLeaderSlots: atom((get) => {
+      const rangeAfterStartup = get(rangeAfterStartupAtom);
+      if (!rangeAfterStartup) return [];
+
+      const slots = [getSlotGroupLeader(rangeAfterStartup.min)];
+      while (
+        slots[slots.length - 1] + slotsPerLeader - 1 <
+        rangeAfterStartup.max
+      ) {
+        slots.push(
+          getSlotGroupLeader(slots[slots.length - 1] + slotsPerLeader),
+        );
+      }
+      return slots;
+    }),
+    slotsShreds: atom((get) => get(_liveShredsAtom)),
+    addShredEvents: atom(
+      null,
+      (
+        get,
+        set,
+        {
+          reference_slot,
+          reference_ts,
+          slot_delta,
+          shred_idx,
+          event,
+          event_ts_delta,
+        }: LiveShreds,
+      ) => {
+        let slotRange = get(_slotRangeAtom);
+        const minCompletedSlot = get(_minCompletedSlotAtom);
+        let newMinCompletedSlot = minCompletedSlot;
+
+        set(_liveShredsAtom, (prev) => {
+          const updated: SlotsShreds = prev ?? {
+            referenceTs: Math.round(Number(reference_ts) / nsPerMs),
+            slots: new Map(),
+          };
+
+          for (let i = 0; i < event.length; i++) {
+            const ev = event[i];
+            // unsupported event type
+            if (!(ev in ShredEvent)) {
+              console.debug(`received unsupported shred event type ${ev}`);
+              continue;
+            }
+
+            if (slot_delta[i] == null || event_ts_delta[i] == null) {
+              console.error(`invalid shred data arrays, missing index ${i}`);
+              break;
+            }
+
+            const slotNumber = reference_slot + slot_delta[i];
+            const shredIdx = shred_idx[i];
+
+            // convert to current reference and delta
+            const eventTsDelta = Math.round(
+              (Number(reference_ts) + event_ts_delta[i]) / nsPerMs -
+                updated.referenceTs,
+            );
+
+            // add event to slot shred
+            updated.slots.set(
+              slotNumber,
+              addEventToSlot(
+                shredIdx,
+                ev,
+                eventTsDelta,
+                updated.slots.get(slotNumber),
+              ),
+            );
+
+            if (ev === ShredEvent.slot_complete) {
+              newMinCompletedSlot = Math.min(
+                slotNumber,
+                newMinCompletedSlot ?? slotNumber,
+              );
+            }
+
+            // update range
+            slotRange = {
+              min: Math.min(slotNumber, slotRange?.min ?? slotNumber),
+              max: Math.max(slotNumber, slotRange?.max ?? slotNumber),
+            };
+          }
+
+          return updated;
+        });
+
+        set(_slotRangeAtom, slotRange);
+        set(_minCompletedSlotAtom, newMinCompletedSlot);
+      },
+    ),
+
+    deleteSlots:
+      /**
+       * Delete slots that completed before the chart x-axis starting time, or with dots outside visible x range
+       * Update the min slot
+       */
+      atom(null, (get, set, deleteAll: boolean, isStartup: boolean) => {
+        if (deleteAll) {
+          set(_slotRangeAtom, undefined);
+          set(_minCompletedSlotAtom, undefined);
+          set(_liveShredsAtom, undefined);
+          return;
+        }
+
+        set(_liveShredsAtom, (prev) => {
+          const slotRange = get(_slotRangeAtom);
+          const now = get(serverTimeMsAtom) ?? Date.now();
+
+          if (!prev || !slotRange) return prev;
+
+          if (isStartup) {
+            // During startup, we only show event dots, not spans. Delete slots without events in chart view
+            for (
+              let slotNumber = slotRange.min;
+              slotNumber <= slotRange.max;
+              slotNumber++
+            ) {
+              const slot = prev.slots.get(slotNumber);
+              if (!slot) continue;
+              if (
+                slot.maxEventTsDelta == null ||
+                isBeforeChartX(slot.maxEventTsDelta, now, prev.referenceTs)
+              ) {
+                prev.slots.delete(slotNumber);
+              }
+            }
+          } else {
+            // After startup complete
+            let minSlot = slotRange.min;
+            const countToKeep = 50;
+            if (slotRange.max - slotRange.min > countToKeep) {
+              // only keep countToKeep slots
+              for (
+                let slotNumber = minSlot;
+                slotNumber <= slotRange.max - countToKeep;
+                slotNumber++
+              ) {
+                const slot = prev.slots.get(slotNumber);
+                if (!slot) continue;
+                prev.slots.delete(slotNumber);
+              }
+
+              minSlot = slotRange.max - countToKeep + 1;
+            }
+
+            let shouldDeleteSlot = false;
+            for (
+              let slotNumber = slotRange.max;
+              slotNumber >= minSlot;
+              slotNumber--
+            ) {
+              const slot = prev.slots.get(slotNumber);
+              if (slot?.maxEventTsDelta == null) continue;
+
+              if (
+                !shouldDeleteSlot &&
+                slot.completionTsDelta != null &&
+                isBeforeChartX(slot.completionTsDelta, now, prev.referenceTs)
+              ) {
+                // once we find a slot that is complete and far enough in the past,
+                // delete all slot numbers less it but keep this one for label spacing reference
+                shouldDeleteSlot = true;
+                continue;
+              }
+
+              if (shouldDeleteSlot) {
+                prev.slots.delete(slotNumber);
+              }
+            }
+          }
+
+          // update range to reflect remaining slots
+          const remainingSlotNumbers = prev.slots.keys();
+          set(_slotRangeAtom, (prevRange) => {
+            if (!prevRange || !prev.slots.size) {
+              return;
+            }
+            return {
+              min: Math.min(...remainingSlotNumbers),
+              max: prevRange.max,
+            };
+          });
+
+          return prev;
+        });
+      }),
   };
-});
+}
+
+function isBeforeChartX(tsDelta: number, now: number, referenceTs: number) {
+  const nowDelta = now - referenceTs;
+  const chartXRange = xRangeMs + delayMs;
+  return nowDelta - tsDelta > chartXRange;
+}
+
+export const shredsAtoms = createLiveShredsAtoms();
+
+/**
+ * Live shreds data assembled from the main-thread atoms
+ */
+export const liveShredsDataAtom = atom<LiveShredsData>((get) => ({
+  slotsShreds: get(shredsAtoms.slotsShreds),
+  range: get(shredsAtoms.range),
+  minCompletedSlot: get(shredsAtoms.minCompletedSlot),
+}));
+
+export const liveShredsPostStartupRangeAtom = atom((get) =>
+  get(shredsAtoms.rangeAfterStartup),
+);
 
 /**
  *  leader slots after startup, used for labels
@@ -31,3 +297,67 @@ export const liveShredsPostStartupLeaderSlotsAtom = atom((get) => {
     max: getSlotGroupLeader(rangeAfterStartup.max),
   };
 });
+
+/**
+ * Mutate shred by adding an event ts to event index
+ */
+function addEventToShred(
+  event: Exclude<ShredEvent, ShredEvent.slot_complete>,
+  eventTsDelta: number,
+  shredToMutate: ShredEventTsDeltas | undefined,
+): ShredEventTsDeltas {
+  const shred = shredToMutate ?? new Array<ShredEventTsDeltaMs>();
+
+  // in case of duplicate events, keep the min ts
+  shred[event] = Math.min(eventTsDelta, shred[event] ?? eventTsDelta);
+
+  return shred;
+}
+
+/**
+ * Mutate slot by marking as complete, or adding an event to the shreds array
+ */
+function addEventToSlot(
+  shredIdx: number | null,
+  event: ShredEvent,
+  eventTsDelta: number,
+  slotToMutate: Slot | undefined,
+): Slot {
+  const slot = slotToMutate ?? {
+    shreds: [],
+  };
+
+  // update slot min event ts
+  slot.minEventTsDelta = Math.min(
+    eventTsDelta,
+    slot.minEventTsDelta ?? eventTsDelta,
+  );
+
+  // update slot max event ts
+  slot.maxEventTsDelta = Math.max(
+    eventTsDelta,
+    slot.maxEventTsDelta ?? eventTsDelta,
+  );
+
+  if (event === ShredEvent.slot_complete) {
+    slot.completionTsDelta = Math.min(
+      eventTsDelta,
+      slot.completionTsDelta ?? eventTsDelta,
+    );
+    return slot;
+  }
+
+  if (shredIdx == null) {
+    console.error("Missing shred ID");
+    return slot;
+  }
+
+  // update shred
+  slot.shreds[shredIdx] = addEventToShred(
+    event,
+    eventTsDelta,
+    slot.shreds[shredIdx],
+  );
+
+  return slot;
+}

--- a/src/features/Overview/ShredsProgression/shredsProgressionPlugin.ts
+++ b/src/features/Overview/ShredsProgression/shredsProgressionPlugin.ts
@@ -30,10 +30,7 @@ import styles from "./shreds.module.css";
 
 import { slotsPerLeader } from "../../../consts";
 import { delayMs } from "../../../api/worker/cache/shreds/shredsCalc";
-import type {
-  SlotsShreds,
-  ShredEventTsDeltas,
-} from "../../../api/worker/cache/shreds/types";
+import type { SlotsShreds, ShredEventTsDeltas } from "./atoms";
 
 const store = getDefaultStore();
 


### PR DESCRIPTION
- Temp change to reduce CPU usage from transferring entire shreds state
- The original plan was to move shreds grouping logic, etc to the web worker too. But that is paused with the WebGL exploration
- Eventually we'll add this back with some other optimization