### PR TITLE
chore: alpenglow PeerUpdateVoteAccount response

### DIFF
--- a/src/api/entities.ts
+++ b/src/api/entities.ts
@@ -853,7 +853,6 @@ const peerUpdateVoteAccountSchema = z.object({
   activated_stake: z.coerce.bigint(),
   last_vote: z.nullable(z.number()),
   root_slot: z.nullable(z.number()),
-  epoch_credits: z.number(),
   commission: z.number(),
   delinquent: z.boolean(),
 });


### PR DESCRIPTION
WS Changes
| epoch_credits   | `number`       | *Tower Only* The number of credits earned by the vote account during the current epoch |
| epoch_rewards   | `string`       | *Alpenglow Only* Voting rewards credited to this account during the current epoch, in lamports |

epoch_credits is not currently used anywhere so we can simply remove it to avoid any zod schema validation errors
