### PR TITLE
feat: highlight tiles table hovered row

### DIFF
--- a/src/components/dataTable.module.css
+++ b/src/components/dataTable.module.css
@@ -56,6 +56,11 @@
         }
       }
 
+      &.hovered {
+        background-color: var(--gray-a3);
+        mix-blend-mode: hard-light;
+      }
+
       .green {
         color: var(--green-9);
       }

--- a/src/features/Overview/LiveTileMetrics/DataRow.tsx
+++ b/src/features/Overview/LiveTileMetrics/DataRow.tsx
@@ -333,15 +333,17 @@ const MUtilization = memo(function Utilization({ idx }: UtilizationProps) {
           tableStyles.noFadeCell,
         )}
       >
-        <TileSparkLine
-          value={avgValue}
-          history={initialHistory}
-          background={tileChartDarkBackground}
-          windowMs={60_000}
-          height={chartHeight}
-          updateIntervalMs={liveTileMetricsSparklineDebounceMs}
-          tickMs={1_000}
-        />
+        <Flex align="center">
+          <TileSparkLine
+            value={avgValue}
+            history={initialHistory}
+            background={tileChartDarkBackground}
+            windowMs={60_000}
+            height={chartHeight}
+            updateIntervalMs={liveTileMetricsSparklineDebounceMs}
+            tickMs={1_000}
+          />
+        </Flex>
       </Table.Cell>
     </>
   );

--- a/src/features/Overview/LiveTileMetrics/DataRow.tsx
+++ b/src/features/Overview/LiveTileMetrics/DataRow.tsx
@@ -6,6 +6,7 @@ import {
   type TileRowMetrics,
 } from "./atoms";
 import { type WriteEl, useRowState, writeRow } from "./utils";
+import type { HoverRowProps } from "./useTileHover";
 import { Flex, Table, Text } from "@radix-ui/themes";
 import tableStyles from "../../../components/dataTable.module.css";
 import { Bars } from "../../StartupProgress/Firedancer/Bars";
