### PR TITLE
chore: sync live metric tiles pinned row with data row updates

### DIFF
--- a/src/features/Overview/LiveTileMetrics/DataRow.tsx
+++ b/src/features/Overview/LiveTileMetrics/DataRow.tsx
@@ -5,6 +5,7 @@ import {
   tileTimerValueAtomFamily,
   type TileRowMetrics,
 } from "./atoms";
+import { type WriteEl, useRowState, writeRow } from "./utils";
 import { Flex, Table, Text } from "@radix-ui/themes";
 import tableStyles from "../../../components/dataTable.module.css";
 import { Bars } from "../../StartupProgress/Firedancer/Bars";
@@ -28,46 +29,14 @@ import { PriorityEnum } from "../../../api/entities";
 
 const store = getDefaultStore();
 
-/**
- * Each component subscribes to the relevant state in the Jotai store.
- * This allows for fine-grained updates without re-rendering through react.
- */
-
-type CellWrite<E extends HTMLElement> = (
-  el: E,
-  cur: TileRowMetrics | undefined,
-  prev: TileRowMetrics | undefined,
-) => void;
-
-function useStateCell<E extends HTMLElement>(
-  idx: number,
-  ref: { current: E | null },
-  write: CellWrite<E>,
-) {
-  useLayoutEffect(() => {
-    const rowAtom = liveTileRowAtomFamily(idx);
-    let prev = store.get(rowAtom);
-
-    const handleUpdate = () => {
-      const cur = store.get(rowAtom);
-      if (ref.current) write(ref.current, cur, prev);
-      prev = cur;
-    };
-
-    const unsub = store.sub(rowAtom, handleUpdate);
-    handleUpdate();
-    return unsub;
-  }, [idx, ref, write]);
-}
-
 interface LiveCellProps {
   idx: number;
-  write: CellWrite<HTMLTableCellElement>;
+  write: WriteEl<HTMLTableCellElement>;
 }
 
 function LiveCell({ idx, write, ...cellProps }: LiveCellProps & CellProps) {
   const ref = useRef<HTMLTableCellElement>(null);
-  useStateCell(idx, ref, write);
+  useRowState(idx, ref, write);
   return <Table.Cell ref={ref} {...cellProps} />;
 }
 
@@ -85,68 +54,59 @@ const priorityLabels: Record<Priority, string> = {
   critical: "Critical",
 };
 
