### PR TITLE
refactor: canvas tps chart

### DIFF
--- a/src/api/consts.ts
+++ b/src/api/consts.ts
@@ -1,4 +1,4 @@
-export const estimatedTpsDebounceMs = 400;
+export const tpsSampleIntervalMs = 200;
 export const liveMetricsDebounceMs = 100;
 export const liveTileMetricsDebounceMs = 25;
 export const liveNetworkMetricsDebounceMs = 100;

--- a/src/api/useSetAtomWsData.ts
+++ b/src/api/useSetAtomWsData.ts
@@ -101,7 +101,7 @@ import {
 } from "./atoms";
 import { accountsNextCompactionAtom } from "../atoms";
 import {
-  estimatedTpsDebounceMs,
+  tpsSampleIntervalMs,
   liveNetworkMetricsDebounceMs,
   liveTileMetricsDebounceMs,
   liveMetricsDebounceMs,
@@ -260,7 +260,7 @@ function useUpdateAtoms() {
     (value?: EstimatedTps) => {
       setEstimatedTps(value);
     },
-    estimatedTpsDebounceMs,
+    tpsSampleIntervalMs,
   );
 
   const setLiveNetworkMetrics = useSetAtom(liveNetworkMetricsAtom);

--- a/src/features/Overview/TransactionsCard/Chart.tsx
+++ b/src/features/Overview/TransactionsCard/Chart.tsx
@@ -1,7 +1,6 @@
-import AutoSizer from "react-virtualized-auto-sizer";
-import { useMemo, useRef } from "react";
-import { isDefined } from "../../../utils";
-import { useAtomValue } from "jotai";
+import { useLayoutEffect, useRef } from "react";
+import { getDefaultStore } from "jotai";
+import { useMeasure, useRafLoop } from "react-use";
 import { tpsDataAtom } from "./atoms";
 import {
   regularTextColor,
@@ -9,123 +8,128 @@ import {
   transactionNonVotePathColor,
   transactionVotePathColor,
 } from "../../../colors";
+import { WINDOW_MS } from "./consts";
 
-const getPath = (points: { x: number; y: number }[], height: number) => {
-  if (!points.length) return "";
+const TOP_PADDING = 10;
 
-  const path = points.map(({ x, y }) => `L ${x} ${height - y}`).join(" ");
-
-  return (
-    "M" +
-    path.slice(1) +
-    `L ${points[points.length - 1].x} ${height} L ${points[0].x} ${height}, L ${points[0].x} ${points[0].y}`
-  );
-};
+const store = getDefaultStore();
 
 export default function Chart() {
-  const tpsData = useAtomValue(tpsDataAtom);
-  const sizeRefs = useRef<{ height: number; width: number }>();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [measureRef, { width, height }] = useMeasure<HTMLDivElement>();
 
-  const maxTotalTps = Math.max(...tpsData.map((d) => d?.total ?? 0));
+  useLayoutEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !width || !height) return;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.round(width * dpr);
+    canvas.height = Math.round(height * dpr);
 
-  const scaledPaths = useMemo(() => {
-    if (!sizeRefs.current) return;
-    if (!tpsData.length) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }, [width, height]);
 
-    const { height, width } = sizeRefs.current;
-    const maxLength = tpsData.length;
-    const xRatio = (width + 2) / maxLength;
-    const yRatio = (height - 10) / (maxTotalTps || 1);
+  useRafLoop(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !width || !height) return;
 
-    const points = tpsData
-      .map((d, i) => {
-        if (d === undefined) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
 
-        return {
-          x: i * xRatio,
-          voteY: d.vote * yRatio,
-          nonvoteFailedY: (d.nonvote_failed + d.vote) * yRatio,
-          nonvoteY: (d.nonvote_success + d.nonvote_failed + d.vote) * yRatio,
-        };
-      })
-      .filter(isDefined);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-    const maxTotalY = height - maxTotalTps * yRatio;
+    const data = store.get(tpsDataAtom);
+    if (!data.length) return;
 
-    return {
-      votePath: getPath(
-        points.map((p) => ({ x: p.x, y: p.voteY })),
-        height,
-      ),
-      failedPath: getPath(
-        points.map((p) => ({ x: p.x, y: p.nonvoteFailedY })),
-        height,
-      ),
-      nonvotePath: getPath(
-        points.map((p) => ({ x: p.x, y: p.nonvoteY })),
-        height,
-      ),
-      totalTpsY: isNaN(maxTotalY) ? undefined : maxTotalY,
-    };
-  }, [maxTotalTps, tpsData]);
+    const maxTotalY = data.reduce((max, p) => Math.max(max, p.tps.total), 0);
+    if (maxTotalY === 0) return;
+
+    const yRatio = (height - TOP_PADDING) / maxTotalY;
+    const now = performance.now();
+
+    const points = data.map((p) => ({
+      x: width * (1 - (now - p.ts) / WINDOW_MS),
+      voteY: p.tps.vote * yRatio,
+      nonvoteFailedY: (p.tps.nonvote_failed + p.tps.vote) * yRatio,
+      nonvoteY:
+        (p.tps.nonvote_success + p.tps.nonvote_failed + p.tps.vote) * yRatio,
+    }));
+
+    drawArea(
+      ctx,
+      points,
+      width,
+      height,
+      "nonvoteY",
+      transactionNonVotePathColor,
+    );
+    drawArea(
+      ctx,
+      points,
+      width,
+      height,
+      "nonvoteFailedY",
+      transactionFailedPathColor,
+    );
+    drawArea(ctx, points, width, height, "voteY", transactionVotePathColor);
+
+    drawPeakLine(ctx, width, height, maxTotalY * yRatio, maxTotalY);
+  });
 
   return (
-    <>
-      <AutoSizer>
-        {({ height, width }) => {
-          sizeRefs.current = { height, width };
-          if (!scaledPaths) return null;
-          return (
-            <>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width={width}
-                height={height}
-                fill="none"
-              >
-                <path
-                  fillRule="evenodd"
-                  clipRule="evenodd"
-                  d={scaledPaths.nonvotePath}
-                  fill={transactionNonVotePathColor}
-                />
-                <path
-                  d={scaledPaths.failedPath}
-                  fill={transactionFailedPathColor}
-                />
-                <path
-                  fillRule="evenodd"
-                  clipRule="evenodd"
-                  fill={transactionVotePathColor}
-                  d={scaledPaths.votePath}
-                />
-
-                {scaledPaths.totalTpsY && (
-                  <>
-                    <line
-                      x1="0"
-                      y1={scaledPaths.totalTpsY}
-                      x2={width}
-                      y2={scaledPaths.totalTpsY}
-                      strokeDasharray="4"
-                      stroke="rgba(255, 255, 255, 0.30)"
-                    />
-                    <text
-                      x="0"
-                      y={scaledPaths.totalTpsY - 3}
-                      fill={regularTextColor}
-                      fontSize="8"
-                      fontFamily="Inter Tight"
-                    >
-                      {maxTotalTps.toLocaleString()}
-                    </text>
-                  </>
-                )}
-              </svg>
-            </>
-          );
-        }}
-      </AutoSizer>
-    </>
+    <div ref={measureRef} style={{ position: "absolute", inset: 0 }}>
+      <canvas ref={canvasRef} style={{ display: "block", width, height }} />
+    </div>
   );
