### PR TITLE
feat: estimate next compaction time

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -150,14 +150,29 @@ describe("getDurationText", () => {
     expect(getDurationText(undefined)).toEqual("Never");
   });
 
-  it("shows 0s if duration is less than a second", () => {
+  it("shows 0s if duration is exactly 0", () => {
+    expect(getDurationText(Duration.fromObject({ millisecond: 0 }))).toEqual(
+      "0s",
+    );
+  });
+
+  it("shows 1s if duration is less than a second but not 0", () => {
+    expect(getDurationText(Duration.fromObject({ millisecond: 999 }))).toEqual(
+      "1s",
+    );
+  });
+
+  it("shows 1m if duration is less than a minute but not 0 with omitSeconds", () => {
     expect(
-      getDurationText(
-        Duration.fromObject({
-          millisecond: 999,
-        }),
-      ),
-    ).toEqual("0s");
+      getDurationText(Duration.fromObject({ millisecond: 59999 }), {
+        omitSeconds: true,
+      }),
+    ).toEqual("1m");
+    expect(
+      getDurationText(Duration.fromObject({ millisecond: 999 }), {
+        omitSeconds: true,
+      }),
+    ).toEqual("1m");
   });
 
   it("shows full duration", () => {

--- a/src/api/atoms.ts
+++ b/src/api/atoms.ts
@@ -197,5 +197,3 @@ export const liveProgramCacheAtom = atom<LiveProgramCache | undefined>(
 export const healthAtom = atom<Health | undefined>(undefined);
 
 export const accountsStatsAtom = atom<AccountsStats | undefined>(undefined);
-
-export const hasAccountStatsAtom = atom((get) => !!get(accountsStatsAtom));

--- a/src/api/entities.ts
+++ b/src/api/entities.ts
@@ -1161,10 +1161,25 @@ const accountsTileSchema = z.object({
   acquired_writable_history: z.array(z.number()),
 });
 
-const accountsPartitionSchema = z.object({
+export const partitionTierSchema = z.union([
+  z.literal(0),
+  z.literal(1),
+  z.literal(2),
+  z.literal(255),
+]);
+export const PartitionTier = { Hot: 0, Warm: 1, Cold: 2, Off: 255 } as const;
+
+export const compactionStateSchema = z.union([
+  z.literal(0),
+  z.literal(1),
+  z.literal(2),
+]);
+export const CompactionState = { Idle: 0, Queued: 1, Compacting: 2 } as const;
+
+export const accountsPartitionSchema = z.object({
   partition_idx: z.number(),
   file_offset: z.number(),
-  tier: z.number(),
+  tier: partitionTierSchema,
   write_offset: z.number(),
   bytes_freed: z.number(),
   read_ops: z.number(),
@@ -1182,7 +1197,7 @@ const accountsPartitionSchema = z.object({
   compaction_trigger_frac: z.number(),
   age_seconds: z.number(),
   filled_seconds: z.number(),
-  compaction_state: z.number(),
+  compaction_state: compactionStateSchema,
   compaction_frac: z.number(),
   is_write_head: z.boolean(),
 });

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -74,6 +74,9 @@ import type {
   turbineHealthSchema,
   healthSchema,
   accountsStatsSchema,
+  accountsPartitionSchema,
+  partitionTierSchema,
+  compactionStateSchema,
 } from "./entities";
 
 export type Client = z.infer<typeof clientSchema>;
@@ -207,3 +210,6 @@ export type ReplayHealth = z.infer<typeof replayHealthSchema>;
 export type TurbineHealth = z.infer<typeof turbineHealthSchema>;
 
 export type AccountsStats = z.infer<typeof accountsStatsSchema>;
+export type AccountsPartition = z.infer<typeof accountsPartitionSchema>;
+export type PartitionTier = z.infer<typeof partitionTierSchema>;
+export type CompactionState = z.infer<typeof compactionStateSchema>;

--- a/src/api/useSetAtomWsData.ts
+++ b/src/api/useSetAtomWsData.ts
@@ -99,6 +99,7 @@ import {
   healthAtom,
   accountsStatsAtom,
 } from "./atoms";
+import { accountsNextCompactionAtom } from "../atoms";
 import {
   estimatedTpsDebounceMs,
   liveNetworkMetricsDebounceMs,
@@ -449,6 +450,9 @@ function useUpdateAtoms() {
   const setHealth = useSetAtom(healthAtom);
 
   const setAccountsStats = useSetAtom(accountsStatsAtom);
+  const updateAccountsNextCompactionCandidates = useSetAtom(
+    accountsNextCompactionAtom,
+  );
 
   const peersBuffer = useRef(new Map<string, Peer>());
   const removePeersBuffer = useRef(new Map<string, PeerRemove>());
@@ -780,6 +784,7 @@ function useUpdateAtoms() {
           switch (key) {
             case "stats": {
               setAccountsStats(value);
+              updateAccountsNextCompactionCandidates(value.partitions);
               break;
             }
           }
@@ -841,6 +846,7 @@ function useUpdateAtoms() {
       setVoteSlot,
       setVoteState,
       setAccountsStats,
+      updateAccountsNextCompactionCandidates,
     ],
   );
 

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -8,6 +8,7 @@ import {
   serverTimeNanosAtom,
   skippedSlotsAtom,
   startupProgressAtom,
+  accountsStatsAtom,
 } from "./api/atoms";
 import type {
   Epoch,
@@ -17,10 +18,12 @@ import type {
   SlotLevel,
   SlotResponse,
   SupermajorityEpoch,
+  AccountsPartition,
 } from "./api/types";
 import { clamp, merge } from "lodash";
 import {
   getDiscountedVoteLatency,
+  getDurationText,
   getLeaderSlots,
   getSlotGroupLeader,
   getStake,
@@ -30,7 +33,9 @@ import { selectedSlotAtom } from "./features/Overview/SlotPerformance/atoms";
 import { atomFamily } from "jotai/utils";
 import memoize from "micro-memoize";
 import { isFrankendancer } from "./client";
+import { CompactionState } from "./api/entities";
 import { numQuickSearchSlots } from "./features/SlotDetails/const";
+import { Duration } from "luxon";
 
 export const isDocumentVisibleAtom = atom<boolean>(
   document.visibilityState === "visible",
@@ -1018,3 +1023,122 @@ export const quickSearchSlotsAtom = atom((get) => {
       .toReversed(),
   };
 });
+
+export const hasAccountsStatsAtom = atom((get) => !!get(accountsStatsAtom));
+
+export type PartitionCandidate = Pick<
+  AccountsPartition,
+  | "partition_idx"
+  | "tier"
+  | "compaction_state"
+  | "used_frac"
+  | "fragmented_frac"
+  | "compaction_trigger_frac"
+> & { estimate: number };
+type PartitionCompactionMap = Map<number, PartitionCandidate>;
+
+export const accountsNextCompactionAtom =
+  (function getAccountsNextCompactionAtom() {
+    const _accountsNextCompactionCandidatesAtom = atom<PartitionCompactionMap>(
+      new Map(),
+    );
+
+    return atom(
+      (get) => {
+        const nextCandidates = get(_accountsNextCompactionCandidatesAtom);
+
+        let nextCandidate: PartitionCandidate | undefined;
+        for (const candidate of nextCandidates.values()) {
+          if (
+            !nextCandidate ||
+            candidate.compaction_state > nextCandidate.compaction_state ||
+            (candidate.compaction_state === nextCandidate.compaction_state &&
+              candidate.estimate < nextCandidate.estimate)
+          ) {
+            nextCandidate = candidate;
+          }
+        }
+
+        if (!nextCandidate) return undefined;
+
+        const timeLabel =
+          nextCandidate.compaction_state !== CompactionState.Idle ||
+          nextCandidate.estimate === 0
+            ? "Now"
+            : nextCandidate.estimate === Infinity
+              ? "--"
+              : `~${getDurationText(
+                  Duration.fromObject({
+                    seconds: nextCandidate.estimate,
+                  }).rescale(),
+                  { showOnlyTwoSignificantUnits: true, omitSeconds: true },
+                )} left`;
+
+        return { partitionIdx: nextCandidate.partition_idx, timeLabel };
+      },
+      (get, set, partitions: AccountsPartition[]) => {
+        const prev = get(_accountsNextCompactionCandidatesAtom);
+        const candidates =
+          partitions?.filter(
+            (p) =>
+              p.is_write_head || p.compaction_state !== CompactionState.Idle,
+          ) ?? [];
+
+        // Update the next compaction estimate only when certain fields update
+        // Excludes age_seconds to avoid noisy updates for newly active write heads
+        const hasChanged =
+          prev.size !== candidates.length ||
+          candidates.some((p) => {
+            const snap = prev.get(p.partition_idx);
+            return (
+              !snap ||
+              snap.compaction_state !== p.compaction_state ||
+              snap.used_frac !== p.used_frac ||
+              snap.fragmented_frac !== p.fragmented_frac ||
+              snap.compaction_trigger_frac !== p.compaction_trigger_frac
+            );
+          });
+
+        if (!hasChanged) return;
+
+        const next: PartitionCompactionMap = new Map(
+          candidates.map((p) => {
+            let estimate: number;
+            if (p.compaction_state !== CompactionState.Idle) {
+              estimate = 0;
+            } else {
+              const headFrac = p.used_frac + p.fragmented_frac;
+              const rate = p.age_seconds > 0 ? 1 / p.age_seconds : 0;
+              const remainingForHead =
+                headFrac >= 1
+                  ? 0
+                  : headFrac > 0 && rate > 0
+                    ? (1 - headFrac) / (headFrac * rate)
+                    : Infinity;
+              const remainingForFrag =
+                p.fragmented_frac >= p.compaction_trigger_frac
+                  ? 0
+                  : p.fragmented_frac > 0 && rate > 0
+                    ? (p.compaction_trigger_frac - p.fragmented_frac) /
+                      (p.fragmented_frac * rate)
+                    : Infinity;
+              estimate = Math.max(remainingForHead, remainingForFrag);
+            }
+            return [
+              p.partition_idx,
+              {
+                partition_idx: p.partition_idx,
+                tier: p.tier,
+                compaction_state: p.compaction_state,
+                used_frac: p.used_frac,
+                fragmented_frac: p.fragmented_frac,
+                compaction_trigger_frac: p.compaction_trigger_frac,
+                estimate,
+              },
+            ];
+          }),
+        );
+        set(_accountsNextCompactionCandidatesAtom, next);
+      },
+    );
+  })();

--- a/src/features/Accounts/CompactionCard/index.tsx
+++ b/src/features/Accounts/CompactionCard/index.tsx
@@ -8,9 +8,10 @@ import { useAtomValue } from "jotai";
 import Stat from "../Stat";
 import PartitionUtilization from "../PartitionUtilization";
 import { formatSIBytes, getSafePct } from "../../../utils";
-import { accountsPartitionCompactionColor } from "../../../colors";
 import styles from "./compactionCard.module.css";
-import { PartitionTier } from "../consts";
+import { partitionTierLabel, partitionTierColor } from "../consts";
+import { CompactionState } from "../../../api/entities";
+import { accountsNextCompactionAtom } from "../../../atoms";
 
 function fmtPct(pct: number) {
   return `${Math.round(pct)}%`;
@@ -18,47 +19,78 @@ function fmtPct(pct: number) {
 
 export default function CompactionCard({ className }: { className?: string }) {
   const accountStats = useAtomValue(accountsStatsAtom);
+  const nextCompaction = useAtomValue(accountsNextCompactionAtom);
+
   if (!accountStats) return;
 
-  const isCompacting = accountStats.compaction.in_compaction;
   const relocatedPerSec = formatSIBytes(
     accountStats.compaction.relocated_bytes_per_sec,
   );
 
-  // TODO: calculate the next compaction time for all partitions
-  // For now, assume the hot partition is the next to compact
-  const nextCompactionPartition = accountStats.partitions?.find(
-    (p) => p.tier === PartitionTier.Hot,
-  );
+  const nextPartition =
+    nextCompaction !== undefined
+      ? accountStats.partitions[nextCompaction.partitionIdx]
+      : undefined;
+  const compactionState =
+    nextPartition?.compaction_state ?? CompactionState.Idle;
 
   return (
     <Card className={className}>
       <Flex direction="column" minWidth="300px" height="100%" gap="5px">
         <CardHeader text="Compaction" />
         <Flex direction="column" gap="5px" height="100%">
-          <Stat
-            label="State"
-            value={isCompacting ? "Compacting..." : "Idle"}
-            color={isCompacting ? accountsPartitionCompactionColor : undefined}
-            size="lg"
-          />
-          {nextCompactionPartition && (
-            <NextCompactionPartitionUtilization
-              usedFrac={nextCompactionPartition.used_frac}
-              fragmentedFrac={nextCompactionPartition.fragmented_frac}
-              compactionTriggerFrac={
-                nextCompactionPartition.compaction_trigger_frac
+          <Flex justify="between" gap="5px">
+            <Stat
+              label="State"
+              value={
+                compactionState === CompactionState.Queued
+                  ? "Queued"
+                  : compactionState === CompactionState.Compacting
+                    ? "Compacting..."
+                    : "Idle"
               }
-              compactionFrac={nextCompactionPartition.compaction_frac}
-              compactionState={nextCompactionPartition.compaction_state}
-              isWriteHead={nextCompactionPartition.is_write_head}
+              color={
+                compactionState === CompactionState.Queued
+                  ? "var(--yellow-9)"
+                  : compactionState === CompactionState.Compacting
+                    ? "var(--amber-9)"
+                    : undefined
+              }
+              size="lg"
             />
-          )}
+            <Stat
+              label="Next Partition"
+              value={
+                nextPartition ? partitionTierLabel[nextPartition.tier] : "--"
+              }
+              color={
+                nextPartition
+                  ? partitionTierColor[nextPartition.tier]
+                  : "var(--gray-7)"
+              }
+              align="end"
+              size="lg"
+            />
+          </Flex>
+          <NextCompactionPartitionUtilization
+            usedFrac={nextPartition?.used_frac ?? 0}
+            fragmentedFrac={nextPartition?.fragmented_frac ?? 0}
+            compactionTriggerFrac={nextPartition?.compaction_trigger_frac ?? 0}
+            compactionFrac={nextPartition?.compaction_frac ?? 0}
+            compactionState={compactionState}
+            isWriteHead={nextPartition?.is_write_head ?? false}
+          />
         </Flex>
         <Flex justify="between" gap="5px">
           <Stat
             label="Relocated"
             value={`${relocatedPerSec.value} ${relocatedPerSec.unit}/s`}
+          />
+          <Stat
+            label="Next Compaction"
+            value={nextCompaction?.timeLabel ?? "--"}
+            align="end"
+            color={nextCompaction ? "#EEE" : "var(--gray-7)"}
           />
         </Flex>
       </Flex>

--- a/src/features/Accounts/Partitions/index.tsx
+++ b/src/features/Accounts/Partitions/index.tsx
@@ -7,13 +7,11 @@ import DataTable from "../../../components/DataTable";
 import TableDescriptionDialog from "../../../components/TableDescriptionDialog";
 import { partitionGroups } from "./consts";
 import { partitionTierLabel, partitionTierColor } from "../consts";
-import type { AccountsStats } from "../../../api/types";
 import tableStyles from "../../../components/dataTable.module.css";
 import accountStyles from "../accounts.module.css";
 import { formatRate, formatSIBytes, formatSIBytesRate } from "../../../utils";
 import PartitionUtilization from "../PartitionUtilization";
-
-type Partition = AccountsStats["partitions"][number];
+import type { AccountsPartition } from "../../../api/types";
 
 export default function Partitions() {
   return (
@@ -52,7 +50,7 @@ function PartitionsTableBody({ isPinned }: { isPinned?: boolean }) {
   );
 }
 
-function PinnedRow({ partition }: { partition: Partition }) {
+function PinnedRow({ partition }: { partition: AccountsPartition }) {
   const offset = formatSIBytes(partition.file_offset, 0);
 
   return (
@@ -70,7 +68,7 @@ function PinnedRow({ partition }: { partition: Partition }) {
   );
 }
 
-function DataRow({ partition }: { partition: Partition }) {
+function DataRow({ partition }: { partition: AccountsPartition }) {
   const isCompacting = partition.compaction_state === 2;
   const filledFrac = partition.used_frac + partition.fragmented_frac;
   const compactionPct =

--- a/src/features/Accounts/Stat.tsx
+++ b/src/features/Accounts/Stat.tsx
@@ -14,6 +14,7 @@ interface StatProps {
   color?: CSSProperties["color"];
   suffix?: string;
   minWidth?: string;
+  align?: "start" | "end";
 }
 
 export default function Stat({
@@ -24,9 +25,15 @@ export default function Stat({
   color,
   suffix,
   minWidth,
+  align,
 }: StatProps) {
   return (
-    <Flex className={className} direction="column" minWidth={minWidth}>
+    <Flex
+      className={className}
+      direction="column"
+      minWidth={minWidth}
+      align={align}
+    >
       {label && <Text className={styles.label}>{label}</Text>}
       <Flex
         className={clsx(styles.valuesContainer, { [styles.lg]: size === "lg" })}

--- a/src/features/Accounts/consts.ts
+++ b/src/features/Accounts/consts.ts
@@ -1,9 +1,4 @@
-export enum PartitionTier {
-  Hot = 0,
-  Warm = 1,
-  Cold = 2,
-  Off = 255,
-}
+import { PartitionTier } from "../../api/entities";
 
 export const partitionTierLabel: Record<number, string> = {
   [PartitionTier.Hot]: "Hot",

--- a/src/features/Accounts/index.tsx
+++ b/src/features/Accounts/index.tsx
@@ -1,6 +1,6 @@
 import { Flex } from "@radix-ui/themes";
 import { useAtomValue } from "jotai";
-import { hasAccountStatsAtom } from "../../api/atoms";
+import { hasAccountsStatsAtom } from "../../atoms";
 import styles from "./accounts.module.css";
 import DiskCard from "./DiskCard";
 import IndexCard from "./IndexCard";
@@ -11,7 +11,7 @@ import Tiles from "./Tiles";
 import Partitions from "./Partitions";
 
 export default function Accounts() {
-  const hasAccountStats = useAtomValue(hasAccountStatsAtom);
+  const hasAccountStats = useAtomValue(hasAccountsStatsAtom);
   if (!hasAccountStats) return;
 
   return (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,10 +58,11 @@ function getUnitValues(
   options?: DurationOptions,
 ): [number, string][] {
   if (options?.showOnlyTwoSignificantUnits) {
-    const firstUnitIndex = descendingUnits.findIndex(
-      ({ unit }) => !!duration[unit],
-    );
-    return descendingUnits
+    const units = options.omitSeconds
+      ? descendingUnits.filter(({ unit }) => unit !== "seconds")
+      : descendingUnits;
+    const firstUnitIndex = units.findIndex(({ unit }) => !!duration[unit]);
+    return units
       .slice(firstUnitIndex, firstUnitIndex + 2)
       .map(({ unit, suffix }) => [duration[unit], suffix]);
   }
@@ -82,10 +83,11 @@ export function getDurationValues(
 ): [number, string][] | undefined {
   if (!duration) return;
 
-  if (duration.toMillis() < 1000) return [[0, "s"]];
+  if (duration.toMillis() === 0) return [[0, "s"]];
 
   const units = getUnitValues(duration, options);
-  return units.length ? units : [[0, "s"]];
+  if (units.length) return units;
+  return options?.omitSeconds ? [[1, "m"]] : [[1, "s"]];
 }
 
 export function getDurationText(


### PR DESCRIPTION
- calculate next compaction time
  - prioritize in order of state idle < queued < compacting
  - within the same state, prioritize by smaller estimated time
- only show 0s if duration is actually 0
- add defaults for when next compaction partition is undefined so layout does not shift when it is missing