### PR TITLE
feat: accounts card

### DIFF
--- a/src/features/Accounts/CacheCard/index.tsx
+++ b/src/features/Accounts/CacheCard/index.tsx
@@ -12,13 +12,8 @@ import {
 import Stat, { FractionStat } from "../Stat";
 
 import { cacheClassList } from "../consts";
-import {
-  accountsReadColor,
-  accountsWriteColor,
-  goodChangedColor,
-  averageChangedColor,
-  badChangedColor,
-} from "../../../colors";
+import { hitRateChangedColor, getHitRateStatus } from "../../../hitRate";
+import { accountsReadColor, accountsWriteColor } from "../../../colors";
 
 export default function CacheCard({ className }: { className?: string }) {
   const accountStats = useAtomValue(accountsStatsAtom);
@@ -26,12 +21,8 @@ export default function CacheCard({ className }: { className?: string }) {
 
   const cacheClasses = accountStats.cache.classes;
 
-  const hitRateColor =
-    accountStats.cache.hit_rate_ema < 0.99
-      ? badChangedColor
-      : accountStats.cache.hit_rate_ema < 0.995
-        ? averageChangedColor
-        : goodChangedColor;
+  const hitRateStatus = getHitRateStatus(accountStats.cache.hit_rate_ema);
+  const hitRateColor = hitRateChangedColor(hitRateStatus);
 
   const readsPerSec = formatCount(
     Math.max(

--- a/src/features/Accounts/CacheClasses/index.tsx
+++ b/src/features/Accounts/CacheClasses/index.tsx
@@ -12,6 +12,7 @@ import {
   cacheClassUnusedColors,
   cacheClassList,
 } from "../consts";
+import { hitRateClass } from "../../../hitRate";
 import type { AccountsStats } from "../../../api/types";
 import tableStyles from "../../../components/dataTable.module.css";
 import styles from "./cacheClasses.module.css";
@@ -142,13 +143,7 @@ function DataRow({
       </Table.Cell>
       <Table.Cell
         align="right"
-        className={
-          cacheClass.hit_rate_ema >= 1
-            ? tableStyles.green
-            : cacheClass.hit_rate_ema > 0.999
-              ? tableStyles.orange
-              : tableStyles.red
-        }
+        className={hitRateClass(cacheClass.hit_rate_ema)}
       >
         {formatHitRate(cacheClass.hit_rate_ema)}%
       </Table.Cell>

--- a/src/features/Accounts/Tiles/index.tsx
+++ b/src/features/Accounts/Tiles/index.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../../utils";
 import HistorySparkline from "./HistorySparkline";
 import { accountsReadColor, accountsWriteColor } from "../../../colors";
+import { hitRateClass } from "../../../hitRate";
 
 export default function Tiles() {
   return (
@@ -82,15 +83,7 @@ function DataRow({ tile }: { tile: Tile }) {
       <MemoCell>{tile.joiner_type}</MemoCell>
       <MemoCell align="right">
         {hasReads ? (
-          <Text
-            className={
-              tile.hit_rate_ema >= 1
-                ? tableStyles.green
-                : tile.hit_rate_ema > 0.999
-                  ? tableStyles.orange
-                  : tableStyles.red
-            }
-          >
+          <Text className={hitRateClass(tile.hit_rate_ema)}>
             {formatHitRate(tile.hit_rate_ema)}%
           </Text>
         ) : (

--- a/src/features/Overview/AccountsCard/accountsCard.module.css
+++ b/src/features/Overview/AccountsCard/accountsCard.module.css
@@ -1,0 +1,5 @@
+.section-label {
+  font-size: 14px;
+  color: #c2c4d2;
+  border-bottom: 1px solid #3c4652;
+}

--- a/src/features/Overview/AccountsCard/index.tsx
+++ b/src/features/Overview/AccountsCard/index.tsx
@@ -1,0 +1,166 @@
+import { Flex } from "@radix-ui/themes";
+import Card from "../../../components/Card";
+import CardHeader from "../../../components/CardHeader";
+import { accountsStatsAtom } from "../../../api/atoms";
+import { useAtomValue } from "jotai";
+import Stat from "../../Accounts/Stat";
+import { formatCount, formatHitRate, formatSIBytes } from "../../../utils";
+import {
+  accountsReadColor,
+  accountsWriteColor,
+  accountsUsedColor,
+  accountsFragmentedColor,
+  accountsSecondaryColor,
+} from "../../../colors";
+import styles from "./accountsCard.module.css";
+import { hitRateChangedColor, getHitRateStatus } from "../../../hitRate";
+import { accountsNextCompactionAtom } from "../../../atoms";
+
+const storageStatsMinWidth = "150px";
+const readWriteStatsMinWidth = "120px";
+const cacheStatsMinWidth = "80px";
+
+export default function AccountsCard({ className }: { className?: string }) {
+  const accountStats = useAtomValue(accountsStatsAtom);
+  const nextCompaction = useAtomValue(accountsNextCompactionAtom);
+
+  if (!accountStats) return null;
+
+  const hitRateStatus = getHitRateStatus(accountStats.cache.hit_rate_ema);
+  const hitRateColor = hitRateChangedColor(hitRateStatus);
+
+  const readsPerSec = formatCount(
+    Math.max(
+      0,
+      accountStats.io.acquired_per_sec -
+        accountStats.io.acquired_writable_per_sec,
+    ),
+  );
+  const writesPerSec = formatCount(accountStats.io.acquired_writable_per_sec);
+
+  const used = formatSIBytes(accountStats.disk.used_bytes);
+  const fragBytes = Math.max(
+    0,
+    accountStats.disk.current_bytes - accountStats.disk.used_bytes,
+  );
+  const frag = formatSIBytes(fragBytes);
+  const readPerSec = formatSIBytes(accountStats.io.bytes_read_per_sec);
+  const writePerSec = formatSIBytes(accountStats.io.bytes_written_per_sec);
+  const allocated = formatSIBytes(accountStats.disk.allocated_bytes);
+
+  return (
+    <Card className={className}>
+      <Flex direction="column" gap="2">
+        <CardHeader text="Accounts" />
+
+        <Flex gap="3" wrap="wrap">
+          <Flex direction="column" gap="2" flexGrow="1">
+            <div className={styles.sectionLabel}>Cache</div>
+            <Stat
+              label="Hit Rate"
+              value={formatHitRate(accountStats.cache.hit_rate_ema)}
+              size="lg"
+              color={hitRateColor}
+              suffix="%"
+            />
+            <Flex gap="2">
+              <Stat
+                label="R/S"
+                value={`${readsPerSec.value}${readsPerSec.unit}`}
+                color={accountsReadColor}
+                minWidth={cacheStatsMinWidth}
+              />
+              <Stat
+                label="W/S"
+                value={`${writesPerSec.value}${writesPerSec.unit}`}
+                color={accountsWriteColor}
+                minWidth={cacheStatsMinWidth}
+              />
+            </Flex>
+          </Flex>
+
+          <Flex direction="column" gap="2" flexGrow="1">
+            <div className={styles.sectionLabel}>Disk</div>
+            <Flex gap="2">
+              <Flex direction="column" gap="2">
+                <Flex gap="2" wrap="wrap">
+                  <Stat
+                    label="Used"
+                    value={used.value}
+                    size="lg"
+                    color={accountsUsedColor}
+                    suffix={used.unit}
+                    minWidth={storageStatsMinWidth}
+                  />
+                  <Stat
+                    label="Fragmented"
+                    value={frag.value}
+                    size="lg"
+                    color={accountsFragmentedColor}
+                    suffix={frag.unit}
+                    minWidth={storageStatsMinWidth}
+                  />
+                </Flex>
+                <Flex gap="2" wrap="wrap">
+                  <Stat
+                    label="Allocated"
+                    value={allocated.value}
+                    color={accountsSecondaryColor}
+                    suffix={allocated.unit}
+                    minWidth={storageStatsMinWidth}
+                  />
+                  {nextCompaction && (
+                    <Stat
+                      label="Next Compaction"
+                      value={nextCompaction.timeLabel}
+                      color="#EEE"
+                      minWidth={storageStatsMinWidth}
+                    />
+                  )}
+                </Flex>
+              </Flex>
+              <Flex direction="column" gap="2">
+                <Flex gap="2" wrap="wrap">
+                  <Stat
+                    label="Read"
+                    value={readPerSec.value}
+                    size="lg"
+                    color={accountsReadColor}
+                    suffix={`${readPerSec.unit}/s`}
+                    minWidth={readWriteStatsMinWidth}
+                  />
+                  <Stat
+                    label="Write"
+                    value={writePerSec.value}
+                    size="lg"
+                    color={accountsWriteColor}
+                    suffix={`${writePerSec.unit}/s`}
+                    minWidth={readWriteStatsMinWidth}
+                  />
+                </Flex>
+                <Flex gap="2" wrap="wrap">
+                  <Stat
+                    label="R/S"
+                    value={Math.round(
+                      accountStats.io.read_ops_per_sec,
+                    ).toLocaleString()}
+                    color={accountsReadColor}
+                    minWidth={readWriteStatsMinWidth}
+                  />
+                  <Stat
+                    label="W/S"
+                    value={Math.round(
+                      accountStats.io.write_ops_per_sec,
+                    ).toLocaleString()}
+                    color={accountsWriteColor}
+                    minWidth={readWriteStatsMinWidth}
+                  />
+                </Flex>
+              </Flex>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Card>
+  );
+}

--- a/src/features/Overview/ProgramCacheCard/HitRateStat.tsx
+++ b/src/features/Overview/ProgramCacheCard/HitRateStat.tsx
@@ -2,48 +2,24 @@ import { Flex, Text } from "@radix-ui/themes";
 import cardStatStyles from "../../../components/cardStat.module.css";
 import styles from "./hitRateStat.module.css";
 import clsx from "clsx";
+import { unknownChangedColor, unknownUnchangedColor } from "../../../colors";
 import {
-  goodChangedColor,
-  goodUnchangedColor,
-  badChangedColor,
-  badUnchangedColor,
-  unknownChangedColor,
-  unknownUnchangedColor,
-  averageChangedColor,
-  averageUnchangedColor,
-} from "../../../colors";
+  hitRateChangedColor,
+  hitRateUnchangedColor,
+  getHitRateStatus,
+  type HitRateStatus,
+} from "../../../hitRate";
 import { formatHitRate } from "../../../utils";
 import ColorText from "../../../components/ColorText";
 import { useAtomValue } from "jotai";
 import { useMemo } from "react";
 import { liveProgramCacheAtom } from "../../../api/atoms";
 
-type Status = "Unknown" | "Good" | "Average" | "Bad";
-
 type HitRateValues = {
   percentage: string;
   hits: string;
   misses: string;
-  status: Status;
-};
-
-const colorsMap: Record<Status, { changed: string; unchanged: string }> = {
-  Unknown: {
-    changed: unknownChangedColor,
-    unchanged: unknownUnchangedColor,
-  },
-  Good: {
-    changed: goodChangedColor,
-    unchanged: goodUnchangedColor,
-  },
-  Average: {
-    changed: averageChangedColor,
-    unchanged: averageUnchangedColor,
-  },
-  Bad: {
-    changed: badChangedColor,
-    unchanged: badUnchangedColor,
-  },
+  status: HitRateStatus;
 };
 
 export default function HitRateStat() {
@@ -61,18 +37,11 @@ export default function HitRateStat() {
 
     const { hits, lookups } = liveProgramCache;
 
-    const fraction = lookups === 0 ? 0 : hits / lookups;
-    const status =
-      lookups === 0
-        ? "Unknown"
-        : fraction < 0.9995
-          ? "Bad"
-          : fraction < 0.99999
-            ? "Average"
-            : "Good";
+    const fraction = lookups === 0 ? null : hits / lookups;
+    const status = getHitRateStatus(fraction);
 
     return {
-      percentage: formatHitRate(fraction),
+      percentage: fraction === null ? "-" : formatHitRate(fraction),
       hits: hits.toLocaleString(),
       misses: (lookups - hits).toLocaleString(),
       status,
@@ -89,14 +58,14 @@ export default function HitRateStat() {
       <Text className={cardStatStyles.label}>
         <Text>Hit Rate</Text>{" "}
         <Text className={styles.trailing}>Trailing 1m</Text>{" "}
-        <Text style={{ color: colorsMap[status].unchanged }}>{status}</Text>
+        <Text style={{ color: hitRateUnchangedColor(status) }}>{status}</Text>
       </Text>
       <Flex gap="2" align="center">
         <Flex align="baseline" gap="1" minWidth="70px">
           <ColorText
             value={percentage}
-            changedColor={colorsMap[status].changed}
-            unchangedColor={colorsMap[status].unchanged}
+            changedColor={hitRateChangedColor(status)}
+            unchangedColor={hitRateUnchangedColor(status)}
             className={clsx(cardStatStyles.value, cardStatStyles.small)}
           />
           <Text className={cardStatStyles.appendValue}>%</Text>

--- a/src/features/Overview/ProgramCacheCard/index.tsx
+++ b/src/features/Overview/ProgramCacheCard/index.tsx
@@ -11,9 +11,13 @@ import HitRateStat from "./HitRateStat";
 import StorageStat from "./StorageStat";
 import { programCacheColor } from "../../../colors";
 
-export default function ProgramCacheCard() {
+export default function ProgramCacheCard({
+  className,
+}: {
+  className?: string;
+}) {
   return (
-    <Card>
+    <Card className={className}>
       <Flex direction="column" height="100%" gap="2" align="start">
         <CardHeader text="Program Cache" />
         <div className={styles.statRow}>

--- a/src/features/Overview/StatusCard/index.tsx
+++ b/src/features/Overview/StatusCard/index.tsx
@@ -20,9 +20,9 @@ import Progress from "../../../components/Progress";
 import { getDurationText } from "../../../utils";
 import { Duration } from "luxon";
 
-export default function StatusCard() {
+export default function StatusCard({ className }: { className?: string }) {
   return (
-    <Card>
+    <Card className={className}>
       <Flex direction="column" height="100%" gap="2" align="start">
         <CardHeader text="Status" />
         <div className={styles.statRow}>

--- a/src/features/Overview/ValidatorsCard/index.tsx
+++ b/src/features/Overview/ValidatorsCard/index.tsx
@@ -5,12 +5,12 @@ import { useAtomValue } from "jotai";
 import { peerStatsAtom } from "../../../atoms";
 import ValidatorsStatsContent from "./ValidatorsStatsContent";
 
-export default function ValidatorsCard() {
+export default function ValidatorsCard({ className }: { className?: string }) {
   const peerStats = useAtomValue(peerStatsAtom);
   if (!peerStats) return null;
 
   return (
-    <Card>
+    <Card className={className}>
       <Flex direction="column" height="100%" gap="2">
         <CardHeader text="Validators" />
         <ValidatorsStatsContent />

--- a/src/features/Overview/index.tsx
+++ b/src/features/Overview/index.tsx
@@ -8,6 +8,7 @@ import LiveNetworkMetrics from "./LiveNetworkMetrics";
 import LiveTileMetrics from "./LiveTileMetrics";
 import SlotTimeline from "./SlotTimeline";
 import ProgramCacheCard from "./ProgramCacheCard";
+import AccountsCard from "./AccountsCard";
 import styles from "./overview.module.css";
 import { isFrankendancer } from "../../client";
 import clsx from "clsx";
@@ -23,8 +24,11 @@ export default function Overview() {
         gap="4"
       >
         <StatusCard />
-        <ValidatorsCard />
-        {!isFrankendancer && <ProgramCacheCard />}
+        <ValidatorsCard className={styles.validatorsCard} />
+        {!isFrankendancer && (
+          <ProgramCacheCard className={styles.programCacheCard} />
+        )}
+        {!isFrankendancer && <AccountsCard className={styles.accountsCard} />}
         <TransactionsCard className={styles.txnsCard} />
       </Grid>
       <ShredsProgression />

--- a/src/features/Overview/overview.module.css
+++ b/src/features/Overview/overview.module.css
@@ -2,30 +2,64 @@
   grid-template-columns: minmax(300px, 1fr);
 }
 
-@media (min-width: 900px) {
-  .cards {
-    grid-template-columns: 1fr 1fr;
-  }
+/* Firedancer */
 
-  .frankendancer {
+@media (900px <= width < 1450px) {
+  .cards:not(.frankendancer) {
+    grid-template-columns: repeat(2, 1fr);
+
+    .program-cache-card,
+    .accounts-card,
     .txns-card {
       grid-column: span 2;
     }
   }
 }
 
-@media (min-width: 1512px) {
-  .cards {
-    grid-template-columns: 1fr 1fr 1fr;
-  }
+@media (1450px <= width < 1770px) {
+  .cards:not(.frankendancer) {
+    grid-template-columns: repeat(3, 1fr);
 
-  .txns-card {
-    grid-column: span 3;
-  }
-
-  .frankendancer {
-    .txns-card {
-      grid-column: span 1;
+    .validators-card,
+    .accounts-card {
+      grid-column: span 2;
     }
+
+    .txns-card {
+      grid-column: span 3;
+    }
+  }
+}
+
+@media (1770px <= width) {
+  .cards:not(.frankendancer) {
+    grid-template-columns: repeat(6, 1fr);
+
+    > * {
+      grid-column: span 2;
+    }
+
+    .accounts-card,
+    .txns-card {
+      grid-column: span 3;
+    }
+  }
+}
+
+/* Frankendancer */
+
+@media (910px <= width < 1850px) {
+  .frankendancer {
+    grid-template-columns: repeat(2, 1fr);
+
+    .txns-card {
+      grid-column: span 2;
+    }
+  }
+}
+
+@media (1850px <= width) {
+  .frankendancer {
+    grid-template-columns: 1fr 1.1fr 2fr;
   }
 }

--- a/src/hitRate.ts
+++ b/src/hitRate.ts
@@ -1,0 +1,44 @@
+import {
+  averageChangedColor,
+  averageUnchangedColor,
+  badChangedColor,
+  badUnchangedColor,
+  goodChangedColor,
+  goodUnchangedColor,
+  unknownChangedColor,
+  unknownUnchangedColor,
+} from "./colors";
+import tableStyles from "./components/dataTable.module.css";
+
+export type HitRateStatus = "Good" | "Average" | "Bad" | "Unknown";
+
+export function getHitRateStatus(
+  rate: number | null | undefined,
+): HitRateStatus {
+  if (rate == null) return "Unknown";
+  if (rate < 0.99) return "Bad";
+  if (rate < 0.995) return "Average";
+  return "Good";
+}
+
+export function hitRateChangedColor(status: HitRateStatus) {
+  if (status === "Good") return goodChangedColor;
+  if (status === "Average") return averageChangedColor;
+  if (status === "Bad") return badChangedColor;
+  return unknownChangedColor;
+}
+
+export function hitRateUnchangedColor(status: HitRateStatus) {
+  if (status === "Good") return goodUnchangedColor;
+  if (status === "Average") return averageUnchangedColor;
+  if (status === "Bad") return badUnchangedColor;
+  return unknownUnchangedColor;
+}
+
+export function hitRateClass(rate: number | null | undefined) {
+  const status = getHitRateStatus(rate);
+  if (status === "Good") return tableStyles.green;
+  if (status === "Average") return tableStyles.orange;
+  if (status === "Bad") return tableStyles.red;
+  return undefined;
+}


### PR DESCRIPTION
- add accounts card to overview page
- update overview card layout (separate frankendancer vs firedancer layout entirely with different breakpoints)