### PR TITLE
chore: memoize partition utilization

### DIFF
--- a/src/features/Accounts/CompactionCard/index.tsx
+++ b/src/features/Accounts/CompactionCard/index.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { PropsWithChildren } from "react";
 import { Flex, Text } from "@radix-ui/themes";
 import Card from "../../../components/Card";
@@ -7,12 +8,9 @@ import { useAtomValue } from "jotai";
 import Stat from "../Stat";
 import PartitionUtilization from "../PartitionUtilization";
 import { formatSIBytes, getSafePct } from "../../../utils";
-import type { AccountsStats } from "../../../api/types";
 import { accountsPartitionCompactionColor } from "../../../colors";
 import styles from "./compactionCard.module.css";
 import { PartitionTier } from "../consts";
-
-type Partition = AccountsStats["partitions"][number];
 
 function fmtPct(pct: number) {
   return `${Math.round(pct)}%`;
@@ -46,7 +44,14 @@ export default function CompactionCard({ className }: { className?: string }) {
           />
           {nextCompactionPartition && (
             <NextCompactionPartitionUtilization
-              partition={nextCompactionPartition}
+              usedFrac={nextCompactionPartition.used_frac}
+              fragmentedFrac={nextCompactionPartition.fragmented_frac}
+              compactionTriggerFrac={
+                nextCompactionPartition.compaction_trigger_frac
+              }
+              compactionFrac={nextCompactionPartition.compaction_frac}
+              compactionState={nextCompactionPartition.compaction_state}
+              isWriteHead={nextCompactionPartition.is_write_head}
             />
           )}
         </Flex>
@@ -61,27 +66,61 @@ export default function CompactionCard({ className }: { className?: string }) {
   );
 }
 
-function NextCompactionPartitionUtilization({
-  partition,
-}: {
-  partition: Partition;
-}) {
-  return (
-    <Flex direction="column" gap="5px">
-      <PartitionUtilization partition={partition} showPct={false} />
-      <PartitionLegend partition={partition} />
-    </Flex>
-  );
+interface NextCompactionProps {
+  usedFrac: number;
+  fragmentedFrac: number;
+  compactionTriggerFrac: number;
+  compactionFrac: number;
+  compactionState: number;
+  isWriteHead: boolean;
 }
 
-function PartitionLegend({ partition }: { partition: Partition }) {
-  const usedPct = fmtPct(partition.used_frac * 100);
-  const fragPct = fmtPct(partition.fragmented_frac * 100);
-  const triggerPct = fmtPct(partition.compaction_trigger_frac * 100);
-  const compactionPct = getSafePct(
-    partition.compaction_frac,
-    partition.used_frac + partition.fragmented_frac,
-  );
+const NextCompactionPartitionUtilization = memo(
+  function NextCompactionPartitionUtilization({
+    usedFrac,
+    fragmentedFrac,
+    compactionTriggerFrac,
+    compactionFrac,
+    compactionState,
+    isWriteHead,
+  }: NextCompactionProps) {
+    return (
+      <Flex direction="column" gap="5px">
+        <PartitionUtilization
+          usedFrac={usedFrac}
+          fragmentedFrac={fragmentedFrac}
+          compactionTriggerFrac={compactionTriggerFrac}
+          compactionFrac={compactionFrac}
+          compactionState={compactionState}
+          isWriteHead={isWriteHead}
+          showPct={false}
+        />
+        <PartitionLegend
+          usedFrac={usedFrac}
+          fragmentedFrac={fragmentedFrac}
+          compactionTriggerFrac={compactionTriggerFrac}
+          compactionFrac={compactionFrac}
+        />
+      </Flex>
+    );
+  },
+);
+
+const PartitionLegend = memo(function PartitionLegend({
+  usedFrac,
+  fragmentedFrac,
+  compactionTriggerFrac,
+  compactionFrac,
+}: {
+  usedFrac: number;
+  fragmentedFrac: number;
+  compactionTriggerFrac: number;
+  compactionFrac: number;
+}) {
+  const usedPct = fmtPct(usedFrac * 100);
+  const fragPct = fmtPct(fragmentedFrac * 100);
+  const triggerPct = fmtPct(compactionTriggerFrac * 100);
+  const compactionPct = getSafePct(compactionFrac, usedFrac + fragmentedFrac);
   return (
     <Flex gap="10px">
       <LegendItem label="Used" value={usedPct}>
@@ -104,7 +143,7 @@ function PartitionLegend({ partition }: { partition: Partition }) {
       </LegendItem>
     </Flex>
   );
-}
+});
 
 function LegendItem({
   children,

--- a/src/features/Accounts/PartitionUtilization.tsx
+++ b/src/features/Accounts/PartitionUtilization.tsx
@@ -1,32 +1,44 @@
+import { memo } from "react";
 import { Tooltip, Flex, Text } from "@radix-ui/themes";
 import { accountsPartitionCompactionColor } from "../../colors";
 import styles from "./partitionUtilization.module.css";
 import type { PropsWithChildren } from "react";
-import type { AccountsStats } from "../../api/types";
 
 function fmtPct(pct: number) {
   return `${pct.toFixed(2)}%`;
 }
 
-export default function PartitionUtilization({
-  partition,
-  showPct = true,
-}: {
-  partition: AccountsStats["partitions"][number];
+interface PartitionUtilizationProps {
+  usedFrac: number;
+  fragmentedFrac: number;
+  compactionTriggerFrac: number;
+  compactionFrac: number;
+  compactionState: number;
+  isWriteHead: boolean;
   showPct?: boolean;
-}) {
-  const fragPct = partition.fragmented_frac * 100;
-  const usedPct = partition.used_frac * 100;
+}
+
+const PartitionUtilization = memo(function PartitionUtilization({
+  usedFrac,
+  fragmentedFrac,
+  compactionTriggerFrac,
+  compactionFrac,
+  compactionState,
+  isWriteHead,
+  showPct = true,
+}: PartitionUtilizationProps) {
+  const fragPct = fragmentedFrac * 100;
+  const usedPct = usedFrac * 100;
   const headPct = fragPct + usedPct;
   const unusedPct = 100 - headPct;
-  const compactionTriggerPct = partition.compaction_trigger_frac * 100;
-  const compactionPct = partition.compaction_frac * 100;
-  const isCompacting = partition.compaction_state === 2;
+  const compactionTriggerPct = compactionTriggerFrac * 100;
+  const compactionPct = compactionFrac * 100;
+  const isCompacting = compactionState === 2;
 
   return (
     <PartitionUtilizationTooltip
-      fragmentedFrac={partition.fragmented_frac}
-      compactionTriggerFrac={partition.compaction_trigger_frac}
+      fragmentedFrac={fragmentedFrac}
+      compactionTriggerFrac={compactionTriggerFrac}
       headPct={headPct}
     >
       <Flex align="center" gap="8px">
@@ -35,7 +47,7 @@ export default function PartitionUtilization({
             className={styles.triggerMarker}
             left={fmtPct(compactionTriggerPct)}
           />
-          {partition.is_write_head && (
+          {isWriteHead && (
             <Flex className={styles.writeHeadMarker} left={fmtPct(headPct)} />
           )}
           {isCompacting && (
@@ -64,7 +76,9 @@ export default function PartitionUtilization({
       </Flex>
     </PartitionUtilizationTooltip>
   );
-}
+});
+
+export default PartitionUtilization;
 
 interface PartitionUtilizationTooltipProps {
   fragmentedFrac: number;

--- a/src/features/Accounts/Partitions/index.tsx
+++ b/src/features/Accounts/Partitions/index.tsx
@@ -81,7 +81,14 @@ function DataRow({ partition }: { partition: Partition }) {
   return (
     <Table.Row className={tableStyles.dataRow}>
       <Table.Cell>
-        <PartitionUtilization partition={partition} />
+        <PartitionUtilization
+          usedFrac={partition.used_frac}
+          fragmentedFrac={partition.fragmented_frac}
+          compactionTriggerFrac={partition.compaction_trigger_frac}
+          compactionFrac={partition.compaction_frac}
+          compactionState={partition.compaction_state}
+          isWriteHead={partition.is_write_head}
+        />
       </Table.Cell>
       <Table.Cell align="right">
         {`${Math.round(partition.fragmented_frac * 100)}%`}


### PR DESCRIPTION
Prevent unnecessary rerenders of infrequently updating partitions. Usually only the hot and warm partitions will have frequent updates, so this prevents re-rendering the partition utilization visuzliation when none of the underlying data has changed.