### PR TITLE
feat: selectable tiles table rows

### DIFF
--- a/src/components/dataTable.module.css
+++ b/src/components/dataTable.module.css
@@ -56,6 +56,33 @@
         }
       }
 
+      &.clickable {
+        cursor: pointer;
+      }
+
+      .select-toggle {
+        flex-shrink: 0;
+        width: 13px;
+        height: 13px;
+        color: var(--table-body-color);
+        .selected-icon {
+          display: none;
+        }
+      }
+
+      &.selected {
+        background-color: var(--gray-a3);
+        mix-blend-mode: hard-light;
+        .select-toggle {
+          .selected-icon {
+            display: block;
+          }
+          .select-icon {
+            display: none;
+          }
+        }
+      }
+
       .green {
         color: var(--green-9);
       }

--- a/src/features/Overview/LiveTileMetrics/DataRow.tsx
+++ b/src/features/Overview/LiveTileMetrics/DataRow.tsx
@@ -332,30 +332,33 @@ const MUtilization = memo(function Utilization({ idx }: UtilizationProps) {
           tableStyles.noFadeCell,
         )}
       >
-        <TileSparkLine
-          value={avgValue}
-          history={initialHistory}
-          background={tileChartDarkBackground}
-          windowMs={60_000}
-          height={chartHeight}
-          updateIntervalMs={liveTileMetricsSparklineDebounceMs}
-          tickMs={1_000}
-        />
+        <Flex align="center">
+          <TileSparkLine
+            value={avgValue}
+            history={initialHistory}
+            background={tileChartDarkBackground}
+            windowMs={60_000}
+            height={chartHeight}
+            updateIntervalMs={liveTileMetricsSparklineDebounceMs}
+            tickMs={1_000}
+          />
+        </Flex>
       </Table.Cell>
     </>
   );
 });
 
 interface DataRowProps {
+  id: string;
   idx: number;
 }
 
