### PR TITLE
chore: unfade live metrics tile utilization cells

### DIFF
--- a/src/components/dataTable.module.css
+++ b/src/components/dataTable.module.css
@@ -51,7 +51,9 @@
 
     .data-row {
       &.faded {
-        filter: brightness(0.55);
+        td:not(.no-fade-cell) {
+          filter: brightness(0.55);
+        }
       }
 
       .green {

--- a/src/features/Overview/LiveTileMetrics/DataRow.tsx
+++ b/src/features/Overview/LiveTileMetrics/DataRow.tsx
@@ -354,7 +354,9 @@ const MUtilization = memo(function Utilization({ idx }: UtilizationProps) {
 
   return (
     <>
-      <Table.Cell className={tableStyles.noPadding}>
+      <Table.Cell
+        className={clsx(tableStyles.noPadding, tableStyles.noFadeCell)}
+      >
         <Flex align="center" ref={barsWrapRef}>
           <Bars
             value={initialPct >= 0 ? initialPct : (prevPctRef.current ?? 0)}
@@ -364,7 +366,11 @@ const MUtilization = memo(function Utilization({ idx }: UtilizationProps) {
         </Flex>
       </Table.Cell>
       <Table.Cell
-        className={clsx(tableStyles.noPadding, tableStyles.rightBorder)}
+        className={clsx(
+          tableStyles.noPadding,
+          tableStyles.rightBorder,
+          tableStyles.noFadeCell,
+        )}
       >
         <TileSparkLine
           value={avgValue}


### PR DESCRIPTION
The Utilization cells in the Live Metrics Table are difficult to read for the floating rows that get a dimming filter applied to them. This applies the filter on each cell (rather than the row) and excludes the utlization cells from being faded.