### PR TITLE
fix: log ratio for zero values

### DIFF
--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/consts.ts
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/consts.ts
@@ -52,3 +52,5 @@ export const enum FilterEnum {
 }
 
 export const txnBarsUplotIdPrefix = "bank-";
+
+export const revenueLogBase = 1.7;

--- a/src/features/Overview/SlotPerformance/TransactionBarsCard/txnBarsPlugin.ts
+++ b/src/features/Overview/SlotPerformance/TransactionBarsCard/txnBarsPlugin.ts
@@ -6,10 +6,10 @@ import { pointWithin, Quadtree } from "./quadTree";
 import type { MutableRefObject } from "react";
 import type { SlotTransactions } from "../../../../api/types";
 import { getDefaultStore } from "jotai";
-import { logRatio } from "../../../../mathUtils";
+import { clampNonZeroValue, logRatio } from "../../../../mathUtils";
 import { slotDurationAtom } from "../../../../atoms";
 import { barCountAtom } from "./atoms";
-import { FilterEnum, stateColors, TxnState } from "./consts";
+import { FilterEnum, revenueLogBase, stateColors, TxnState } from "./consts";
 import {
   getMaxFees,
   getMaxTips,
@@ -33,6 +33,12 @@ let stateSeriesHgt = 0;
 
 const outOfFocusBrightness = 0.5;
 const focusBrightness = 1.3;
+
+function getRevenueRatio(maxValue: bigint, value: bigint) {
+  if (maxValue === 0n) return 0;
+  const ratio = 1 / logRatio(Number(maxValue), Number(value), revenueLogBase);
+  return clampNonZeroValue(ratio, 0.1, 0.9);
+}
 
 export let focusedErrorCode: number;
 export function highlightErrorCode(errorCode: number) {
@@ -330,9 +336,7 @@ export function txnBarsPlugin(
           transactionsRef.current.txn_priority_fee[txnIdx] +
           transactionsRef.current.txn_transaction_fee[txnIdx];
         if (fees !== undefined) {
-          let ratio = 1 / logRatio(Number(maxFees), Number(fees), 1.7);
-          if (ratio > 0.9) ratio = 0.9;
-          if (ratio < 0.1) ratio = 0.1;
+          const ratio = getRevenueRatio(maxFees, fees);
           const ratioHgt = hgt * ratio;
           const diff = hgt - ratioHgt;
           hgt -= diff;
@@ -343,10 +347,7 @@ export function txnBarsPlugin(
       if (value === FilterEnum.TIPS) {
         const tips = transactionsRef.current?.txn_tips[txnIdx];
         if (tips !== undefined) {
-          let ratio = 1 / logRatio(Number(maxTips), Number(tips), 1.7);
-
-          if (ratio > 0.9) ratio = 0.9;
-          if (ratio < 0.1) ratio = 0.1;
+          const ratio = getRevenueRatio(maxTips, tips);
           const ratioHgt = hgt * ratio;
           const diff = hgt - ratioHgt;
           hgt -= diff;

--- a/src/mathUtils.ts
+++ b/src/mathUtils.ts
@@ -1,7 +1,8 @@
+import { clamp } from "lodash";
+
 export function logRatio(a: number, b: number, base = Math.E) {
-  if (a === 0 || b === 0) {
-    return 0;
-  }
+  if (b === 0) return Infinity;
+  if (a === 0) return 0;
   if (a <= 0 || b <= 0) {
     console.error(a, b);
     console.error("Logarithms are only defined for positive numbers.");
@@ -42,4 +43,9 @@ export function safeDivide(a: number, b: number) {
   } else {
     return a / b;
   }
+}
+
+export function clampNonZeroValue(value: number, lower: number, upper: number) {
+  if (value === 0) return 0;
+  return clamp(value, lower, upper);
 }


### PR DESCRIPTION
- handle 0 value in log ratio. This was not hit in the existing code path due to earlier filtering out of 0n values in the series data.
- helper function for clamping non-zero values. This allows any non-zero bars to have a min height so they are visible