### PR TITLE
omit tpu waterfall, schedule for RPC nodes

### DIFF
--- a/src/api/atoms.ts
+++ b/src/api/atoms.ts
@@ -66,6 +66,10 @@ export const startupTimeAtom = atom<
 
 export const tilesAtom = atom<Tile[] | undefined>(undefined);
 
+export const blockProductionEnabledAtom = atom((get) =>
+  get(tilesAtom)?.some(({ kind }) => kind === "pack"),
+);
+
 export const scheduleStrategyAtom = atom<ScheduleStrategy | undefined>(
   undefined,
 );

--- a/src/features/Header/Nav.tsx
+++ b/src/features/Header/Nav.tsx
@@ -18,7 +18,7 @@ import type { RouteLabel } from "../../hooks/useCurrentRoute";
 import { RouteLabelToPath, useCurrentRoute } from "../../hooks/useCurrentRoute";
 import useNavigateLeaderSlot from "../../hooks/useNavigateLeaderSlot";
 import { maxZIndex, slotsNavSpacing } from "../../consts";
-import { clusterAtom } from "../../api/atoms";
+import { blockProductionEnabledAtom, clusterAtom } from "../../api/atoms";
 import { getClusterColor } from "../../utils";
 import { navButtonInactiveTextColor } from "../../colors";
 import { isFrankendancer } from "../../client";
@@ -36,7 +36,12 @@ const RouteLabelToIcon: Record<RouteLabel, FC<SVGProps<SVGSVGElement>>> = {
   Accounts: AccountBalanceIcon,
 };
 
-function isRouteHidden(routeLabel: RouteLabel) {
+function isRouteHidden(
+  routeLabel: RouteLabel,
+  blockProductionEnabled?: boolean,
+) {
+  if (blockProductionEnabled === false && routeLabel === "Slot Details")
+    return true;
   if (isFrankendancer)
     return routeLabel === "Gossip" || routeLabel === "Accounts";
   return false;
@@ -100,12 +105,13 @@ NavButton.displayName = "NavButton";
 
 export function NavLinks() {
   const currentRoute = useCurrentRoute();
+  const blockProductionEnabled = useAtomValue(blockProductionEnabledAtom);
 
   return (
     <Flex gap={`${slotsNavSpacing}px`}>
       {Object.keys(RouteLabelToPath).map((label) => {
         const routeLabel = label as RouteLabel;
-        if (isRouteHidden(routeLabel)) return;
+        if (isRouteHidden(routeLabel, blockProductionEnabled)) return;
 
         return (
           <NavButton
@@ -123,6 +129,7 @@ export function NavLinks() {
 export function DropdownNav() {
   const containerEl = useAtomValue(containerElAtom);
   const currentRoute = useCurrentRoute();
+  const blockProductionEnabled = useAtomValue(blockProductionEnabledAtom);
 
   return (
     <DropdownMenu.Root>
@@ -145,7 +152,7 @@ export function DropdownNav() {
         >
           {Object.keys(RouteLabelToPath).map((label) => {
             const routeLabel = label as RouteLabel;
-            if (isRouteHidden(routeLabel)) return;
+            if (isRouteHidden(routeLabel, blockProductionEnabled)) return;
 
             return (
               <DropdownMenu.Item key={routeLabel} asChild>

--- a/src/features/Overview/SlotPerformance/index.tsx
+++ b/src/features/Overview/SlotPerformance/index.tsx
@@ -5,8 +5,12 @@ import TilesPerformance from "./TilesPerformance";
 import Card from "../../../components/Card";
 import SankeyControls from "./SankeyControls";
 import styles from "./SlotSankey/slotSankey.module.css";
+import { useAtomValue } from "jotai";
+import { blockProductionEnabledAtom } from "../../../api/atoms";
 
 export default function SlotPerformance() {
+  const blockProductionEnabled = useAtomValue(blockProductionEnabledAtom);
+
   return (
     <Card>
       <Flex
@@ -14,10 +18,14 @@ export default function SlotPerformance() {
         gap="1"
         className={styles.slotPerformanceContainer}
       >
-        <Flex gap="3">
-          <CardHeader text="TPU Waterfall" />
-        </Flex>
-        <SankeyContainer />
+        {blockProductionEnabled !== false && (
+          <>
+            <Flex gap="3">
+              <CardHeader text="TPU Waterfall" />
+            </Flex>
+            <SankeyContainer />
+          </>
+        )}
         <TilesPerformance />
       </Flex>
     </Card>

--- a/src/features/Overview/SlotTimeline/SlotLanes.tsx
+++ b/src/features/Overview/SlotTimeline/SlotLanes.tsx
@@ -16,6 +16,7 @@ import {
 import { useAtomValue } from "jotai";
 import { epochAtom } from "../../../atoms";
 import { nsPerMs } from "../../../consts";
+import { blockProductionEnabledAtom } from "../../../api/atoms";
 
 export default function SlotLanes() {
   const [measureRef, { width: barsContainerWidth }] =
@@ -222,6 +223,7 @@ interface NextLeaderTimerProps {
   isNarrow: boolean;
 }
 function NextLeaderTimer({ isNarrow }: NextLeaderTimerProps) {
+  const blockProductionEnabled = useAtomValue(blockProductionEnabledAtom);
   const { progressSinceLastLeader, nextSlotText, nextLeaderSlot } = useNextSlot(
     {
       showNowIfCurrent: false,
@@ -237,6 +239,8 @@ function NextLeaderTimer({ isNarrow }: NextLeaderTimerProps) {
     useAtomValue(epochAtom)?.target_slot_duration_nanos ?? 400 * nsPerMs;
   // a bit longer than an expected slot duration
   const progressDuration = (targetSlotDurationNs / nsPerMs) * 1.25;
+
+  if (blockProductionEnabled === false) return null;
 
   return (
     <Flex


### PR DESCRIPTION
RPC nodes ([layout].enable_block_production = false) do not have
leader slots or block production tiles, so skip rendering empty
views.
