### PR TITLE
chore: hide sankey and slot details link for RPC nodes

### DIFF
--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -11,6 +11,7 @@ import {
   accountsStatsAtom,
   completedSlotAtom,
   voteSlotAtom,
+  tilesAtom,
 } from "./api/atoms";
 import type {
   Epoch,
@@ -1108,3 +1109,7 @@ export const alpenglowVoteDistanceAtom = atom((get) => {
   if (replaySlot == null || voteSlot == null) return;
   return replaySlot - voteSlot;
 });
+
+export const isBlockProductionEnabledAtom = atom(
+  (get) => get(tilesAtom)?.some(({ kind }) => kind === "pack") ?? true,
+);

--- a/src/features/Header/Nav.tsx
+++ b/src/features/Header/Nav.tsx
@@ -12,7 +12,7 @@ import { Link } from "@tanstack/react-router";
 import clsx from "clsx";
 import type { FC, SVGProps } from "react";
 import { forwardRef, useEffect, useMemo } from "react";
-import { containerElAtom } from "../../atoms";
+import { isBlockProductionEnabledAtom, containerElAtom } from "../../atoms";
 import { useAtomValue } from "jotai";
 import type { RouteLabel } from "../../hooks/useCurrentRoute";
 import { RouteLabelToPath, useCurrentRoute } from "../../hooks/useCurrentRoute";
@@ -36,7 +36,11 @@ const RouteLabelToIcon: Record<RouteLabel, FC<SVGProps<SVGSVGElement>>> = {
   Accounts: AccountBalanceIcon,
 };
 
-function isRouteHidden(routeLabel: RouteLabel) {
+function isRouteHidden(
+  routeLabel: RouteLabel,
+  isBlockProductionEnabled: boolean,
+) {
+  if (!isBlockProductionEnabled && routeLabel === "Slot Details") return true;
   if (isFrankendancer)
     return routeLabel === "Gossip" || routeLabel === "Accounts";
   return false;
@@ -100,12 +104,13 @@ NavButton.displayName = "NavButton";
 
 export function NavLinks() {
   const currentRoute = useCurrentRoute();
+  const isBlockProductionEnabled = useAtomValue(isBlockProductionEnabledAtom);
 
   return (
     <Flex gap={`${slotsNavSpacing}px`}>
       {Object.keys(RouteLabelToPath).map((label) => {
         const routeLabel = label as RouteLabel;
-        if (isRouteHidden(routeLabel)) return;
+        if (isRouteHidden(routeLabel, isBlockProductionEnabled)) return;
 
         return (
           <NavButton
@@ -123,6 +128,7 @@ export function NavLinks() {
 export function DropdownNav() {
   const containerEl = useAtomValue(containerElAtom);
   const currentRoute = useCurrentRoute();
+  const isBlockProductionEnabled = useAtomValue(isBlockProductionEnabledAtom);
 
   return (
     <DropdownMenu.Root>
@@ -145,7 +151,7 @@ export function DropdownNav() {
         >
           {Object.keys(RouteLabelToPath).map((label) => {
             const routeLabel = label as RouteLabel;
-            if (isRouteHidden(routeLabel)) return;
+            if (isRouteHidden(routeLabel, isBlockProductionEnabled)) return;
 
             return (
               <DropdownMenu.Item key={routeLabel} asChild>

--- a/src/features/Overview/SlotPerformance/index.tsx
+++ b/src/features/Overview/SlotPerformance/index.tsx
@@ -5,8 +5,12 @@ import TilesPerformance from "./TilesPerformance";
 import Card from "../../../components/Card";
 import SankeyControls from "./SankeyControls";
 import styles from "./SlotSankey/slotSankey.module.css";
+import { useAtomValue } from "jotai";
+import { isBlockProductionEnabledAtom } from "../../../atoms";
 
 export default function SlotPerformance() {
+  const isBlockProductionEnabled = useAtomValue(isBlockProductionEnabledAtom);
+
   return (
     <Card>
       <Flex
@@ -14,10 +18,14 @@ export default function SlotPerformance() {
         gap="1"
         className={styles.slotPerformanceContainer}
       >
-        <Flex gap="3">
-          <CardHeader text="TPU Waterfall" />
-        </Flex>
-        <SankeyContainer />
+        {isBlockProductionEnabled && (
+          <>
+            <Flex gap="3">
+              <CardHeader text="TPU Waterfall" />
+            </Flex>
+            <SankeyContainer />
+          </>
+        )}
         <TilesPerformance />
       </Flex>
     </Card>

--- a/src/features/StartupProgress/Body.tsx
+++ b/src/features/StartupProgress/Body.tsx
@@ -3,7 +3,7 @@ import { startupProgressAtom } from "../../api/atoms";
 import styles from "./body.module.css";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
-import { showStartupProgressAtom } from "./atoms";
+import { hasFrankendancerAppDataAtom, showStartupProgressAtom } from "./atoms";
 import fdLogo from "../../assets/firedancer.svg";
 import frLogo from "../../assets/frankendancer.svg";
 import { Box, Flex } from "@radix-ui/themes";
@@ -13,7 +13,6 @@ import InprogressStep from "./InprogressStep";
 import CompleteStep from "./CompleteStep";
 import LoadingLedgerProgress from "./LedgerProgress";
 import FullSnapshotProgress from "./FullSnapshotProgress";
-import { peersAtom } from "../../atoms";
 import IncrementalSnapshotProgress from "./IncrementalSnapshotProgress";
 import { animated, useSpring } from "@react-spring/web";
 import FullSnapshotStats from "./FullSnapshotStats";
@@ -62,12 +61,11 @@ const steps: {
 ];
 
 export default function Body() {
+  const hasFrankendancerAppData = useAtomValue(hasFrankendancerAppDataAtom);
   const startupProgress = useAtomValue(startupProgressAtom);
   const [showStartupProgress, setShowStartupProgress] = useAtom(
     showStartupProgressAtom,
   );
-  const peers = useAtomValue(peersAtom);
-  const hasPeers = !!Object.values(peers).length;
 
   const [_hideSteps, setHideSteps] = useState<boolean>();
 
@@ -87,11 +85,11 @@ export default function Body() {
   const hideSteps = _hideSteps === true || _hideSteps === undefined;
 
   useEffect(() => {
-    if (hasPeers && startupProgress?.phase === "running") {
+    if (hasFrankendancerAppData && startupProgress?.phase === "running") {
       setShowStartupProgress(false);
     }
   }, [
-    hasPeers,
+    hasFrankendancerAppData,
     setShowStartupProgress,
     showStartupProgress,
     startupProgress?.phase,

--- a/src/features/StartupProgress/Firedancer/Body.tsx
+++ b/src/features/StartupProgress/Firedancer/Body.tsx
@@ -12,7 +12,7 @@ import Header from "../../Header/index";
 import { BootPhaseEnum } from "../../../api/entities";
 import { bootProgressContainerElAtom } from "../../../atoms";
 import type { BootPhase } from "../../../api/types";
-import Logo from "./Logo";
+import { MLogo } from "./Logo";
 import { appMaxWidth } from "../../../consts";
 import Snapshot from "./Snapshot";
 import CatchingUp from "./CatchingUp";
@@ -39,7 +39,7 @@ export default function Body() {
   return (
     <>
       {phase && <BootProgressContent phase={phase} />}
-      <Logo />
+      <MLogo />
     </>
   );
 }

--- a/src/features/StartupProgress/Firedancer/Logo.tsx
+++ b/src/features/StartupProgress/Firedancer/Logo.tsx
@@ -1,16 +1,17 @@
 import { Flex } from "@radix-ui/themes";
 import clsx from "clsx";
-import { useAtomValue } from "jotai";
-import { useState } from "react";
+import { memo, useState } from "react";
 import styles from "./logo.module.css";
 import fdLogo from "../../../assets/firedancer.svg";
-import { bootProgressPhaseAtom } from "../atoms";
+import { bootProgressPhaseAtom, hasFiredancerAppDataAtom } from "../atoms";
+import { useAtomValue } from "jotai";
 
-export default function Logo() {
-  const phase = useAtomValue(bootProgressPhaseAtom);
+export const MLogo = memo(function Logo() {
+  const hasPhase = useAtomValue(bootProgressPhaseAtom) != null;
+  const hasFdAppData = useAtomValue(hasFiredancerAppDataAtom);
   const [showInitialLogo, setShowInitialLogo] = useState(true);
 
-  if (phase && showInitialLogo) {
+  if (hasPhase && hasFdAppData && showInitialLogo) {
     setShowInitialLogo(false);
   }
 
@@ -23,4 +24,4 @@ export default function Logo() {
       <img src={fdLogo} alt="fd" />
     </Flex>
   );
-}
+});

--- a/src/features/StartupProgress/atoms.ts
+++ b/src/features/StartupProgress/atoms.ts
@@ -1,8 +1,9 @@
 import { atom } from "jotai";
-import { bootProgressAtom } from "../../api/atoms";
+import { bootProgressAtom, clusterAtom, tilesAtom } from "../../api/atoms";
 import { BootPhaseEnum } from "../../api/entities";
 import type { BootPhase } from "../../api/types";
 import { isFrankendancer } from "../../client";
+import { peersCountAtom } from "../../atoms";
 
 export const bootProgressPhaseAtom = atom(
   (get) => get(bootProgressAtom)?.phase,
@@ -110,5 +111,17 @@ export const snapshotSlotAtom = atom<number | null | undefined>((get) => {
   return (
     get(bootProgressAtom)?.loading_incremental_snapshot_slot ??
     get(bootProgressAtom)?.loading_full_snapshot_slot
+  );
+});
+
+export const hasFiredancerAppDataAtom = atom((get) => {
+  return get(clusterAtom) != null && get(tilesAtom) != null;
+});
+
+export const hasFrankendancerAppDataAtom = atom((get) => {
+  return (
+    get(clusterAtom) != null &&
+    get(peersCountAtom) > 0 &&
+    get(tilesAtom) != null
   );
 });


### PR DESCRIPTION
Based on this PR by @ripatel-fd : https://github.com/firedancer-io/firedancer-frontend/pull/425

For RPC nodes (no leader slots or block production tiles), hide the sankey and Slot Details link.
Update startup and boot progress logos to fade out after app data is ready.