### PR TITLE
fix: update webgl geometry max instance count on capacity change

### DIFF
--- a/src/features/Overview/ShredsProgression/webglUtils.ts
+++ b/src/features/Overview/ShredsProgression/webglUtils.ts
@@ -156,6 +156,10 @@ export function ensureCapacity(slotMesh: SlotMesh, needed: number) {
   const geometry = slotMesh.mesh.geometry as THREE.InstancedBufferGeometry;
   geometry.setAttribute("instanceRect", slotMesh.rectAttr);
   geometry.setAttribute("instanceColor", slotMesh.colorAttr);
+  // clear private field _maxInstanceCount for recomputation,
+  // instead of allocating a new geometry
+  // @ts-expect-error
+  geometry._maxInstanceCount = undefined;
 }
 
 export function addRectangleToMesh(


### PR DESCRIPTION
- Three sets `geometry._maxInstanceCount` once and doesn't change it even if `instanceCount` is changed. Manually set the value to `undefined` to trigger value setting again