### PR TITLE
feat: dynamic heights for banks chart/series

### DIFF
--- a/src/features/Overview/SlotPerformance/ComputeUnitsCard/atoms.ts
+++ b/src/features/Overview/SlotPerformance/ComputeUnitsCard/atoms.ts
@@ -5,8 +5,9 @@ import { ScheduleStrategyEnum } from "../../../../api/entities";
 
 export const cuChartTooltipDataAtom = atom<CuChartTooltipData>();
 
-export const leftAxisSizeAtom = atom(0);
-export const rightAxisSizeAtom = atom(0);
+// seed with estimates to reduce shift on load before the real sizes are measured
+export const leftAxisSizeAtom = atom(45);
+export const rightAxisSizeAtom = atom(60);
 
 export const isFullXRangeAtom = atom(true);
 

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/BarChartFloatingAction.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/BarChartFloatingAction.tsx
@@ -1,20 +1,26 @@
 import { Button, Text } from "@radix-ui/themes";
 import { EnterFullScreenIcon, ExitFullScreenIcon } from "@radix-ui/react-icons";
 import styles from "./barChartFloatingAction.module.css";
+import { barChartAxisSize } from "./consts";
 
 interface BarChartFloatingActionProps {
   isSelected: boolean;
   setSelected: () => void;
   bankIdx: number;
+  hasTopAxis?: boolean;
 }
 
 export default function BarChartFloatingAction({
   setSelected,
   bankIdx,
   isSelected,
+  hasTopAxis,
 }: BarChartFloatingActionProps) {
   return (
-    <div className={styles.container}>
+    <div
+      className={styles.container}
+      style={{ marginTop: hasTopAxis ? barChartAxisSize : undefined }}
+    >
       <Text className={styles.label}>Bank {bankIdx}</Text>
       <Button variant="ghost" size="1" onClick={() => setSelected()}>
         {!isSelected ? (

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChart.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChart.tsx
@@ -21,6 +21,7 @@ import { chartAxisColor, chartGridStrokeColor } from "../../../../colors";
 import { banksXScaleKey } from "../ComputeUnitsCard/consts";
 import { getTxnBundleStats } from "../../../../transactionUtils";
 import clsx from "clsx";
+import { barChartAxisSize } from "./consts";
 
 /** Buffer of the canvas past the axes of the chart to prevent the first and last tick labels from being cut off */
 const xBuffer = 20;
@@ -107,7 +108,7 @@ export default function BarsChart({
               ? ticks.map((rawValue) => safeDivide(rawValue, 1_000_000) + "ms")
               : [];
           },
-          size: isFirstOrLastChart ? 40 : 0,
+          size: isFirstOrLastChart ? barChartAxisSize : 0,
           space: 100,
           grid: { stroke: chartGridStrokeColor },
           border: {
@@ -179,7 +180,7 @@ export default function BarsChart({
         marginRight: `${rightAxisSize}px`,
         display: hide ? "none" : "block",
         height: isSelected
-          ? `${Math.max(2, barCount) * 90 + 40}px`
+          ? `${Math.max(2, barCount) * 90 + barChartAxisSize}px`
           : // Only the first and last charts have a visible labeled x axis
             isFirstOrLastChart
             ? "170px"

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChart.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChart.tsx
@@ -5,7 +5,8 @@ import "uplot/dist/uPlot.min.css";
 import { txnBarsPlugin } from "./txnBarsPlugin";
 import { getDefaultStore, useAtomValue, useSetAtom } from "jotai";
 import UplotReact from "../../../../uplotReact/UplotReact";
-import AutoSizer from "react-virtualized-auto-sizer";
+import { useMeasure } from "react-use";
+import { useDebounce } from "use-debounce";
 import type { SlotTransactions } from "../../../../api/types";
 import { tooltipTxnIdxAtom, tooltipTxnStateAtom } from "./chartTooltipAtoms";
 import { timeScaleDragPlugin } from "./scaleDragPlugin";
@@ -21,40 +22,50 @@ import { chartAxisColor, chartGridStrokeColor } from "../../../../colors";
 import { banksXScaleKey } from "../ComputeUnitsCard/consts";
 import { getTxnBundleStats } from "../../../../transactionUtils";
 import clsx from "clsx";
-import { barChartAxisSize } from "./consts";
+import { barChartAxisSize, barChartXBuffer } from "./consts";
 
-/** Buffer of the canvas past the axes of the chart to prevent the first and last tick labels from being cut off */
-const xBuffer = 20;
+const store = getDefaultStore();
 
 interface BarsChartProps {
   bankIdx: number;
   transactions: SlotTransactions;
   maxTs: number;
-  isFirstChart?: boolean;
-  isLastChart?: boolean;
-  hide?: boolean;
-  isSelected?: boolean;
+  rowHeight: number;
+  hasAxis?: boolean;
+  hasTopAxis?: boolean;
   isFocused?: boolean;
 }
+
+const resizeDebounceMs = 500;
 
 export default function BarsChart({
   bankIdx,
   transactions,
   maxTs,
-  isFirstChart,
-  isLastChart,
-  hide,
-  isSelected,
+  rowHeight,
+  hasAxis,
+  hasTopAxis,
   isFocused,
 }: BarsChartProps) {
-  const isFirstOrLastChart = isFirstChart || isLastChart;
-  const leftAxisSize = useAtomValue(leftAxisSizeAtom) - xBuffer;
-  const rightAxisSize = useAtomValue(rightAxisSizeAtom) - xBuffer;
+  const leftAxisSize = Math.max(
+    0,
+    useAtomValue(leftAxisSizeAtom) - barChartXBuffer,
+  );
+  const rightAxisSize = Math.max(
+    0,
+    useAtomValue(rightAxisSizeAtom) - barChartXBuffer,
+  );
+  const yAxisHeight = hasAxis ? barChartAxisSize : 0;
 
   const setTxnIdx = useSetAtom(tooltipTxnIdxAtom);
   const setTxnState = useSetAtom(tooltipTxnStateAtom);
 
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerRef, { width: measuredWidth }] = useMeasure<HTMLDivElement>();
+  const [width] = useDebounce(measuredWidth, resizeDebounceMs, {
+    leading: true,
+    trailing: true,
+    maxWait: resizeDebounceMs,
+  });
   const transactionsRef = useRef<SlotTransactions>(transactions);
   transactionsRef.current = transactions;
   const chartData = useMemo<uPlot.AlignedData | undefined>(() => {
@@ -62,7 +73,7 @@ export default function BarsChart({
       transactions,
       bankIdx,
       maxTs,
-      Object.values(getDefaultStore().get(chartFiltersAtom)),
+      Object.values(store.get(chartFiltersAtom)),
     );
   }, [bankIdx, maxTs, transactions]);
 
@@ -74,7 +85,7 @@ export default function BarsChart({
           transactions,
           bankIdx,
           maxTs,
-          Object.values(getDefaultStore().get(chartFiltersAtom)),
+          Object.values(store.get(chartFiltersAtom)),
         ),
         false,
       );
@@ -104,11 +115,11 @@ export default function BarsChart({
           scale: banksXScaleKey,
           stroke: chartAxisColor,
           values: (self, ticks) => {
-            return isFirstOrLastChart
+            return hasAxis
               ? ticks.map((rawValue) => safeDivide(rawValue, 1_000_000) + "ms")
               : [];
           },
-          size: isFirstOrLastChart ? barChartAxisSize : 0,
+          size: yAxisHeight,
           space: 100,
           grid: { stroke: chartGridStrokeColor },
           border: {
@@ -121,7 +132,7 @@ export default function BarsChart({
             stroke: chartAxisColor,
             size: 5,
           },
-          side: isFirstChart ? 0 : 2,
+          side: hasTopAxis ? 0 : 2,
         },
         {
           border: {
@@ -133,7 +144,7 @@ export default function BarsChart({
         },
       ],
       legend: { markers: { width: 0 }, show: false },
-      padding: [0, xBuffer, 0, xBuffer],
+      padding: [0, barChartXBuffer, 0, barChartXBuffer],
       series: [{ scale: banksXScaleKey }, { label: `Bank ${bankIdx}` }, {}],
       plugins: [
         txnBarsPlugin(transactionsRef, transactionsBundleStats),
@@ -161,8 +172,9 @@ export default function BarsChart({
   }, [
     bankIdx,
     chartData?.length,
-    isFirstChart,
-    isFirstOrLastChart,
+    yAxisHeight,
+    hasTopAxis,
+    hasAxis,
     setTxnIdx,
     setTxnState,
     transactionsBundleStats,
@@ -170,7 +182,11 @@ export default function BarsChart({
 
   const barCount = useAtomValue(barCountAtom);
 
-  if (!chartData || !options || hide) return null;
+  if (!chartData || !options) return null;
+
+  const chartHeight = Math.max(1, barCount) * rowHeight + yAxisHeight;
+  options.width = width;
+  options.height = chartHeight;
 
   return (
     <div
@@ -178,33 +194,20 @@ export default function BarsChart({
         flex: 1,
         marginLeft: `${leftAxisSize}px`,
         marginRight: `${rightAxisSize}px`,
-        display: hide ? "none" : "block",
-        height: isSelected
-          ? `${Math.max(2, barCount) * 90 + barChartAxisSize}px`
-          : // Only the first and last charts have a visible labeled x axis
-            isFirstOrLastChart
-            ? "170px"
-            : "130px",
+        height: `${chartHeight}px`,
       }}
       ref={containerRef}
     >
-      <AutoSizer>
-        {({ height, width }) => {
-          options.width = width;
-          options.height = height;
-          return (
-            <>
-              <UplotReact
-                id={getUplotId(bankIdx)}
-                className={clsx(isFocused && styles.focused)}
-                options={options}
-                data={chartData}
-                onCreate={handleCreate}
-              />
-            </>
-          );
-        }}
-      </AutoSizer>
+      {width > 0 && (
+        <UplotReact
+          id={getUplotId(bankIdx)}
+          className={clsx(isFocused && styles.focused)}
+          options={options}
+          data={chartData}
+          onCreate={handleCreate}
+          setSizeDebounceMs={resizeDebounceMs}
+        />
+      )}
     </div>
   );
 }

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChartContainer.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChartContainer.tsx
@@ -1,14 +1,20 @@
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import type uPlot from "uplot";
 import "uplot/dist/uPlot.min.css";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useMeasure, useWindowSize } from "react-use";
+import { clamp } from "lodash";
 import { selectedSlotAtom, tileCountAtom } from "../atoms";
-import type { SlotTransactions } from "../../../../api/types";
 import ChartControls from "./ChartControls";
 import { Flex } from "@radix-ui/themes";
 import BarsChart from "./BarsChart";
+import {
+  barChartAxisSize,
+  barChartMaxHeight,
+  barChartMinRowHeight,
+} from "./consts";
 import { useSlotQueryResponseTransactions } from "../../../../hooks/useSlotQuery";
-import { baseChartDataAtom, selectedBankAtom } from "./atoms";
+import { baseChartDataAtom, barCountAtom, selectedBankAtom } from "./atoms";
 import { getChartData } from "./chartUtils";
 import BarChartFloatingAction from "./BarChartFloatingAction";
 import CardHeader from "../../../../components/CardHeader";
@@ -38,10 +44,7 @@ export default function BarsChartContainer() {
   const slot = useAtomValue(selectedSlotAtom);
 
   const query = useSlotQueryResponseTransactions(slot);
-  const queryTxsRef = useRef<SlotTransactions | null | undefined>(
-    query.response?.transactions,
-  );
-  queryTxsRef.current = query.response?.transactions;
+  const transactions = query.response?.transactions;
 
   const tileCount = useAtomValue(tileCountAtom);
   const bankTileCount = tileCount[tileNames.bank];
@@ -49,32 +52,54 @@ export default function BarsChartContainer() {
   const setBaseChartDataAtom = useSetAtom(baseChartDataAtom);
 
   const maxTs = useMemo(() => {
-    if (!query.response?.transactions) return 0;
+    if (!transactions) return 0;
 
-    return getMaxTs(query.response.transactions, true);
-  }, [query.response?.transactions]);
+    return getMaxTs(transactions, true);
+  }, [transactions]);
 
   useMemo(() => {
-    if (!query.response?.transactions) return;
+    if (!transactions) return;
     const chartData: uPlot.AlignedData[] = [];
     for (let i = 0; i < bankTileCount; i++) {
-      chartData.push(getChartData(query.response.transactions, i, maxTs));
+      chartData.push(getChartData(transactions, i, maxTs));
     }
     setBaseChartDataAtom(chartData);
-  }, [
-    bankTileCount,
-    maxTs,
-    query.response?.transactions,
-    setBaseChartDataAtom,
-  ]);
+  }, [bankTileCount, maxTs, transactions, setBaseChartDataAtom]);
 
   const [selected, setSelected] = useAtom(selectedBankAtom);
 
-  if (!query.response?.transactions) return null;
+  const { height: windowHeight } = useWindowSize();
+  const [controlsRef, { height: controlsHeight }] =
+    useMeasure<HTMLDivElement>();
+
+  const barCount = useAtomValue(barCountAtom);
+
+  const rowHeight = useMemo(() => {
+    const rows = Math.max(1, barCount);
+    const visibleBankCount =
+      selected !== undefined ? 1 : Math.max(1, bankTileCount);
+    const availableForCharts =
+      windowHeight -
+      txnBarsControlsStickyTop -
+      controlsHeight -
+      barChartAxisSize * Math.min(visibleBankCount, 2);
+    const maxRowHeight = Math.max(
+      barChartMaxHeight / rows,
+      barChartMinRowHeight,
+    );
+    return clamp(
+      availableForCharts / (visibleBankCount * rows),
+      barChartMinRowHeight,
+      maxRowHeight,
+    );
+  }, [windowHeight, controlsHeight, bankTileCount, barCount, selected]);
+
+  if (!transactions) return null;
 
   return (
     <Flex direction="column" height="100%">
       <Flex
+        ref={controlsRef}
         id="transaction-bars-controls"
         gap="2"
         position="sticky"
@@ -89,16 +114,14 @@ export default function BarsChartContainer() {
         }}
       >
         <CardHeader text="Banks" />
-        <ChartControls
-          transactions={query.response.transactions}
-          maxTs={maxTs}
-        />
+        <ChartControls transactions={transactions} maxTs={maxTs} />
       </Flex>
       {new Array(bankTileCount).fill(0).map((_, bankIdx) => {
         const isSelected = selected === bankIdx;
         if (selected !== undefined && !isSelected) return;
 
         const hasTopAxis = bankIdx === 0 || isSelected;
+        const hasAxis = hasTopAxis || bankIdx === bankTileCount - 1;
 
         return (
           <div key={bankIdx} style={{ position: "relative" }}>
@@ -117,15 +140,12 @@ export default function BarsChartContainer() {
             <BarsChart
               key={`${bankIdx}`}
               bankIdx={bankIdx}
-              transactions={query.response.transactions}
+              transactions={transactions}
               maxTs={maxTs}
-              isFirstChart={bankIdx === 0 && bankTileCount > 1}
-              isLastChart={
-                bankIdx === bankTileCount - 1 || selected !== undefined
-              }
-              isSelected={selected === bankIdx}
-              hide={selected !== undefined && selected !== bankIdx}
+              hasAxis={hasAxis}
+              hasTopAxis={hasTopAxis}
               isFocused={focusedBankIdx === bankIdx}
+              rowHeight={rowHeight}
             />
           </div>
         );

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChartContainer.tsx
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/BarsChartContainer.tsx
@@ -95,12 +95,14 @@ export default function BarsChartContainer() {
         />
       </Flex>
       {new Array(bankTileCount).fill(0).map((_, bankIdx) => {
-        if (!query.response?.transactions) return;
-        if (selected !== undefined && selected !== bankIdx) return;
+        const isSelected = selected === bankIdx;
+        if (selected !== undefined && !isSelected) return;
+
+        const hasTopAxis = bankIdx === 0 || isSelected;
 
         return (
           <div key={bankIdx} style={{ position: "relative" }}>
-            {(selected === undefined || selected === bankIdx) && (
+            {(selected === undefined || isSelected) && (
               <BarChartFloatingAction
                 bankIdx={bankIdx}
                 setSelected={() =>
@@ -108,7 +110,8 @@ export default function BarsChartContainer() {
                     prev === undefined ? bankIdx : undefined,
                   )
                 }
-                isSelected={selected === bankIdx}
+                isSelected={isSelected}
+                hasTopAxis={hasTopAxis}
               />
             )}
             <BarsChart

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/atoms.ts
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/atoms.ts
@@ -273,7 +273,7 @@ function addSeriesAtom(
         u.addSeries({ ...u.series[1], label: `${filterEnum}` }, sidx);
         setBarCount(u.series.filter((s) => s.show).length - 1);
         u.setData(u.data, false);
-        if (get(selectedBankAtom) === undefined) u.redraw(true, true);
+        u.redraw(true, true);
       }
 
       addSeriesFunc[filterEnum] = addSeries;
@@ -328,7 +328,7 @@ export const removeSeriesAtom = atom(
     u.data.splice(sidx, 1);
     setBarCount(u.data.length - 1);
     u.setData(u.data, false);
-    if (get(selectedBankAtom) === undefined) u.redraw(true, true);
+    u.redraw(true, true);
 
     delete addSeriesFunc[filterEnum];
   },

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/consts.ts
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/consts.ts
@@ -55,4 +55,8 @@ export const txnBarsUplotIdPrefix = "bank-";
 
 export const revenueLogBase = 1.7;
 
+/** Buffer of the canvas past the axes of the chart to prevent the first and last tick labels from being cut off */
+export const barChartXBuffer = 20;
 export const barChartAxisSize = 40;
+export const barChartMinRowHeight = 30;
+export const barChartMaxHeight = 130;

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/consts.ts
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/consts.ts
@@ -54,3 +54,5 @@ export const enum FilterEnum {
 export const txnBarsUplotIdPrefix = "bank-";
 
 export const revenueLogBase = 1.7;
+
+export const barChartAxisSize = 40;


### PR DESCRIPTION
Fixes existing bugs:
- the first bank chart label does not render next to the bank track itself because the chart itself includes a x-axis whose height is not accounted for
- toggling a series while a bank is selected was not updating the chart because the redraw was skipped

Dynamically calculate the row height for series in bank charts based on the user's window height and min/max values. The maximum height of a bank chart is either `130px` or the combined minimum height of the visible series if it's larger. The window height is distributed evenly over the number of bank charts.