### PR TITLE
fix: use vote_commission message

### DIFF
--- a/src/api/atoms.ts
+++ b/src/api/atoms.ts
@@ -42,6 +42,7 @@ import type {
   SlotCaughtUp,
   Health,
   AccountsStats,
+  VoteCommission,
 } from "./types";
 import { rafAtom } from "../atomUtils";
 import type { ValuesWithHistory } from "./worker/types";
@@ -67,6 +68,8 @@ export const scheduleStrategyAtom = atom<ScheduleStrategy | undefined>(
 );
 
 export const identityBalanceAtom = atom<IdentityBalance | undefined>(undefined);
+
+export const voteCommissionAtom = atom<VoteCommission | undefined>(undefined);
 
 export const voteBalanceAtom = atom<VoteBalance | undefined>(undefined);
 

--- a/src/api/entities.ts
+++ b/src/api/entities.ts
@@ -111,6 +111,8 @@ export const tileSchema = z.object({
 
 export const identityBalanceSchema = z.coerce.bigint();
 
+export const voteCommissionSchema = z.number().nullable();
+
 export const voteBalanceSchema = z.coerce.bigint();
 
 export const rootSlotSchema = z.number();
@@ -594,6 +596,10 @@ export const summarySchema = z.discriminatedUnion("key", [
   summaryTopicSchema.extend({
     key: z.literal("identity_balance"),
     value: identityBalanceSchema,
+  }),
+  summaryTopicSchema.extend({
+    key: z.literal("vote_commission"),
+    value: voteCommissionSchema,
   }),
   summaryTopicSchema.extend({
     key: z.literal("vote_balance"),

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -77,6 +77,7 @@ import type {
   accountsPartitionSchema,
   partitionTierSchema,
   compactionStateSchema,
+  voteCommissionSchema,
 } from "./entities";
 
 export type Client = z.infer<typeof clientSchema>;
@@ -96,6 +97,8 @@ export type Tile = z.infer<typeof tileSchema>;
 export type ScheduleStrategy = z.infer<typeof scheduleStrategySchema>;
 
 export type IdentityBalance = z.infer<typeof identityBalanceSchema>;
+
+export type VoteCommission = z.infer<typeof voteCommissionSchema>;
 
 export type VoteBalance = z.infer<typeof voteBalanceSchema>;
 

--- a/src/api/useSetAtomWsData.ts
+++ b/src/api/useSetAtomWsData.ts
@@ -98,6 +98,7 @@ import {
   slotCaughtUpAtom,
   healthAtom,
   accountsStatsAtom,
+  voteCommissionAtom,
 } from "./atoms";
 import { accountsNextCompactionAtom } from "../atoms";
 import {
@@ -227,6 +228,7 @@ function useUpdateAtoms() {
   const setTiles = useSetAtom(tilesAtom);
 
   const setIdentityBalance = useSetAtom(identityBalanceAtom);
+  const setVoteCommission = useSetAtom(voteCommissionAtom);
   const setVoteBalance = useSetAtom(voteBalanceAtom);
   const setScheduleStrategy = useSetAtom(scheduleStrategyAtom);
 
@@ -558,6 +560,10 @@ function useUpdateAtoms() {
               setIdentityKey(value);
               break;
             }
+            case "vote_commission": {
+              setVoteCommission(value);
+              break;
+            }
             case "vote_balance": {
               setVoteBalance(value);
               break;
@@ -793,58 +799,59 @@ function useUpdateAtoms() {
       }
     },
     [
-      addLiveShreds,
-      addRepairSlot,
-      addRepairSlots,
-      addSkippedClusterSlots,
       addToPeersBuffer,
-      addToSupermajorityPeersBuffers,
-      addTurbineSlot,
-      addTurbineSlots,
-      handleSlotUpdate,
-      setBlockEngine,
-      setBootProgress,
+      setSlotCaughtUp,
+      setDbLiveTileMetrics,
+      setLiveProgramCache,
+      setHealth,
+      setVersion,
       setCluster,
       setCommitHash,
-      setCompletedSlot,
+      setIdentityKey,
+      setVoteCommission,
+      setVoteBalance,
+      setStartupTime,
+      setTiles,
+      setScheduleStrategy,
+      setIdentityBalance,
       setDbEstimatedSlotDuration,
       setDbEstimatedTps,
-      setDbGossipNetworkStats,
-      setDbGossipPeersSize,
-      setDbLiveNetworkMetrics,
       setDbLivePrimaryMetrics,
-      setDbLiveTileMetrics,
       setDbLiveTxnWaterfall,
       setDbTileTimer,
-      setEpoch,
-      setGossipPeersCells,
-      setGossipPeersRows,
-      setHealth,
-      setIdentityBalance,
-      setIdentityKey,
-      setLateVoteHistory,
-      setLiveProgramCache,
-      setOptimisticallyConfirmedSlot,
-      setResetSlot,
-      setRootSlot,
-      setScheduleStrategy,
-      setServerTimeNanos,
-      setSkipRate,
-      setSkippedSlots,
-      setSlotCaughtUp,
-      setSlotRankings,
-      setSlotResponse,
+      setBootProgress,
       setStartupProgress,
-      setStartupTime,
-      setStorageSlot,
-      setSupermajorityEpoch,
-      setTiles,
       setTpsHistory,
-      setVersion,
-      setVoteBalance,
-      setVoteDistance,
-      setVoteSlot,
       setVoteState,
+      setVoteDistance,
+      setSkipRate,
+      setCompletedSlot,
+      addTurbineSlot,
+      addRepairSlot,
+      setResetSlot,
+      setStorageSlot,
+      setVoteSlot,
+      setRootSlot,
+      setOptimisticallyConfirmedSlot,
+      addTurbineSlots,
+      addRepairSlots,
+      setServerTimeNanos,
+      setDbLiveNetworkMetrics,
+      setEpoch,
+      setDbGossipNetworkStats,
+      setDbGossipPeersSize,
+      setGossipPeersRows,
+      setGossipPeersCells,
+      setSkippedSlots,
+      addSkippedClusterSlots,
+      setSlotResponse,
+      handleSlotUpdate,
+      setSlotRankings,
+      addLiveShreds,
+      setLateVoteHistory,
+      setBlockEngine,
+      setSupermajorityEpoch,
+      addToSupermajorityPeersBuffers,
       setAccountsStats,
       updateAccountsNextCompactionCandidates,
     ],

--- a/src/features/Header/IdentityKey.tsx
+++ b/src/features/Header/IdentityKey.tsx
@@ -1,5 +1,9 @@
 import { useAtomValue } from "jotai";
-import { identityBalanceAtom, voteBalanceAtom } from "../../api/atoms";
+import {
+  identityBalanceAtom,
+  voteBalanceAtom,
+  voteCommissionAtom,
+} from "../../api/atoms";
 import { Text, Flex } from "@radix-ui/themes";
 import styles from "./identityKey.module.css";
 import PeerIcon from "../../components/PeerIcon";
@@ -16,7 +20,7 @@ import { identityIconOnlyWidth, maxZIndex } from "../../consts";
 import { useUptimeDuration } from "../../hooks/useUptime";
 import CopyButton from "../../components/CopyButton";
 import ConditionalTooltip from "../../components/ConditionalTooltip";
-import { client } from "../../client";
+import { client, isFiredancer } from "../../client";
 
 export default function IdentityKey() {
   const { peer, identityKey } = useIdentityPeer();
@@ -196,6 +200,18 @@ function StakeValue({ showTooltip }: TooltipProps) {
 }
 
 function Commission() {
+  return (
+    <Label label="Commission">
+      {isFiredancer ? (
+        <FiredancerCommissionValue />
+      ) : (
+        <FrankendancerCommissionValue />
+      )}
+    </Label>
+  );
+}
+
+function FrankendancerCommissionValue() {
   const { peer } = useIdentityPeer();
 
   const maxCommission = peer?.vote.reduce<{
@@ -210,14 +226,18 @@ function Commission() {
     },
     { maxStake: 0n, commission: undefined },
   );
-
   return (
-    <Label label="Commission">
-      <ValueWithSuffix
-        value={maxCommission?.commission?.toLocaleString()}
-        suffix="%"
-      />
-    </Label>
+    <ValueWithSuffix
+      value={maxCommission?.commission?.toLocaleString()}
+      suffix="%"
+    />
+  );
+}
+
+function FiredancerCommissionValue() {
+  const voteCommission = useAtomValue(voteCommissionAtom);
+  return (
+    <ValueWithSuffix value={voteCommission?.toLocaleString()} suffix="%" />
   );
 }
 


### PR DESCRIPTION
- use `vote_commission` message for Firedancer clients
- continue to use peer vote info for Frankendancer clients