@@ -348,14 +349,18 @@ const MUtilization = memo(function Utilization({ idx }: UtilizationProps) {
 
 interface DataRowProps {
   idx: number;
+  hoverProps: HoverRowProps;
 }
 
-export const DataRow = memo(function DataRow({ idx }: DataRowProps) {
+export const DataRow = memo(function DataRow({
+  idx,
+  hoverProps,
+}: DataRowProps) {
   const rowRef = useRef<HTMLTableRowElement>(null);
   useRowState(idx, rowRef, writeRow);
 
   return (
-    <Table.Row ref={rowRef} className={tableStyles.dataRow}>
+    <Table.Row ref={rowRef} className={tableStyles.dataRow} {...hoverProps}>
       <LiveCell idx={idx} write={writeCpu} align="right" />
       <LiveCell idx={idx} write={writeAlive} align="right" />
       <LiveCell idx={idx} write={writePriority} align="right" />

--- a/src/features/Overview/LiveTileMetrics/PinnedRow.tsx
+++ b/src/features/Overview/LiveTileMetrics/PinnedRow.tsx
@@ -3,21 +3,24 @@ import tableStyles from "../../../components/dataTable.module.css";
 import type { Tile } from "../../../api/types";
 import { memo, useRef } from "react";
 import { useRowState, writeRow } from "./utils";
+import type { HoverRowProps } from "./useTileHover";
 
 interface PinnedRowProps {
   tile: Tile;
   idx: number;
+  hoverProps: HoverRowProps;
 }
 
 export const PinnedRow = memo(function PinnedRow({
   tile,
   idx,
+  hoverProps,
 }: PinnedRowProps) {
   const rowRef = useRef<HTMLTableRowElement>(null);
   useRowState(idx, rowRef, writeRow);
 
   return (
-    <Table.Row ref={rowRef} className={tableStyles.dataRow}>
+    <Table.Row ref={rowRef} className={tableStyles.dataRow} {...hoverProps}>
       <Table.Cell className={tableStyles.rightBorder}>
         {tile.kind}:{tile.kind_id}
       </Table.Cell>

--- a/src/features/Overview/LiveTileMetrics/index.tsx
+++ b/src/features/Overview/LiveTileMetrics/index.tsx
@@ -8,7 +8,13 @@ import styles from "./liveTileMetrics.module.css";
 import { headerGap } from "../../Gossip/consts";
 import type { Tile } from "../../../api/types";
 import clsx from "clsx";
-import { memo, useMemo, type CSSProperties } from "react";
+import {
+  memo,
+  useMemo,
+  useRef,
+  type CSSProperties,
+  type MutableRefObject,
+} from "react";
 import TableDescriptionDialog from "../../../components/TableDescriptionDialog";
 import {
   chartHeight,
@@ -21,6 +27,7 @@ import { PriorityEnum } from "../../../api/entities";
 import { DataRow } from "./DataRow";
 import { PinnedRow } from "./PinnedRow";
 import { TableHeader } from "../../../components/DataTable";
+import { useTileHover } from "./useTileHover";
 
 export default memo(function LiveTileMetrics() {
   return (
@@ -37,18 +44,21 @@ export default memo(function LiveTileMetrics() {
 });
 
 function LiveMetricsTables() {
+  const hoveredIdxRef = useRef<number | undefined>();
+
   return (
     <Flex>
-      <LiveMetricsTable isPinned={true} />
-      <LiveMetricsTable isPinned={false} />
+      <LiveMetricsTable isPinned={true} hoveredIdxRef={hoveredIdxRef} />
+      <LiveMetricsTable isPinned={false} hoveredIdxRef={hoveredIdxRef} />
     </Flex>
   );
 }
 
 interface LiveMetricsTableProps {
   isPinned: boolean;
+  hoveredIdxRef: MutableRefObject<number | undefined>;
 }
-function LiveMetricsTable({ isPinned }: LiveMetricsTableProps) {
+function LiveMetricsTable({ isPinned, hoveredIdxRef }: LiveMetricsTableProps) {
   const tiles = useAtomValue(tilesAtom);
   const hasMetrics = useAtomValue(hasLiveTileMetricsAtom);
 
@@ -85,6 +95,7 @@ function LiveMetricsTable({ isPinned }: LiveMetricsTableProps) {
             tile={tile}
             idx={i}
             isPinned={isPinned}
+            hoveredIdxRef={hoveredIdxRef}
           />
         ))}
       </Table.Body>
@@ -96,18 +107,22 @@ interface TableRowProps {
   tile: Tile;
   idx: number;
   isPinned: boolean;
+  hoveredIdxRef: MutableRefObject<number | undefined>;
 }
 
 const TableRow = memo(function TableRow({
   tile,
   idx,
   isPinned,
+  hoveredIdxRef,
 }: TableRowProps) {
+  const hoverProps = useTileHover(isPinned, idx, hoveredIdxRef);
+
   if (!isPinned) {
-    return <DataRow idx={idx} />;
+    return <DataRow idx={idx} hoverProps={hoverProps} />;
   }
 
-  return <PinnedRow tile={tile} idx={idx} />;
+  return <PinnedRow tile={tile} idx={idx} hoverProps={hoverProps} />;
 });
 
 function PriorityCountCell() {

--- a/src/features/Overview/LiveTileMetrics/useTileHover.ts
+++ b/src/features/Overview/LiveTileMetrics/useTileHover.ts
@@ -1,0 +1,54 @@
+import { useEffect, useMemo, type MutableRefObject } from "react";
+import tableStyles from "../../../components/dataTable.module.css";
+import { getPinnedRowId, getRowIds, getUnpinnedRowId } from "./utils";
+
+export interface HoverRowProps {
+  id: string;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}
+
+function setRowHover(idx: number, hover: boolean) {
+  for (const id of getRowIds(idx)) {
+    document.getElementById(id)?.classList.toggle(tableStyles.hovered, hover);
+  }
+}
+
+function setHoveredIdx(
+  hoveredIdxRef: MutableRefObject<number | undefined>,
+  idx: number,
+  isHovered: boolean,
+) {
+  setRowHover(idx, isHovered);
+
+  if (isHovered) {
+    hoveredIdxRef.current = idx;
+    return;
+  }
+
+  if (hoveredIdxRef.current === idx) {
+    // clear hover idx if it's still this idx
+    hoveredIdxRef.current = undefined;
+  }
+}
+
+export function useTileHover(
+  isPinned: boolean,
+  idx: number,
+  hoveredIdxRef: MutableRefObject<number | undefined>,
+): HoverRowProps {
+  // re-sync hover state on mount / idx change
+  useEffect(() => {
+    const isHovered = hoveredIdxRef.current === idx;
+    setHoveredIdx(hoveredIdxRef, idx, isHovered);
+  }, [idx, isPinned, hoveredIdxRef]);
+
+  return useMemo(
+    () => ({
+      id: isPinned ? getPinnedRowId(idx) : getUnpinnedRowId(idx),
+      onMouseEnter: () => setHoveredIdx(hoveredIdxRef, idx, true),
+      onMouseLeave: () => setHoveredIdx(hoveredIdxRef, idx, false),
+    }),
+    [hoveredIdxRef, idx, isPinned],
+  );
+}

--- a/src/features/Overview/LiveTileMetrics/utils.ts
+++ b/src/features/Overview/LiveTileMetrics/utils.ts
@@ -46,3 +46,15 @@ export const writeRow: WriteEl<HTMLTableRowElement> = (el, c, p) => {
   el.style.display = alive === 2 || !hasTimers ? "none" : "";
   el.classList.toggle(tableStyles.faded, priority === PriorityEnum.floating);
 };
+
+export function getPinnedRowId(idx: number) {
+  return `pinned-row-${idx}`;
+}
+
+export function getUnpinnedRowId(idx: number) {
+  return `unpinned-row-${idx}`;
+}
+
+export function getRowIds(idx: number) {
+  return [getPinnedRowId(idx), getUnpinnedRowId(idx)];
+}


### PR DESCRIPTION
- highlight the hovered row on the tiles table
- keep the pinned table and unpinned table hover states in sync
- implemented without react states (it was noticeably laggy when implemented with useState)
- vertically center sparkline in cell