### PR TITLE
fix: tiles table sample rates

### DIFF
--- a/src/api/atoms.ts
+++ b/src/api/atoms.ts
@@ -119,7 +119,7 @@ export const liveTilePrimaryMetricAtom = atom<
   LiveTilePrimaryMetric | undefined
 >(undefined);
 
-export const liveTileMetricsAtom = atom<TileMetrics | undefined>(undefined);
+export const liveTileMetricsAtom = rafAtom<TileMetrics | undefined>(undefined);
 
 export const tileTimerAtom = atom<number[] | undefined>(undefined);
 

--- a/src/api/consts.ts
+++ b/src/api/consts.ts
@@ -1,6 +1,6 @@
 export const estimatedTpsDebounceMs = 400;
 export const liveMetricsDebounceMs = 100;
-export const liveTileMetricsDebounceMs = 130;
+export const liveTileMetricsDebounceMs = 25;
 export const liveNetworkMetricsDebounceMs = 100;
 export const waterfallDebounceMs = 100;
 export const tileTimerDebounceMs = 25;

--- a/src/features/Overview/LiveTileMetrics/DataRow.tsx
+++ b/src/features/Overview/LiveTileMetrics/DataRow.tsx
@@ -289,7 +289,7 @@ interface UtilizationProps {
   idx: number;
 }
 
-const updateIntervalMs = 300;
+const liveTileMetricsSparklineDebounceMs = 300;
 
 const timerToPct = (tileTimer: number | null | undefined) =>
   tileTimer != null && tileTimer >= 0 ? 1 - Math.max(0, tileTimer) : -1;
@@ -338,7 +338,7 @@ const MUtilization = memo(function Utilization({ idx }: UtilizationProps) {
 
     setAvgValue(rollingSum.current.sum / rollingSum.current.count);
     rollingSum.current = { count: 0, sum: 0 };
-  }, updateIntervalMs);
+  }, liveTileMetricsSparklineDebounceMs);
 
   const initialHistory = useMemo(
     () =>
@@ -372,7 +372,7 @@ const MUtilization = memo(function Utilization({ idx }: UtilizationProps) {
           background={tileChartDarkBackground}
           windowMs={60_000}
           height={chartHeight}
-          updateIntervalMs={updateIntervalMs}
+          updateIntervalMs={liveTileMetricsSparklineDebounceMs}
           tickMs={1_000}
         />
       </Table.Cell>


### PR DESCRIPTION
- increase sample rate for overview tiles table data (live tile metrics), to match the bars (tiles timers)
- NOTE: does not update sparklines sample rate