-export const DataRow = memo(function DataRow({ idx }: DataRowProps) {
+export const DataRow = memo(function DataRow({ id, idx }: DataRowProps) {
   const rowRef = useRef<HTMLTableRowElement>(null);
   useRowState(idx, rowRef, writeRow);
 
   return (
-    <Table.Row ref={rowRef} className={tableStyles.dataRow}>
+    <Table.Row id={id} ref={rowRef} className={tableStyles.dataRow}>
       <LiveCell idx={idx} write={writeCpu} align="right" />
       <LiveCell idx={idx} write={writeAlive} align="right" />
       <LiveCell idx={idx} write={writePriority} align="right" />

--- a/src/features/Overview/LiveTileMetrics/PinnedRow.tsx
+++ b/src/features/Overview/LiveTileMetrics/PinnedRow.tsx
@@ -1,25 +1,41 @@
-import { Table } from "@radix-ui/themes";
+import { Flex, Table } from "@radix-ui/themes";
 import tableStyles from "../../../components/dataTable.module.css";
 import type { Tile } from "../../../api/types";
 import { memo, useRef } from "react";
 import { useRowState, writeRow } from "./utils";
+import { SelectTileToggle } from "./SelectTileToggle";
+import { useTileSelect } from "./TileSelectContext";
+import clsx from "clsx";
 
 interface PinnedRowProps {
   tile: Tile;
+  id: string;
   idx: number;
 }
 
 export const PinnedRow = memo(function PinnedRow({
   tile,
+  id,
   idx,
 }: PinnedRowProps) {
   const rowRef = useRef<HTMLTableRowElement>(null);
   useRowState(idx, rowRef, writeRow);
+  const { onTileClick } = useTileSelect();
 
   return (
-    <Table.Row ref={rowRef} className={tableStyles.dataRow}>
+    <Table.Row
+      id={id}
+      ref={rowRef}
+      className={clsx(tableStyles.dataRow, tableStyles.clickable)}
+      onClick={() => onTileClick(tile)}
+    >
       <Table.Cell className={tableStyles.rightBorder}>
-        {tile.kind}:{tile.kind_id}
+        <Flex align="center" gap="8px">
+          <SelectTileToggle />
+          <span>
+            {tile.kind}:{tile.kind_id}
+          </span>
+        </Flex>
       </Table.Cell>
     </Table.Row>
   );

--- a/src/features/Overview/LiveTileMetrics/SelectTileToggle.tsx
+++ b/src/features/Overview/LiveTileMetrics/SelectTileToggle.tsx
@@ -1,0 +1,12 @@
+import { CircleIcon, RadiobuttonIcon } from "@radix-ui/react-icons";
+import tableStyles from "../../../components/dataTable.module.css";
+import { Flex } from "@radix-ui/themes";
+
+export function SelectTileToggle() {
+  return (
+    <Flex align="center" className={tableStyles.selectToggle}>
+      <CircleIcon className={tableStyles.selectIcon} />
+      <RadiobuttonIcon className={tableStyles.selectedIcon} />
+    </Flex>
+  );
+}

--- a/src/features/Overview/LiveTileMetrics/TileSelectContext.tsx
+++ b/src/features/Overview/LiveTileMetrics/TileSelectContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+import type { Tile } from "../../../api/types";
+
+export interface TileSelectContextValue {
+  onTileClick: (tile: Tile) => void;
+  syncSelectedClass: (tile: Tile) => void;
+}
+
+export const TileSelectContext = createContext<TileSelectContextValue | null>(
+  null,
+);
+
+export function useTileSelect() {
+  const ctx = useContext(TileSelectContext);
+  if (!ctx) {
+    throw new Error("useTileSelect must be used within a TileSelectProvider");
+  }
+  return ctx;
+}

--- a/src/features/Overview/LiveTileMetrics/TileSelectProvider.tsx
+++ b/src/features/Overview/LiveTileMetrics/TileSelectProvider.tsx
@@ -1,0 +1,54 @@
+import { useCallback, useMemo, useRef, type ReactNode } from "react";
+import type { Tile } from "../../../api/types";
+import { areTilesEqual, getAllTileIds } from "./utils";
+import {
+  TileSelectContext,
+  type TileSelectContextValue,
+} from "./TileSelectContext";
+import tableStyles from "../../../components/dataTable.module.css";
+
+export function TileSelectProvider({ children }: { children: ReactNode }) {
+  const selectedTileRef = useRef<Tile | undefined>();
+
+  const onTileClick = useCallback((tile: Tile) => {
+    if (areTilesEqual(selectedTileRef.current, tile)) {
+      // deselect if clicking selected
+      toggleTileSelectedClass(tile, false);
+      selectedTileRef.current = undefined;
+      return;
+    }
+
+    if (selectedTileRef.current) {
+      // deselect previously selected
+      toggleTileSelectedClass(selectedTileRef.current, false);
+    }
+
+    selectedTileRef.current = tile;
+    toggleTileSelectedClass(selectedTileRef.current, true);
+  }, []);
+
+  const syncSelectedClass = useCallback((tile: Tile) => {
+    // sync states if row was remounted
+    const isSelected = areTilesEqual(selectedTileRef.current, tile);
+    toggleTileSelectedClass(tile, isSelected);
+  }, []);
+
+  const value = useMemo<TileSelectContextValue>(
+    () => ({ onTileClick, syncSelectedClass }),
+    [onTileClick, syncSelectedClass],
+  );
+
+  return (
+    <TileSelectContext.Provider value={value}>
+      {children}
+    </TileSelectContext.Provider>
+  );
+}
+
+function toggleTileSelectedClass(tile: Tile, isSelected: boolean) {
+  for (const id of getAllTileIds(tile)) {
+    document
+      .getElementById(id)
+      ?.classList.toggle(tableStyles.selected, isSelected);
+  }
+}

--- a/src/features/Overview/LiveTileMetrics/consts.ts
+++ b/src/features/Overview/LiveTileMetrics/consts.ts
@@ -32,7 +32,7 @@ export const metricGroups: ColumnGroup[] = [
         uniqueName: "Name",
         description:
           "The name and index of each tile. A tile represents a sandboxed process or individual thread that communicates with other tiles using message passing queues.",
-        headerColWidth: 85,
+        headerColWidth: 106,
       },
     ],
   },

--- a/src/features/Overview/LiveTileMetrics/index.tsx
+++ b/src/features/Overview/LiveTileMetrics/index.tsx
@@ -8,7 +8,7 @@ import styles from "./liveTileMetrics.module.css";
 import { headerGap } from "../../Gossip/consts";
 import type { Tile } from "../../../api/types";
 import clsx from "clsx";
-import { memo, useMemo, type CSSProperties } from "react";
+import { memo, useEffect, useMemo, type CSSProperties } from "react";
 import TableDescriptionDialog from "../../../components/TableDescriptionDialog";
 import {
   chartHeight,
@@ -21,6 +21,9 @@ import { PriorityEnum } from "../../../api/entities";
 import { DataRow } from "./DataRow";
 import { PinnedRow } from "./PinnedRow";
 import { TableHeader } from "../../../components/DataTable";
+import { getTileId } from "./utils";
+import { TileSelectProvider } from "./TileSelectProvider";
+import { useTileSelect } from "./TileSelectContext";
 
 export default memo(function LiveTileMetrics() {
   return (
@@ -38,10 +41,12 @@ export default memo(function LiveTileMetrics() {
 
 function LiveMetricsTables() {
   return (
-    <Flex>
-      <LiveMetricsTable isPinned={true} />
-      <LiveMetricsTable isPinned={false} />
-    </Flex>
+    <TileSelectProvider>
+      <Flex>
+        <LiveMetricsTable isPinned={true} />
+        <LiveMetricsTable isPinned={false} />
+      </Flex>
+    </TileSelectProvider>
   );
 }
 
@@ -103,11 +108,20 @@ const TableRow = memo(function TableRow({
   idx,
   isPinned,
 }: TableRowProps) {
+  const { syncSelectedClass } = useTileSelect();
+
+  // re-sync selected state on mount / tile change
+  useEffect(() => {
+    syncSelectedClass(tile);
+  }, [syncSelectedClass, tile]);
+
+  const id = getTileId(tile, isPinned);
+
   if (!isPinned) {
-    return <DataRow idx={idx} />;
+    return <DataRow id={id} idx={idx} />;
   }
 
-  return <PinnedRow tile={tile} idx={idx} />;
+  return <PinnedRow id={id} tile={tile} idx={idx} />;
 });
 
 function PriorityCountCell() {
@@ -146,7 +160,7 @@ function PriorityCountCell() {
   if (!counts) return;
 
   return (
-    <Flex className={styles.priorityCount} gap="5px" justify="between">
+    <Flex className={styles.priorityCount} gap="5px">
       <Text>
         {counts.critical} <Text className={styles.critical}>C</Text>
       </Text>

--- a/src/features/Overview/LiveTileMetrics/liveTileMetrics.module.css
+++ b/src/features/Overview/LiveTileMetrics/liveTileMetrics.module.css
@@ -1,4 +1,5 @@
 .priority-count {
+  justify-content: space-evenly;
   .critical {
     color: var(--gold-10);
   }

--- a/src/features/Overview/LiveTileMetrics/utils.ts
+++ b/src/features/Overview/LiveTileMetrics/utils.ts
@@ -3,6 +3,7 @@ import { liveTileRowAtomFamily, type TileRowMetrics } from "./atoms";
 import tableStyles from "../../../components/dataTable.module.css";
 import { PriorityEnum } from "../../../api/entities";
 import { useLayoutEffect } from "react";
+import type { Tile } from "../../../api/types";
 
 const store = getDefaultStore();
 
@@ -46,3 +47,20 @@ export const writeRow: WriteEl<HTMLTableRowElement> = (el, c, p) => {
   el.style.display = alive === 2 || !hasTimers ? "none" : "";
   el.classList.toggle(tableStyles.faded, priority === PriorityEnum.floating);
 };
+
+export function areTilesEqual(
+  tile1: Tile | null | undefined,
+  tile2: Tile | null | undefined,
+) {
+  if (tile1 == null || tile2 == null) return false;
+  return tile1.kind === tile2.kind && tile1.kind_id === tile2.kind_id;
+}
+
+export function getTileId(tile: Tile, isPinned: boolean) {
+  const prefix = isPinned ? "pinned-row" : "unpinned-row";
+  return `${prefix}:${tile.kind}:${tile.kind_id}`;
+}
+
+export function getAllTileIds(tile: Tile) {
+  return [getTileId(tile, true), getTileId(tile, false)];
+}


### PR DESCRIPTION
- highlight the selected tile on the tiles table
- keep the pinned table and unpinned table selected states in sync
- implemented without react states (it was noticeably laggy when implemented with useState)
- vertically center sparkline in cell