+}
+
+type Point = {
+  x: number;
+  voteY: number;
+  nonvoteFailedY: number;
+  nonvoteY: number;
+};
+
+function drawArea(
+  ctx: CanvasRenderingContext2D,
+  points: Point[],
+  canvasWidth: number,
+  canvasHeight: number,
+  heightKey: keyof Omit<Point, "x">,
+  color: string,
+) {
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, canvasHeight - points[0][heightKey]);
+  for (let i = 1; i < points.length; i++) {
+    ctx.lineTo(points[i].x, canvasHeight - points[i][heightKey]);
+  }
+  ctx.lineTo(canvasWidth, canvasHeight - points[points.length - 1][heightKey]);
+  ctx.lineTo(canvasWidth, canvasHeight);
+  ctx.lineTo(points[0].x, canvasHeight);
+  ctx.closePath();
+  ctx.fillStyle = color;
+  ctx.fill();
+}
+
+function drawPeakLine(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  peakPixelHeight: number,
+  peakTps: number,
+) {
+  const y = height - peakPixelHeight;
+  ctx.beginPath();
+  ctx.setLineDash([4, 4]);
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.30)";
+  ctx.lineWidth = 1;
+  ctx.moveTo(0, y);
+  ctx.lineTo(width, y);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  ctx.fillStyle = regularTextColor;
+  ctx.font = "8px 'Inter Tight'";
+  ctx.fillText(peakTps.toLocaleString(), 0, y - 3);
 }

--- a/src/features/Overview/TransactionsCard/atoms.ts
+++ b/src/features/Overview/TransactionsCard/atoms.ts
@@ -1,7 +1,9 @@
 import type { EstimatedTps } from "../../../api/types";
 import { atomWithImmer } from "jotai-immer";
-import { maxTransactionChartPoints } from "./consts";
 
-export const tpsDataAtom = atomWithImmer<(EstimatedTps | undefined)[]>(
-  new Array<undefined>(maxTransactionChartPoints).fill(undefined),
-);
+export interface TpsDataPoint {
+  ts: number;
+  tps: EstimatedTps;
+}
+
+export const tpsDataAtom = atomWithImmer<TpsDataPoint[]>([]);

