### PR TITLE
feat: add version to leader schedule search

### DIFF
--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -580,6 +580,7 @@ export const allLeaderNamesClientIdsAtom = atom((get) => {
     pubkey: pubkey,
     name: peers[pubkey]?.info?.name?.toLowerCase(),
     clientId: peers[pubkey]?.gossip?.client_id,
+    version: peers[pubkey]?.gossip?.version,
   }));
 });
 

--- a/src/features/LeaderSchedule/Search.tsx
+++ b/src/features/LeaderSchedule/Search.tsx
@@ -69,7 +69,7 @@ export default function Search() {
     <Flex className={styles.container} gap="2" wrap="wrap">
       <Box className={styles.searchBox}>
         <TextField.Root
-          placeholder="Name, Client Id, Pubkey, or Slot (use , for multiple)"
+          placeholder="Name, Client Id, Pubkey, Version, or Slot (use , for multiple)"
           variant="soft"
           color="gray"
           onChange={(e) => {

--- a/src/features/LeaderSchedule/atoms.ts
+++ b/src/features/LeaderSchedule/atoms.ts
@@ -60,10 +60,13 @@ export const setSearchLeaderSlotsAtom = atom(
     const leaders = get(allLeaderNamesClientIdsAtom);
     const searchPubkeys = leaders
       ?.filter(
-        ({ name, pubkey, clientId }) =>
+        ({ name, pubkey, clientId, version }) =>
           (clientId != null && matchingClientIds.has(clientId)) ||
           searchTextParts.some(
-            (s) => name?.includes(s) || pubkey.toLowerCase().includes(s),
+            (s) =>
+              name?.includes(s) ||
+              pubkey.toLowerCase().includes(s) ||
+              (version != null && `v${version}`.includes(s)),
           ),
       )
       .map(({ pubkey }) => pubkey);


### PR DESCRIPTION
Adds gossip version as a search filter on the leader schedule page.

<img width="1915" height="983" alt="image" src="https://github.com/user-attachments/assets/e1cab283-9f2a-4d02-b669-86a09c9949a1" />

<img width="1919" height="967" alt="image" src="https://github.com/user-attachments/assets/99cf0660-d2ee-410e-93e9-c2883e2cdfaa" />