-const writeCpu: CellWrite<HTMLTableCellElement> = (el, c, p) => {
+const writeCpu: WriteEl<HTMLTableCellElement> = (el, c, p) => {
   el.textContent = `${c?.last_cpu ?? p?.last_cpu ?? ""}`;
 };
 
-const writeAlive: CellWrite<HTMLTableCellElement> = (el, c, p) => {
+const writeAlive: WriteEl<HTMLTableCellElement> = (el, c, p) => {
   const alive = c?.alive ?? p?.alive;
   el.textContent = alive ? "Live" : "Dead";
   el.classList.toggle(tableStyles.green, !!alive);
   el.classList.toggle(tableStyles.red, !alive);
 };
 
-const writePriority: CellWrite<HTMLTableCellElement> = (el, c, p) => {
+const writePriority: WriteEl<HTMLTableCellElement> = (el, c, p) => {
   const priority = c?.priority ?? p?.priority;
   el.textContent = priority ? priorityLabels[priority] : "-";
   el.classList.toggle(tableStyles.critical, priority === PriorityEnum.critical);
 };
 
-const writeInBackp: CellWrite<HTMLTableCellElement> = (el, c, p) => {
+const writeInBackp: WriteEl<HTMLTableCellElement> = (el, c, p) => {
   const inBackp = c?.in_backp ?? p?.in_backp;
   el.textContent = inBackp ? "Yes" : "-";
   el.classList.toggle(tableStyles.red, !!inBackp);
 };
 
-const writeHKeep: CellWrite<HTMLTableCellElement> = (el, c, p) => {
+const writeHKeep: WriteEl<HTMLTableCellElement> = (el, c, p) => {
   const t = normTimers(c, p);
   const v = t[0] + t[1] + t[2];
   el.textContent = pctText(v);
   el.classList.toggle(tableStyles.red, v > 1);
 };
 
-const writeWait: CellWrite<HTMLTableCellElement> = (el, c, p) => {
+const writeWait: WriteEl<HTMLTableCellElement> = (el, c, p) => {
   el.textContent = pctText(normTimers(c, p)[6]);
 };
 
-const writeBackpPct: CellWrite<HTMLTableCellElement> = (el, c, p) => {
+const writeBackpPct: WriteEl<HTMLTableCellElement> = (el, c, p) => {
   const v = normTimers(c, p)[5];
   el.textContent = pctText(v);
   el.classList.toggle(tableStyles.red, v > 0);
 };
 
-const writeWork: CellWrite<HTMLTableCellElement> = (el, c, p) => {
+const writeWork: WriteEl<HTMLTableCellElement> = (el, c, p) => {
   const t = normTimers(c, p);
   const v = t[3] + t[4] + t[7];
   el.textContent = pctText(v);
   el.style.setProperty("--pct", `${v}%`);
 };
 
-const writeMinflt: CellWrite<HTMLTableCellElement> = (el, c, p) => {
+const writeMinflt: WriteEl<HTMLTableCellElement> = (el, c, p) => {
   el.textContent = (c?.minflt ?? p?.minflt)?.toLocaleString() ?? "-";
 };
 
-const writeMajflt: CellWrite<HTMLTableCellElement> = (el, c, p) => {
+const writeMajflt: WriteEl<HTMLTableCellElement> = (el, c, p) => {
   el.textContent = (c?.majflt ?? p?.majflt)?.toLocaleString() ?? "-";
-};
-
-// alive === 2 (shutdown) or no timers -> row hidden.
-const writeRow: CellWrite<HTMLTableRowElement> = (el, c, p) => {
-  const alive = c?.alive ?? p?.alive;
-  const hasTimers = !!(c?.timers || p?.timers);
-  const priority = c?.priority ?? p?.priority;
-  el.style.display = alive === 2 || !hasTimers ? "none" : "";
-  el.classList.toggle(tableStyles.faded, priority === PriorityEnum.floating);
 };
 
 type RowPick = (row: TileRowMetrics | undefined) => number | null | undefined;
@@ -386,7 +346,7 @@ interface DataRowProps {
 
 export const DataRow = memo(function DataRow({ idx }: DataRowProps) {
   const rowRef = useRef<HTMLTableRowElement>(null);
-  useStateCell(idx, rowRef, writeRow);
+  useRowState(idx, rowRef, writeRow);
 
   return (
     <Table.Row ref={rowRef} className={tableStyles.dataRow}>

--- a/src/features/Overview/LiveTileMetrics/PinnedRow.tsx
+++ b/src/features/Overview/LiveTileMetrics/PinnedRow.tsx
@@ -1,0 +1,26 @@
+import { Table } from "@radix-ui/themes";
+import tableStyles from "../../../components/dataTable.module.css";
+import type { Tile } from "../../../api/types";
+import { memo, useRef } from "react";
+import { useRowState, writeRow } from "./utils";
+
+interface PinnedRowProps {
+  tile: Tile;
+  idx: number;
+}
+
+export const PinnedRow = memo(function PinnedRow({
+  tile,
+  idx,
+}: PinnedRowProps) {
+  const rowRef = useRef<HTMLTableRowElement>(null);
+  useRowState(idx, rowRef, writeRow);
+
+  return (
+    <Table.Row ref={rowRef} className={tableStyles.dataRow}>
+      <Table.Cell className={tableStyles.rightBorder}>
+        {tile.kind}:{tile.kind_id}
+      </Table.Cell>
+    </Table.Row>
+  );
+});

--- a/src/features/Overview/LiveTileMetrics/index.tsx
+++ b/src/features/Overview/LiveTileMetrics/index.tsx
@@ -1,10 +1,6 @@
 import { useAtomValue } from "jotai";
 import { tilesAtom } from "../../../api/atoms";
-import {
-  hasLiveTileMetricsAtom,
-  liveTileRowAtomFamily,
-  tilePriorityCountsAtom,
-} from "./atoms";
+import { hasLiveTileMetricsAtom, tilePriorityCountsAtom } from "./atoms";
 import Card from "../../../components/Card";
 import { Flex, Table, Text } from "@radix-ui/themes";
 import tableStyles from "../../../components/dataTable.module.css";
@@ -12,7 +8,6 @@ import styles from "./liveTileMetrics.module.css";
 import { headerGap } from "../../Gossip/consts";
 import type { Tile } from "../../../api/types";
 import clsx from "clsx";
-import { usePreviousDistinct } from "react-use";
 import { memo, useMemo, type CSSProperties } from "react";
 import TableDescriptionDialog from "../../../components/TableDescriptionDialog";
 import {
@@ -24,6 +19,7 @@ import {
 } from "./consts";
 import { PriorityEnum } from "../../../api/entities";
 import { DataRow } from "./DataRow";
+import { PinnedRow } from "./PinnedRow";
 import { TableHeader } from "../../../components/DataTable";
 
 export default memo(function LiveTileMetrics() {
@@ -111,52 +107,7 @@ const TableRow = memo(function TableRow({
     return <DataRow idx={idx} />;
   }
 
-  return <PinnedTableRow tile={tile} idx={idx} />;
-});
-
-interface PinnedTableRowProps {
-  tile: Tile;
-  idx: number;
-}
-
-const PinnedTableRow = memo(function PinnedTableRow({
-  tile,
-  idx,
-}: PinnedTableRowProps) {
-  const cur = useAtomValue(liveTileRowAtomFamily(idx));
-  const prev = usePreviousDistinct(cur);
-
-  const alive = cur?.alive ?? prev?.alive;
-  // Meaning tile has shut down, no need to list it in the table
-  if (alive === 2) return;
-
-  const timers = cur?.timers || prev?.timers;
-  if (!timers) return;
-
-  const isFloating =
-    (cur?.priority ?? prev?.priority) === PriorityEnum.floating;
-
-  return <PinnedTableRowContent tile={tile} isFloating={isFloating} />;
-});
-
-interface PinnedTableRowContentProps {
-  tile: Tile;
-  isFloating: boolean;
-}
-
-const PinnedTableRowContent = memo(function PinnedTableRowContent({
-  tile,
-  isFloating,
-}: PinnedTableRowContentProps) {
-  return (
-    <Table.Row
-      className={clsx(tableStyles.dataRow, { [tableStyles.faded]: isFloating })}
-    >
-      <Table.Cell className={tableStyles.rightBorder}>
-        {tile.kind}:{tile.kind_id}
-      </Table.Cell>
-    </Table.Row>
-  );
+  return <PinnedRow tile={tile} idx={idx} />;
 });
 
 function PriorityCountCell() {

--- a/src/features/Overview/LiveTileMetrics/utils.ts
+++ b/src/features/Overview/LiveTileMetrics/utils.ts
@@ -1,0 +1,48 @@
+import { getDefaultStore } from "jotai";
+import { liveTileRowAtomFamily, type TileRowMetrics } from "./atoms";
+import tableStyles from "../../../components/dataTable.module.css";
+import { PriorityEnum } from "../../../api/entities";
+import { useLayoutEffect } from "react";
+
+const store = getDefaultStore();
+
+/**
+ * Each component subscribes to the relevant state in the Jotai store.
+ * This allows for fine-grained updates without re-rendering through react.
+ */
+
+export type WriteEl<E extends HTMLElement> = (
+  el: E,
+  cur: TileRowMetrics | undefined,
+  prev: TileRowMetrics | undefined,
+) => void;
+
+export function useRowState<E extends HTMLElement>(
+  idx: number,
+  ref: { current: E | null },
+  write: WriteEl<E>,
+) {
+  useLayoutEffect(() => {
+    const rowAtom = liveTileRowAtomFamily(idx);
+    let prev = store.get(rowAtom);
+
+    const handleUpdate = () => {
+      const cur = store.get(rowAtom);
+      if (ref.current) write(ref.current, cur, prev);
+      prev = cur;
+    };
+
+    const unsub = store.sub(rowAtom, handleUpdate);
+    handleUpdate();
+    return unsub;
+  }, [idx, ref, write]);
+}
+
+// alive === 2 (shutdown) or no timers -> row hidden.
+export const writeRow: WriteEl<HTMLTableRowElement> = (el, c, p) => {
+  const alive = c?.alive ?? p?.alive;
+  const hasTimers = !!(c?.timers || p?.timers);
+  const priority = c?.priority ?? p?.priority;
+  el.style.display = alive === 2 || !hasTimers ? "none" : "";
+  el.classList.toggle(tableStyles.faded, priority === PriorityEnum.floating);
+};


### PR DESCRIPTION
The pinned row and data row in the live metric tiles table were updating out of sync because the pinned row was on the react render cycle while the data row was subscribing to atom updates and changing the text content of the elements directly in a useLayoutEffect. This causing the table to "flash" when a tile shutdown happens and a new one up to replace it (observed frequently with netlnk) because either the pinned row or the data row would render before the other leaving an incomplete row for a single frame. This syncs their updates by using the same method to subscribe to and update the data.