--- a/src/features/Overview/TransactionsCard/consts.ts
+++ b/src/features/Overview/TransactionsCard/consts.ts
@@ -1,1 +1,2 @@
-export const maxTransactionChartPoints = 600;
+// Keep in sync with the hardcoded "~ 1min ago" axis label in index.tsx
+export const WINDOW_MS = 60_000;

--- a/src/features/Overview/TransactionsCard/index.tsx
+++ b/src/features/Overview/TransactionsCard/index.tsx
@@ -17,7 +17,13 @@ export default function TransactionsCard({
         <Flex gap="4" flexGrow="1">
           <TransactionStats />
           <Flex direction="column" flexGrow="1">
-            <Box flexGrow="1" minWidth="180px" overflow="hidden">
+            <Box
+              flexGrow="1"
+              minWidth="180px"
+              minHeight="80px"
+              overflow="hidden"
+              position="relative"
+            >
               <Chart />
             </Box>
             <Flex justify="between">

--- a/src/features/Overview/TransactionsCard/useUpdateTransactions.tsx
+++ b/src/features/Overview/TransactionsCard/useUpdateTransactions.tsx
@@ -1,11 +1,12 @@
 import { getDefaultStore, useAtomValue, useSetAtom } from "jotai";
 import { estimatedTpsAtom, tpsHistoryAtom } from "../../../api/atoms";
+import { tpsSampleIntervalMs } from "../../../api/consts";
 import { useEffect, useRef } from "react";
 import { tpsDataAtom } from "./atoms";
-import type { EstimatedTps } from "../../../api/types";
-import { maxTransactionChartPoints } from "./consts";
+import { WINDOW_MS } from "./consts";
 
 const store = getDefaultStore();
+const MAX_HISTORY_POINTS = Math.ceil(WINDOW_MS / tpsSampleIntervalMs);
 
 export default function useUpdateTransactions() {
   const tpsHistory = useAtomValue(tpsHistoryAtom);
@@ -14,53 +15,27 @@ export default function useUpdateTransactions() {
   useEffect(() => {
     if (!tpsHistory) return;
 
-    const empty: undefined[] = new Array<undefined>(
-      maxTransactionChartPoints,
-    ).fill(undefined);
+    const now = performance.now();
 
-    const tps = [
-      ...empty,
-      ...tpsHistory.flatMap<EstimatedTps>(
-        ([total, vote, nonvote_success, nonvote_failed]) => [
-          {
-            total,
-            vote,
-            nonvote_success,
-            nonvote_failed,
-          },
-          {
-            total,
-            vote,
-            nonvote_success,
-            nonvote_failed,
-          },
-          {
-            total,
-            vote,
-            nonvote_success,
-            nonvote_failed,
-          },
-          {
-            total,
-            vote,
-            nonvote_success,
-            nonvote_failed,
-          },
-        ],
-      ),
-    ];
-    setTpsData(tps.slice(tps.length - maxTransactionChartPoints));
+    const timestampedHistory = tpsHistory
+      .slice(-MAX_HISTORY_POINTS)
+      .map(([total, vote, nonvote_success, nonvote_failed], i, arr) => ({
+        ts: now - (arr.length - 1 - i) * tpsSampleIntervalMs,
+        tps: { total, vote, nonvote_success, nonvote_failed },
+      }));
+
+    setTpsData(timestampedHistory);
   }, [setTpsData, tpsHistory]);
 
   const pushTpsData = () => {
-    if (!tpsHistory) return;
-
     const tps = store.get(estimatedTpsAtom);
     if (tps === undefined) return;
 
+    const ts = performance.now();
     setTpsData((draft) => {
-      draft.push(tps);
-      if (draft.length > maxTransactionChartPoints) draft.shift();
+      draft.push({ ts, tps });
+      const windowStart = ts - WINDOW_MS;
+      while (draft.length > 1 && draft[1].ts < windowStart) draft.shift();
     });
   };
 
@@ -71,7 +46,7 @@ export default function useUpdateTransactions() {
     let timeout: NodeJS.Timeout;
     function tick() {
       pushTpsDataRef.current();
-      timeout = setTimeout(tick, 100);
+      timeout = setTimeout(tick, tpsSampleIntervalMs);
     }
     tick();
     return () => clearTimeout(timeout);


### PR DESCRIPTION
- rewrites TPS chart from SVG to canvas
- draws on every animation frame instead of every 100ms tick when tps data is pushed
- fix syncing of tps data pushing (100ms) with the estimatedTpsAtom updating (previously 400ms)
- fix the assumed sampling rate of tpsHistory points (previously 400ms)
- derive window label from window ms

Related backend change to account for tps history samples being 200ms apart: https://github.com/firedancer-io/firedancer/commit/73146bf3e5831d902cef59ca8d941294cd66d310