### PR TITLE
feat: use tiled queries

### DIFF
--- a/src/api/atoms.ts
+++ b/src/api/atoms.ts
@@ -43,6 +43,7 @@ import type {
   Health,
   AccountsStats,
   VoteCommission,
+  AggRevenue,
 } from "./types";
 import { rafAtom } from "../atomUtils";
 import type { ValuesWithHistory } from "./worker/types";
@@ -200,3 +201,5 @@ export const liveProgramCacheAtom = atom<LiveProgramCache | undefined>(
 export const healthAtom = atom<Health | undefined>(undefined);
 
 export const accountsStatsAtom = atom<AccountsStats | undefined>(undefined);
+
+export const aggRevenueAtom = atom<AggRevenue | undefined>(undefined);

--- a/src/api/entities.ts
+++ b/src/api/entities.ts
@@ -23,6 +23,10 @@ const slotTopicSchema = z.object({
   topic: z.literal("slot"),
 });
 
+const timelineTopicSchema = z.object({
+  topic: z.literal("timeline"),
+});
+
 const blockEngineTopicSchema = z.object({
   topic: z.literal("block_engine"),
 });
@@ -1224,5 +1228,51 @@ export const accountsSchema = z.discriminatedUnion("key", [
   accountsTopicSchema.extend({
     key: z.literal("stats"),
     value: accountsStatsSchema,
+  }),
+]);
+
+export const aggGranularitySchema = z.enum([
+  "250ms",
+  "500ms",
+  "1s",
+  "2s",
+  "4s",
+  "8s",
+  "15s",
+  "30s",
+  "1m",
+  "2m",
+  "4m",
+  "8m",
+  "15m",
+  "30m",
+  "1h",
+  "2h",
+  "4h",
+  "8h",
+  "12h",
+  "1d",
+]);
+
+export enum RevenueType {
+  TxnFees = "txn_fees",
+  PrioFees = "prio_fees",
+  Tips = "tips",
+}
+
+export const revenueTypeSchema = z.enum(["txn_fees", "prio_fees", "tips"]);
+
+export const aggRevenueSchema = z.object({
+  granularity: aggGranularitySchema,
+  reference_ts_ns: z.coerce.bigint(),
+  [RevenueType.TxnFees]: z.array(z.coerce.bigint().nullable()),
+  [RevenueType.PrioFees]: z.array(z.coerce.bigint().nullable()),
+  [RevenueType.Tips]: z.array(z.coerce.bigint().nullable()),
+});
+
+export const timelineSchema = z.discriminatedUnion("key", [
+  timelineTopicSchema.extend({
+    key: z.literal("query_agg_revenue"),
+    value: aggRevenueSchema,
   }),
 ]);

--- a/src/api/entities.ts
+++ b/src/api/entities.ts
@@ -1254,6 +1254,14 @@ export const aggGranularitySchema = z.enum([
   "1d",
 ]);
 
+export const aggSlotsSchema = z.object({
+  granularity: aggGranularitySchema,
+  reference_ts_ns: z.coerce.bigint(),
+  start_slot: z.array(z.number().nullable()),
+  end_slot: z.array(z.number().nullable()),
+  skipped: z.array(z.number().nullable()),
+});
+
 export enum RevenueType {
   TxnFees = "txn_fees",
   PrioFees = "prio_fees",
@@ -1272,6 +1280,12 @@ export const aggRevenueSchema = z.object({
 
 export const timelineSchema = z.discriminatedUnion("key", [
   timelineTopicSchema.extend({
+    id: z.number(),
+    key: z.literal("query_agg_slots"),
+    value: aggSlotsSchema,
+  }),
+  timelineTopicSchema.extend({
+    id: z.number(),
     key: z.literal("query_agg_revenue"),
     value: aggRevenueSchema,
   }),

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -80,6 +80,7 @@ import type {
   voteCommissionSchema,
   aggGranularitySchema,
   aggRevenueSchema,
+  aggSlotsSchema,
 } from "./entities";
 
 export type Client = z.infer<typeof clientSchema>;
@@ -220,4 +221,5 @@ export type PartitionTier = z.infer<typeof partitionTierSchema>;
 export type CompactionState = z.infer<typeof compactionStateSchema>;
 
 export type AggGranularity = z.infer<typeof aggGranularitySchema>;
+export type AggSlots = z.infer<typeof aggSlotsSchema>;
 export type AggRevenue = z.infer<typeof aggRevenueSchema>;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -78,6 +78,8 @@ import type {
   partitionTierSchema,
   compactionStateSchema,
   voteCommissionSchema,
+  aggGranularitySchema,
+  aggRevenueSchema,
 } from "./entities";
 
 export type Client = z.infer<typeof clientSchema>;
@@ -216,3 +218,6 @@ export type AccountsStats = z.infer<typeof accountsStatsSchema>;
 export type AccountsPartition = z.infer<typeof accountsPartitionSchema>;
 export type PartitionTier = z.infer<typeof partitionTierSchema>;
 export type CompactionState = z.infer<typeof compactionStateSchema>;
+
+export type AggGranularity = z.infer<typeof aggGranularitySchema>;
+export type AggRevenue = z.infer<typeof aggRevenueSchema>;

--- a/src/api/useSetAtomWsData.ts
+++ b/src/api/useSetAtomWsData.ts
@@ -99,6 +99,7 @@ import {
   healthAtom,
   accountsStatsAtom,
   voteCommissionAtom,
+  aggRevenueAtom,
 } from "./atoms";
 import {
   tpsSampleIntervalMs,
@@ -534,6 +535,8 @@ function useUpdateAtoms() {
     [dbFlushSupermajorityPeersBuffers],
   );
 
+  const setAggRevenue = useSetAtom(aggRevenueAtom);
+
   const updateAtoms = useCallback(
     (item: WsEntity) => {
       const { topic, key, value } = item;
@@ -765,6 +768,15 @@ function useUpdateAtoms() {
           }
           break;
         }
+        case "timeline": {
+          switch (key) {
+            case "query_agg_revenue": {
+              setAggRevenue(value);
+              break;
+            }
+          }
+          break;
+        }
         case "wait_for_supermajority": {
           switch (key) {
             case "stakes": {
@@ -845,6 +857,7 @@ function useUpdateAtoms() {
       addLiveShreds,
       setLateVoteHistory,
       setBlockEngine,
+      setAggRevenue,
       setSupermajorityEpoch,
       addToSupermajorityPeersBuffers,
       setAccountsStats,

--- a/src/api/useSetAtomWsData.ts
+++ b/src/api/useSetAtomWsData.ts
@@ -770,6 +770,10 @@ function useUpdateAtoms() {
         }
         case "timeline": {
           switch (key) {
+            case "query_agg_slots": {
+              // listen in component
+              break;
+            }
             case "query_agg_revenue": {
               setAggRevenue(value);
               break;

--- a/src/api/worker/types.ts
+++ b/src/api/worker/types.ts
@@ -30,7 +30,11 @@ export type WsMessage = z.infer<typeof WsMessageSchema>;
 type KvFrom<TSchema extends z.ZodTypeAny, TTopic extends string> =
   z.infer<TSchema> extends infer U
     ? U extends { key: infer K; value: infer V }
-      ? { topic: TTopic; key: K & string; value: V }
+      ? { topic: TTopic; key: K & string; value: V } & (U extends {
+          id: infer I;
+        }
+          ? { id: I }
+          : object)
       : never
     : never;
 

--- a/src/api/worker/types.ts
+++ b/src/api/worker/types.ts
@@ -8,6 +8,7 @@ import {
   slotSchema,
   summarySchema,
   supermajoritySchema,
+  timelineSchema,
 } from "../entities";
 import type { GossipHealthEma } from "../atoms";
 import type { LiveShredsData } from "./cache/shreds/types";
@@ -15,6 +16,7 @@ import type { LiveShredsData } from "./cache/shreds/types";
 export const WsMessageSchema = z.discriminatedUnion("topic", [
   summarySchema,
   epochSchema,
+  timelineSchema,
   gossipSchema,
   peersSchema,
   slotSchema,
@@ -40,6 +42,7 @@ export type ToWorkerMessage =
 export type WsEntity =
   | KvFrom<typeof summarySchema, "summary">
   | KvFrom<typeof epochSchema, "epoch">
+  | KvFrom<typeof timelineSchema, "timeline">
   | KvFrom<typeof gossipSchema, "gossip">
   | KvFrom<typeof peersSchema, "peers">
   | KvFrom<typeof slotSchema, "slot">

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -7,7 +7,9 @@ export const maxSolDecimals = 9;
 export const lamportsPerSol = 1_000_000_000;
 
 export const nsPerMs = 1_000_000;
-export const msPerDay = 24 * 60 * 60 * 1000;
+export const msPerMinute = 60_000;
+export const msPerHour = msPerMinute * 60;
+export const msPerDay = 24 * msPerHour;
 export const MAX_WEBGL_PX_RATIO = 2;
 
 /** Max compute units is dynamic and pulled from the server,

--- a/src/features/Header/Nav.tsx
+++ b/src/features/Header/Nav.tsx
@@ -7,6 +7,7 @@ import AssessmentIcon from "@material-design-icons/svg/filled/assessment.svg?rea
 import CalendarMonthIcon from "@material-design-icons/svg/filled/calendar_month.svg?react";
 import CampaignIcon from "@material-design-icons/svg/filled/campaign.svg?react";
 import AccountBalanceIcon from "@material-design-icons/svg/filled/account_balance.svg?react";
+import ReplayIcon from "@material-design-icons/svg/filled/replay_circle_filled.svg?react";
 import KeyboardArrowDownIcon from "@material-design-icons/svg/filled/keyboard_arrow_down.svg?react";
 import { Link } from "@tanstack/react-router";
 import clsx from "clsx";
@@ -34,6 +35,7 @@ const RouteLabelToIcon: Record<RouteLabel, FC<SVGProps<SVGSVGElement>>> = {
   Gossip: CampaignIcon,
   "Slot Details": AssessmentIcon,
   Accounts: AccountBalanceIcon,
+  Replay: ReplayIcon,
 };
 
 function isRouteHidden(routeLabel: RouteLabel) {

--- a/src/features/Header/index.tsx
+++ b/src/features/Header/index.tsx
@@ -42,7 +42,7 @@ export default function Header({ isStartup }: { isStartup?: boolean }) {
     `(max-width: ${identityIconOnlyWidth})`,
   );
 
-  const { isNarrowScreen, blurBackground, showNav, showOnlyEpochBar } =
+  const { noNav, isNarrowScreen, showNav, showOnlyEpochBar } =
     useSlotsNavigation();
 
   const useExtraNarrowGap = !showNav && isXNarrow;
@@ -74,7 +74,7 @@ export default function Header({ isStartup }: { isStartup?: boolean }) {
             ml={`${-epochThumbPadding}px`}
             pl={`${epochThumbPadding}px`}
           >
-            {!isStartup && isNarrowScreen && !showNav && (
+            {!noNav && !isStartup && isNarrowScreen && !showNav && (
               <NavCollapseToggle isLarge />
             )}
             <Logo />
@@ -130,11 +130,11 @@ export default function Header({ isStartup }: { isStartup?: boolean }) {
               </Flex>
             </Flex>
 
-            {blurBackground && <NavBlur />}
+            <NavBlur />
           </Flex>
         </Flex>
 
-        {!isStartup && !isNarrowScreen && (
+        {!noNav && !isStartup && !isNarrowScreen && (
           <div
             style={{
               position: "relative",

--- a/src/features/Navigation/NavBlur.tsx
+++ b/src/features/Navigation/NavBlur.tsx
@@ -2,7 +2,8 @@ import { maxZIndex } from "../../consts";
 import { useSlotsNavigation } from "../../hooks/useSlotsNavigation";
 
 export default function NavBlur() {
-  const { setIsNavCollapsed } = useSlotsNavigation();
+  const { setIsNavCollapsed, blurBackground } = useSlotsNavigation();
+  if (!blurBackground) return null;
 
   return (
     <div

--- a/src/features/Navigation/index.tsx
+++ b/src/features/Navigation/index.tsx
@@ -38,15 +38,18 @@ const top = clusterIndicatorHeight + headerHeight;
 export default function Navigation() {
   const isNarrow = useMedia(narrowNavMedia);
 
-  const { showNav, occupyRowWidth, showOnlyEpochBar } = useSlotsNavigation();
-
-  // padding to make sure epoch thumb is visible,
-  // as it is positioned slightly outside of the container
-  const thumbPadding = showNav ? epochThumbPadding : 0;
+  const { noNav, showNav, occupyRowWidth, showOnlyEpochBar } =
+    useSlotsNavigation();
 
   const width = useMemo(() => {
     return showOnlyEpochBar ? slotNavWithoutListWidth : slotNavWidth;
   }, [showOnlyEpochBar]);
+
+  if (noNav) return;
+
+  // padding to make sure epoch thumb is visible,
+  // as it is positioned slightly outside of the container
+  const thumbPadding = showNav ? epochThumbPadding : 0;
 
   return (
     <>

--- a/src/features/Overview/ShredsProgression/WebGl/Chart.tsx
+++ b/src/features/Overview/ShredsProgression/WebGl/Chart.tsx
@@ -6,7 +6,7 @@ import type { FlexProps } from "@radix-ui/themes";
 import { useShredsChartScale } from "../useShredsChartScale";
 import { useSetAtom } from "jotai";
 import { minDirtySlotByChartAtom } from "../atoms";
-import type { RendererObj, TsRange } from "./chartUtils";
+import type { RendererObj } from "./chartUtils";
 import { setUpRenderer, draw } from "./chartUtils";
 import ShredsSlotLabels from "../ShredsSlotLabels";
 import { MChartAxes, xAxisHeight } from "./ChartAxes";
@@ -15,6 +15,7 @@ import withWebGlRemount, {
   type WebGlRemountProps,
 } from "../../../WebGl/withWebGlRemount";
 import { useWebGlEventHandlers } from "../../../WebGl/useWebGlEventHandlers";
+import type { TsRange } from "../../../WebGl/webglUtils";
 
 const REDRAW_INTERVAL_MS = 15;
 

--- a/src/features/Overview/ShredsProgression/WebGl/chartUtils.ts
+++ b/src/features/Overview/ShredsProgression/WebGl/chartUtils.ts
@@ -21,7 +21,7 @@ import type {
   WebglResources,
 } from "../../../WebGl/webglUtils";
 import {
-  createSlotMesh,
+  createRectMesh,
   updateSlotMeshCounts,
   ensureCapacity,
   addRectangleToMesh,
@@ -246,7 +246,7 @@ export function draw(
     const isNewMesh = !slotMesh;
     if (!slotMesh) {
       const lastMesh = rendererObj.availableMeshes.pop();
-      slotMesh = lastMesh ?? createSlotMesh(rendererObj.resources);
+      slotMesh = lastMesh ?? createRectMesh(rendererObj.resources);
       rendererObj.meshes.set(slotNumber, slotMesh);
       rendererObj.scene.add(slotMesh.mesh);
     }

--- a/src/features/Overview/ShredsProgression/WebGl/chartUtils.ts
+++ b/src/features/Overview/ShredsProgression/WebGl/chartUtils.ts
@@ -16,13 +16,13 @@ import {
 import { shredEventDescPriorities } from "../const";
 import { updateLabels } from "../shredsProgressionPlugin";
 import type {
-  SlotMesh,
+  RectMesh,
   TsRange,
   WebglResources,
 } from "../../../WebGl/webglUtils";
 import {
   createRectMesh,
-  updateSlotMeshCounts,
+  updateRectMeshCounts,
   ensureCapacity,
   addRectangleToMesh,
   convertToWebGlColor,
@@ -64,8 +64,8 @@ export type RendererObj = {
   renderer: THREE.WebGLRenderer;
   camera: THREE.OrthographicCamera;
   scene: THREE.Scene;
-  meshes: Map<number, SlotMesh>;
-  availableMeshes: SlotMesh[];
+  meshes: Map<number, RectMesh>;
+  availableMeshes: RectMesh[];
   worldTsRange: TsRange;
   // resources shared by this renderer's slot meshes
   resources: WebglResources;
@@ -115,8 +115,8 @@ export function setUpRenderer(
     renderer.setSize(canvasWidth, canvasHeight);
     renderer.setClearColor(0x000000, 0);
 
-    const meshes = new Map<number, SlotMesh>();
-    const availableMeshes: SlotMesh[] = [];
+    const meshes = new Map<number, RectMesh>();
+    const availableMeshes: RectMesh[] = [];
     const resources = createWebglResources(SHREDS_OPACITY);
     renderer.render(scene, camera);
     const clearContextListeners = setUpContextListeners(renderer.domElement);
@@ -127,11 +127,11 @@ export function setUpRenderer(
       // Three doesn't restore GPU objects for restored contexts unless there's a render.
       // Remount on restore to reset the context listeners state
       if (!getWasContextLost()) {
-        for (const slotMesh of meshes.values()) {
-          slotMesh.mesh.geometry.dispose();
+        for (const rectMesh of meshes.values()) {
+          rectMesh.mesh.geometry.dispose();
         }
-        for (const slotMesh of availableMeshes) {
-          slotMesh.mesh.geometry.dispose();
+        for (const rectMesh of availableMeshes) {
+          rectMesh.mesh.geometry.dispose();
         }
         // dispose this chart's own unitQuad / sharedMaterial
         disposeWebglResources(resources);
@@ -279,7 +279,7 @@ export function draw(
         anythingDrawn = true;
       }
     }
-    updateSlotMeshCounts(slotMesh, rectangleIdx);
+    updateRectMeshCounts(slotMesh, rectangleIdx);
   }
 
   store.set(minDirtySlotByChartAtom, (prev) => {
@@ -347,7 +347,7 @@ interface AddEventsForRowArgs {
     Exclude<ShredEvent, ShredEvent.slot_complete>,
     { x: number; w: number }
   >;
-  slotMesh: SlotMesh;
+  slotMesh: RectMesh;
   startRectangleIdx: number;
   eventTsDeltas: ShredEventTsDeltas;
   slotCompletionTsDelta: number | undefined;

--- a/src/features/Overview/ShredsProgression/WebGl/chartUtils.ts
+++ b/src/features/Overview/ShredsProgression/WebGl/chartUtils.ts
@@ -15,7 +15,11 @@ import {
 } from "../atoms";
 import { shredEventDescPriorities } from "../const";
 import { updateLabels } from "../shredsProgressionPlugin";
-import type { SlotMesh, WebglResources } from "../../../WebGl/webglUtils";
+import type {
+  SlotMesh,
+  TsRange,
+  WebglResources,
+} from "../../../WebGl/webglUtils";
 import {
   createSlotMesh,
   updateSlotMeshCounts,
@@ -48,6 +52,7 @@ import { isWebgl2SupportedAtom } from "../../../WebGl/atoms";
 
 const store = getDefaultStore();
 
+const SHREDS_OPACITY = 0.8;
 const SKIPPED_SLOT_DOT_DURATION_MS = 10;
 
 const tempEventPositions = new Map<
@@ -112,7 +117,7 @@ export function setUpRenderer(
 
     const meshes = new Map<number, SlotMesh>();
     const availableMeshes: SlotMesh[] = [];
-    const resources = createWebglResources();
+    const resources = createWebglResources(SHREDS_OPACITY);
     renderer.render(scene, camera);
     const clearContextListeners = setUpContextListeners(renderer.domElement);
 
@@ -336,8 +341,6 @@ function updateVisibleXRange(
   camera.updateProjectionMatrix();
   return true;
 }
-
-export type TsRange = [startTs: number, endTs: number];
 
 interface AddEventsForRowArgs {
   tempEventPositions: Map<

--- a/src/features/Replay/Chart.tsx
+++ b/src/features/Replay/Chart.tsx
@@ -1,0 +1,178 @@
+import { Flex } from "@radix-ui/themes";
+import { useAtomValue } from "jotai";
+import { useRef, useLayoutEffect, useMemo, useCallback, useState } from "react";
+import { useMeasure } from "react-use";
+import styles from "./chart.module.css";
+import { type MarkerLinesProps } from "./const.ts";
+import { nsPerMs } from "../../consts.ts";
+import { clamp } from "../../uplotReact/utils.ts";
+import { calcRelativeMs, getInitVisibleRange } from "./utils.ts";
+import VisibleRange from "./VisibleRangeInfo.tsx";
+import { currentSlotAtom } from "../../atoms.ts";
+import RevenueTrack from "./RevenueTrack/RevenueTrack.tsx";
+import { RevenueType } from "../../api/entities.ts";
+import type { TsRange } from "../WebGl/webglUtils.ts";
+import { useExplorableChart } from "./useExplorableChart.ts";
+import { useVisibleRangeSubscribers } from "./useVisibleRangeSubscribers.ts";
+
+const LIVE_CHART_DELAY_MS = 500;
+const MARKER_PCT_VAR = "--marker-lines-pct";
+const markerLinesProps: MarkerLinesProps = {
+  markerLinesClassName: styles.withMarkerLines,
+};
+
+interface ChartProps {
+  /**
+   * use reference ts so we can convert bigints to number without losing precision
+   */
+  startupTimeNs: bigint;
+}
+
+/**
+ * Set up Replay chart, which keeps track of a reference ts (startup time), and
+ * visible and world ts ranges.
+ * Informs subscribers of visible range changes.
+ */
+export default function Chart({ startupTimeNs }: ChartProps) {
+  const currentSlot = useAtomValue(currentSlotAtom);
+
+  const [measureRef, { width }] = useMeasure<HTMLDivElement>();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const setContainerRefs = useCallback(
+    (el: HTMLDivElement | null) => {
+      containerRef.current = el;
+      if (el) {
+        measureRef(el);
+      }
+    },
+    [measureRef],
+  );
+
+  const rangeRef = useRef<
+    | {
+        referenceNs: bigint;
+        worldEndMs: number;
+        visibleRangeMs: TsRange;
+      }
+    | undefined
+  >();
+  const [isRangeInitialized, setIsRangeInitialized] = useState(false);
+  const selectedMsRef = useRef<number | undefined>();
+
+  const { broadcastVisibleRangeChange, visibleRangeSubscriberProps } =
+    useVisibleRangeSubscribers({ rangeRef, selectedMsRef });
+
+  const { refreshSelectedMarkerLine, setVisibleRange, setSelectedMs } =
+    useMemo(() => {
+      const refreshSelectedMarkerLine = () => {
+        if (!containerRef.current) return;
+        if (selectedMsRef.current == null) {
+          // off screen
+          containerRef.current.style.setProperty(MARKER_PCT_VAR, "-300%");
+          return;
+        }
+
+        if (!rangeRef.current) return;
+        const [start, end] = rangeRef.current.visibleRangeMs;
+        const pct = (100 * (selectedMsRef.current - start)) / (end - start);
+        containerRef.current.style.setProperty(MARKER_PCT_VAR, `${pct}%`);
+      };
+
+      const setSelectedMs = (ts: number | undefined) => {
+        selectedMsRef.current = ts;
+        refreshSelectedMarkerLine();
+      };
+
+      const setVisibleRange = (unclampedNewRange: TsRange) => {
+        if (!rangeRef.current) return;
+
+        const { worldEndMs, visibleRangeMs } = rangeRef.current;
+        const newRange = clamp(
+          unclampedNewRange[1] - unclampedNewRange[0],
+          unclampedNewRange[0],
+          unclampedNewRange[1],
+          worldEndMs,
+          0,
+          worldEndMs,
+        );
+
+        if (
+          visibleRangeMs[0] === newRange[0] &&
+          visibleRangeMs[1] === newRange[1]
+        ) {
+          return;
+        }
+
+        rangeRef.current.visibleRangeMs = newRange;
+        broadcastVisibleRangeChange();
+        refreshSelectedMarkerLine();
+      };
+
+      return {
+        refreshSelectedMarkerLine,
+        setSelectedMs,
+        setVisibleRange,
+      };
+    }, [broadcastVisibleRangeChange]);
+
+  const explorableChartProps = useExplorableChart({
+    rangeRef,
+    setSelectedMs,
+    setVisibleRange,
+  });
+
+  // refresh world size
+  useLayoutEffect(() => {
+    const referenceNs = rangeRef.current?.referenceNs ?? startupTimeNs;
+    const newWorldEndNs =
+      BigInt(new Date().getTime() - LIVE_CHART_DELAY_MS) * BigInt(nsPerMs);
+    const newWorldEndMs = calcRelativeMs(referenceNs, newWorldEndNs);
+
+    // delay if too soon after startup
+    if (newWorldEndMs < 0) return;
+
+    if (rangeRef.current) {
+      rangeRef.current.worldEndMs = newWorldEndMs;
+      return;
+    }
+
+    // initialize ranges
+    const visibleRangeMs = getInitVisibleRange(
+      selectedMsRef.current,
+      newWorldEndMs,
+    );
+    rangeRef.current = {
+      referenceNs,
+      worldEndMs: newWorldEndMs,
+      visibleRangeMs,
+    };
+    broadcastVisibleRangeChange();
+    refreshSelectedMarkerLine();
+    setIsRangeInitialized(true);
+  }, [
+    currentSlot,
+    startupTimeNs,
+    setVisibleRange,
+    broadcastVisibleRangeChange,
+    refreshSelectedMarkerLine,
+  ]);
+
+  return (
+    <div className={styles.container} ref={setContainerRefs}>
+      {!!width && isRangeInitialized && (
+        <>
+          <VisibleRange {...visibleRangeSubscriberProps} />
+          <Flex direction="column" gapY="4" position="relative">
+            <RevenueTrack
+              type={RevenueType.TxnFees}
+              width={width}
+              {...visibleRangeSubscriberProps}
+              {...explorableChartProps}
+              {...markerLinesProps}
+            />
+          </Flex>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/features/Replay/Chart.tsx
+++ b/src/features/Replay/Chart.tsx
@@ -59,8 +59,11 @@ export default function Chart({ startupTimeNs }: ChartProps) {
   const [isRangeInitialized, setIsRangeInitialized] = useState(false);
   const selectedMsRef = useRef<number | undefined>();
 
-  const { broadcastVisibleRangeChange, visibleRangeSubscriberProps } =
-    useVisibleRangeSubscribers({ rangeRef, selectedMsRef });
+  const {
+    broadcastVisibleRangeChange,
+    broadcastSelectedMsChange,
+    visibleRangeSubscriberProps,
+  } = useVisibleRangeSubscribers({ rangeRef, selectedMsRef });
 
   const { refreshSelectedMarkerLine, setVisibleRange, setSelectedMs } =
     useMemo(() => {
@@ -79,6 +82,7 @@ export default function Chart({ startupTimeNs }: ChartProps) {
       };
 
       const setSelectedMs = (ts: number | undefined) => {
+        broadcastSelectedMsChange();
         selectedMsRef.current = ts;
         refreshSelectedMarkerLine();
       };
@@ -113,7 +117,7 @@ export default function Chart({ startupTimeNs }: ChartProps) {
         setSelectedMs,
         setVisibleRange,
       };
-    }, [broadcastVisibleRangeChange]);
+    }, [broadcastSelectedMsChange, broadcastVisibleRangeChange]);
 
   const explorableChartProps = useExplorableChart({
     rangeRef,
@@ -152,7 +156,6 @@ export default function Chart({ startupTimeNs }: ChartProps) {
   }, [
     currentSlot,
     startupTimeNs,
-    setVisibleRange,
     broadcastVisibleRangeChange,
     refreshSelectedMarkerLine,
   ]);

--- a/src/features/Replay/Chart.tsx
+++ b/src/features/Replay/Chart.tsx
@@ -82,8 +82,8 @@ export default function Chart({ startupTimeNs }: ChartProps) {
       };
 
       const setSelectedMs = (ts: number | undefined) => {
-        broadcastSelectedMsChange();
         selectedMsRef.current = ts;
+        broadcastSelectedMsChange();
         refreshSelectedMarkerLine();
       };
 

--- a/src/features/Replay/Chart.tsx
+++ b/src/features/Replay/Chart.tsx
@@ -3,7 +3,7 @@ import { useAtomValue } from "jotai";
 import { useRef, useLayoutEffect, useMemo, useCallback, useState } from "react";
 import { useMeasure } from "react-use";
 import styles from "./chart.module.css";
-import { type MarkerLinesProps } from "./const.ts";
+import type { MarkerLinesProps } from "./const.ts";
 import { nsPerMs } from "../../consts.ts";
 import { clamp } from "../../uplotReact/utils.ts";
 import { calcRelativeMs, getInitVisibleRange } from "./utils.ts";
@@ -14,11 +14,15 @@ import { RevenueType } from "../../api/entities.ts";
 import type { TsRange } from "../WebGl/webglUtils.ts";
 import { useExplorableChart } from "./useExplorableChart.ts";
 import { useVisibleRangeSubscribers } from "./useVisibleRangeSubscribers.ts";
+import MiniMap from "./MiniMap/MiniMap.tsx";
 
 const LIVE_CHART_DELAY_MS = 500;
 const MARKER_PCT_VAR = "--marker-lines-pct";
+const WORLD_MARKER_PCT_VAR = "--world-marker-lines-pct";
+
 const markerLinesProps: MarkerLinesProps = {
   markerLinesClassName: styles.withMarkerLines,
+  miniMapMarkerLinesClassName: styles.withWorldMarkerLines,
 };
 
 interface ChartProps {
@@ -62,6 +66,7 @@ export default function Chart({ startupTimeNs }: ChartProps) {
   const {
     broadcastVisibleRangeChange,
     broadcastSelectedMsChange,
+    broadcastWorldRangeChange,
     visibleRangeSubscriberProps,
   } = useVisibleRangeSubscribers({ rangeRef, selectedMsRef });
 
@@ -72,6 +77,7 @@ export default function Chart({ startupTimeNs }: ChartProps) {
         if (selectedMsRef.current == null) {
           // off screen
           containerRef.current.style.setProperty(MARKER_PCT_VAR, "-300%");
+          containerRef.current.style.setProperty(WORLD_MARKER_PCT_VAR, "-300%");
           return;
         }
 
@@ -79,6 +85,13 @@ export default function Chart({ startupTimeNs }: ChartProps) {
         const [start, end] = rangeRef.current.visibleRangeMs;
         const pct = (100 * (selectedMsRef.current - start)) / (end - start);
         containerRef.current.style.setProperty(MARKER_PCT_VAR, `${pct}%`);
+
+        const worldPct =
+          (100 * selectedMsRef.current) / rangeRef.current.worldEndMs;
+        containerRef.current.style.setProperty(
+          WORLD_MARKER_PCT_VAR,
+          `${worldPct}%`,
+        );
       };
 
       const setSelectedMs = (ts: number | undefined) => {
@@ -119,7 +132,7 @@ export default function Chart({ startupTimeNs }: ChartProps) {
       };
     }, [broadcastSelectedMsChange, broadcastVisibleRangeChange]);
 
-  const explorableChartProps = useExplorableChart({
+  const { explorableChartProps, miniMapProps } = useExplorableChart({
     rangeRef,
     setSelectedMs,
     setVisibleRange,
@@ -137,6 +150,8 @@ export default function Chart({ startupTimeNs }: ChartProps) {
 
     if (rangeRef.current) {
       rangeRef.current.worldEndMs = newWorldEndMs;
+      broadcastWorldRangeChange();
+      refreshSelectedMarkerLine();
       return;
     }
 
@@ -158,6 +173,7 @@ export default function Chart({ startupTimeNs }: ChartProps) {
     startupTimeNs,
     broadcastVisibleRangeChange,
     refreshSelectedMarkerLine,
+    broadcastWorldRangeChange,
   ]);
 
   return (
@@ -165,6 +181,12 @@ export default function Chart({ startupTimeNs }: ChartProps) {
       {!!width && isRangeInitialized && (
         <>
           <VisibleRange {...visibleRangeSubscriberProps} />
+          <MiniMap
+            width={width}
+            {...visibleRangeSubscriberProps}
+            {...miniMapProps}
+            {...markerLinesProps}
+          />
           <Flex direction="column" gapY="4" position="relative">
             <RevenueTrack
               type={RevenueType.TxnFees}

--- a/src/features/Replay/MiniMap/MiniMap.tsx
+++ b/src/features/Replay/MiniMap/MiniMap.tsx
@@ -1,0 +1,206 @@
+import { useRef, useCallback, useLayoutEffect } from "react";
+import {
+  type MarkerLinesProps,
+  type MiniMapSetupProps,
+  type RangeChangeSubscriberProps,
+} from "../const.ts";
+import type { WebGlRemountProps } from "../../WebGl/withWebGlRemount.tsx";
+import { useWebGlEventHandlers } from "../../WebGl/useWebGlEventHandlers.ts";
+import withWebGlRemount from "../../WebGl/withWebGlRemount.tsx";
+import {
+  drawMiniMap,
+  moveCamera,
+  render,
+  setUpRenderer,
+  type RendererObj,
+} from "./utils.ts";
+import type { NsTsRange, TsRange } from "../../WebGl/webglUtils.ts";
+import useMiniMapQuery, { getMiniMapGranularity } from "./useMiniMapQuery.ts";
+import type { AggSlots } from "../../../api/types.ts";
+import { useTimelineServerMessage } from "../utils.ts";
+import { RequesterId } from "../useAggSlotsQuery.ts";
+import { useThrottledCallback } from "use-debounce";
+import styles from "./miniMap.module.css";
+import clsx from "clsx";
+import { Box } from "@radix-ui/themes";
+
+const height = 25;
+const chartId = "mini-map-track";
+
+interface MiniMapProps
+  extends WebGlRemountProps,
+    RangeChangeSubscriberProps,
+    MiniMapSetupProps,
+    MarkerLinesProps {
+  width: number;
+}
+
+function MiniMap({
+  remount,
+  subscribeRangeChange,
+  getAbsoluteNs,
+  getRelativeMs,
+  miniMapMarkerLinesClassName,
+  setUpMiniMap,
+  width,
+}: MiniMapProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  const visibleRangeElRef = useRef<HTMLDivElement>(null);
+  const leftHandleRef = useRef<HTMLDivElement>(null);
+  const rightHandleRef = useRef<HTMLDivElement>(null);
+  const rendererRef = useRef<RendererObj | undefined>();
+
+  // keep the latest converter available to the WS message handler without
+  // forcing a re-subscription each time it changes
+  const getRelativeMsRef = useRef(getRelativeMs);
+  getRelativeMsRef.current = getRelativeMs;
+
+  const widthRef = useRef(width);
+  widthRef.current = width;
+  const hasWidth = width > 0;
+
+  const { setUpContextListeners, getWasContextLost } = useWebGlEventHandlers({
+    remount,
+  });
+
+  const query = useMiniMapQuery();
+
+  const updateVisibleEl = useThrottledCallback(
+    useCallback((visibleRangeMs: TsRange, worldRangeMs: TsRange) => {
+      const el = visibleRangeElRef.current;
+      if (!el) return;
+      const worldRange = worldRangeMs[1] - worldRangeMs[0];
+      const pct = ((visibleRangeMs[1] - visibleRangeMs[0]) / worldRange) * 100;
+      el.style.width = `${pct.toFixed(2)}%`;
+      const pos = 100 - (visibleRangeMs[1] / worldRange) * 100;
+      el.style.right = `${pos}%`;
+    }, []),
+    30,
+    {
+      leading: true,
+      trailing: true,
+    },
+  );
+
+  const updateWorldEl = useCallback(
+    (worldRangeMs: TsRange) => {
+      if (!rendererRef.current) return;
+      const granularity = getMiniMapGranularity(
+        worldRangeMs[1] - worldRangeMs[0],
+      );
+      const worldRangeNs: NsTsRange = [
+        getAbsoluteNs(worldRangeMs[0]),
+        getAbsoluteNs(worldRangeMs[1]),
+      ];
+      query(worldRangeNs, granularity);
+      moveCamera(rendererRef.current, worldRangeMs);
+      render(rendererRef.current);
+    },
+    [getAbsoluteNs, query],
+  );
+
+  /**
+   * Update camera and query data for new range
+   */
+  const onRangeChange = useCallback(
+    (visibleRangeMs: TsRange, worldRangeMs: TsRange) => {
+      if (!rendererRef.current) return;
+      updateWorldEl(worldRangeMs);
+      updateVisibleEl(visibleRangeMs, worldRangeMs);
+    },
+    [updateVisibleEl, updateWorldEl],
+  );
+
+  // set up renderer and subscribe to range change, to trigger queries
+  useLayoutEffect(() => {
+    if (
+      rendererRef.current ||
+      !hasWidth ||
+      !containerRef.current ||
+      !chartContainerRef.current ||
+      !visibleRangeElRef.current ||
+      !leftHandleRef.current ||
+      !rightHandleRef.current
+    )
+      return;
+
+    const rendererObj = setUpRenderer(
+      widthRef.current,
+      height,
+      setUpContextListeners,
+      getWasContextLost,
+    );
+    if (!rendererObj) return;
+
+    rendererRef.current = rendererObj;
+    chartContainerRef.current.replaceChildren(rendererObj.renderer.domElement);
+
+    const unsubscribe = subscribeRangeChange(
+      chartId,
+      onRangeChange,
+      undefined,
+      onRangeChange,
+    );
+    const cleanUpMiniMapListeners = setUpMiniMap(
+      containerRef.current,
+      visibleRangeElRef.current,
+      leftHandleRef.current,
+      rightHandleRef.current,
+    );
+
+    // cleanup
+    return () => {
+      unsubscribe?.();
+      rendererRef.current?.cleanUp();
+      rendererRef.current = undefined;
+      cleanUpMiniMapListeners?.();
+    };
+  }, [
+    onRangeChange,
+    subscribeRangeChange,
+    setUpContextListeners,
+    getWasContextLost,
+    hasWidth,
+    setUpMiniMap,
+  ]);
+
+  // handle chart resize
+  useLayoutEffect(() => {
+    if (!rendererRef.current) return;
+    rendererRef.current.renderer.setSize(width, height);
+    render(rendererRef.current);
+  }, [width]);
+
+  const onMessage = useCallback((message: { id: number; value: AggSlots }) => {
+    if (!rendererRef.current || message.id !== RequesterId.MiniMap) return;
+
+    drawMiniMap(rendererRef.current, message.value, getRelativeMsRef.current);
+    render(rendererRef.current);
+  }, []);
+
+  useTimelineServerMessage("query_agg_slots", onMessage);
+
+  return (
+    <Box
+      ref={containerRef}
+      className={styles.miniMapContainer}
+      height={`${height}px`}
+    >
+      <div
+        ref={chartContainerRef}
+        className={clsx(styles.miniMapTrack, miniMapMarkerLinesClassName)}
+      />
+      <div ref={visibleRangeElRef} className={styles.visibleRangeBox}>
+        <div ref={leftHandleRef} className={clsx(styles.handle, styles.left)} />
+        <div
+          ref={rightHandleRef}
+          className={clsx(styles.handle, styles.right)}
+        />
+      </div>
+    </Box>
+  );
+}
+
+const MiniMapTrackWithRemount = withWebGlRemount(MiniMap);
+export default MiniMapTrackWithRemount;

--- a/src/features/Replay/MiniMap/MiniMap.tsx
+++ b/src/features/Replay/MiniMap/MiniMap.tsx
@@ -9,6 +9,7 @@ import { useWebGlEventHandlers } from "../../WebGl/useWebGlEventHandlers.ts";
 import withWebGlRemount from "../../WebGl/withWebGlRemount.tsx";
 import {
   drawMiniMap,
+  trackHeight,
   moveCamera,
   render,
   setUpRenderer,
@@ -24,7 +25,6 @@ import styles from "./miniMap.module.css";
 import clsx from "clsx";
 import { Box } from "@radix-ui/themes";
 
-const height = 25;
 const chartId = "mini-map-track";
 
 interface MiniMapProps
@@ -127,7 +127,7 @@ function MiniMap({
 
     const rendererObj = setUpRenderer(
       widthRef.current,
-      height,
+      trackHeight,
       setUpContextListeners,
       getWasContextLost,
     );
@@ -168,7 +168,7 @@ function MiniMap({
   // handle chart resize
   useLayoutEffect(() => {
     if (!rendererRef.current) return;
-    rendererRef.current.renderer.setSize(width, height);
+    rendererRef.current.renderer.setSize(width, trackHeight);
     render(rendererRef.current);
   }, [width]);
 
@@ -185,7 +185,7 @@ function MiniMap({
     <Box
       ref={containerRef}
       className={styles.miniMapContainer}
-      height={`${height}px`}
+      height={`${trackHeight}px`}
     >
       <div
         ref={chartContainerRef}

--- a/src/features/Replay/MiniMap/miniMap.module.css
+++ b/src/features/Replay/MiniMap/miniMap.module.css
@@ -1,0 +1,50 @@
+.mini-map-container {
+  cursor: pointer;
+  position: relative;
+  margin-bottom: 10px;
+
+  .mini-map-track {
+    width: 100%;
+    height: 100%;
+  }
+
+  .visible-range-box {
+    cursor: grab;
+    box-sizing: content-box;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 100%;
+    height: calc(100% + 4px);
+    border: 2px solid white;
+
+    &::before {
+      content: "";
+      position: absolute;
+      /* expand clickable range */
+      inset: -5px -10px;
+    }
+  }
+
+  .handle {
+    display: none;
+    cursor: ew-resize;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 50%;
+    width: 5px;
+    border: 2px solid white;
+    background-color: var(--gray-8);
+    &.left {
+      right: 100%;
+    }
+    &.right {
+      left: 100%;
+    }
+  }
+
+  &:hover .handle {
+    display: block;
+  }
+}

--- a/src/features/Replay/MiniMap/useMiniMapQuery.ts
+++ b/src/features/Replay/MiniMap/useMiniMapQuery.ts
@@ -1,0 +1,60 @@
+import { useCallback, useRef } from "react";
+import { ascBucketGranularities, msBucketSizes } from "../const";
+import useAggSlotsQuery, { RequesterId } from "../useAggSlotsQuery";
+import type { AggGranularity } from "../../../api/types";
+import type { NsTsRange } from "../../WebGl/webglUtils";
+import { useThrottledCallback } from "use-debounce";
+
+export default function useMiniMapQuery() {
+  const lastRequestRef = useRef<
+    | {
+        endNs: bigint;
+        granularity: AggGranularity;
+      }
+    | undefined
+  >(undefined);
+
+  const query = useAggSlotsQuery(RequesterId.MiniMap);
+
+  return useThrottledCallback(
+    useCallback(
+      (worldRangeNs: NsTsRange, granularity: AggGranularity) => {
+        if (lastRequestRef.current?.granularity === granularity) {
+          if (lastRequestRef.current?.endNs === worldRangeNs[1]) {
+            // nothing to fetch
+            return;
+          }
+
+          // fetch missing data
+          query([lastRequestRef.current.endNs, worldRangeNs[1]], granularity);
+        } else {
+          // fetch entire world on granularity change
+          query(worldRangeNs, granularity);
+        }
+
+        lastRequestRef.current = {
+          endNs: worldRangeNs[1],
+          granularity,
+        };
+      },
+      [query],
+    ),
+    400,
+    {
+      leading: true,
+      trailing: true,
+    },
+  );
+}
+
+/**
+ * At most, how many buckets should be visible
+ */
+const BUCKET_COUNT_THRESHOLD = 1000;
+export function getMiniMapGranularity(worldSizeMs: number) {
+  return (
+    ascBucketGranularities.find((g) => {
+      return worldSizeMs < BUCKET_COUNT_THRESHOLD * msBucketSizes[g];
+    }) ?? ascBucketGranularities[ascBucketGranularities.length - 1]
+  );
+}

--- a/src/features/Replay/MiniMap/utils.ts
+++ b/src/features/Replay/MiniMap/utils.ts
@@ -1,0 +1,270 @@
+import { MAX_WEBGL_PX_RATIO } from "../../../consts.ts";
+import * as THREE from "three";
+import {
+  createWebglResources,
+  disposeWebglResources,
+  type RectMesh,
+  type WebglResources,
+  addRectangleToMesh,
+  updateRectMeshCounts,
+  createRectMesh,
+  createRenderer,
+  type RgbColor,
+  type TsRange,
+  updateMeshRange,
+  convertToWebGlColor,
+} from "../../WebGl/webglUtils.ts";
+import type { ContextHelpers } from "../../WebGl/useWebGlEventHandlers.ts";
+import { msBucketSizes } from "../const.ts";
+import type { AggGranularity, AggSlots } from "../../../api/types.ts";
+import { epochSliderProgressColor } from "../../../colors.ts";
+
+const opacity = 1;
+const MAX_RECTANGLES_PER_MESH = 8000;
+
+interface MeshReferences {
+  granularity: AggGranularity;
+  referenceMs: number;
+}
+
+export type RendererObj = {
+  renderer: THREE.WebGLRenderer;
+  camera: THREE.OrthographicCamera;
+  scene: THREE.Scene;
+  /* resources shared by this renderer's meshes */
+  resources: WebglResources;
+  meshes: RectMesh[];
+  meshReferences: MeshReferences | undefined;
+  cleanUp: () => void;
+};
+
+export function setUpRenderer(
+  canvasWidth: number,
+  canvasHeight: number,
+  setUpContextListeners: ContextHelpers["setUpContextListeners"],
+  getWasContextLost: ContextHelpers["getWasContextLost"],
+): RendererObj | undefined {
+  const rendererObj = createRenderer(
+    canvasWidth,
+    canvasHeight,
+    MAX_WEBGL_PX_RATIO,
+    setUpContextListeners,
+    getWasContextLost,
+  );
+  if (!rendererObj) return;
+
+  const { renderer, cleanUpRenderer } = rendererObj;
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.OrthographicCamera(0, 0, 0, 0, 0.5, 10);
+  camera.position.z = 1;
+
+  const resources = createWebglResources(opacity);
+  const mesh = createRectMesh(resources, MAX_RECTANGLES_PER_MESH);
+  const meshes = [mesh];
+  scene.add(mesh.mesh);
+
+  const cleanUp = () => {
+    // If context was lost at some point, its GPU objects are already gone so skip objects disposal,
+    // to prevent warnings e.g. WebGL: INVALID_OPERATION: delete: object does not belong to this context
+    // Three doesn't restore GPU objects for restored contexts unless there's a render.
+    // Remount on restore to reset the context listeners state
+    if (!getWasContextLost()) {
+      for (const mesh of meshes) {
+        mesh.mesh.geometry.dispose();
+      }
+      // dispose this chart's own unitQuad / sharedMaterial
+      disposeWebglResources(resources);
+    }
+    cleanUpRenderer();
+  };
+
+  return {
+    renderer,
+    camera,
+    scene,
+    resources,
+    meshes,
+    meshReferences: undefined,
+    cleanUp,
+  };
+}
+
+export function render(rendererObj: RendererObj) {
+  const { renderer, scene, camera } = rendererObj;
+  renderer.render(scene, camera);
+}
+
+enum ColorState {
+  Skipped = "Skipped",
+  NotSkipped = "NotSkipped",
+}
+
+const colorStates = Object.values(ColorState);
+
+const colors: Record<ColorState, RgbColor> = {
+  [ColorState.Skipped]: [235 / 255, 64 / 255, 52 / 255],
+  [ColorState.NotSkipped]: convertToWebGlColor(epochSliderProgressColor),
+};
+
+function getBucketColorCounts(
+  startSlot: number | null,
+  endSlot: number | null,
+  skippedCount: number | null,
+): Record<ColorState, number> {
+  if (startSlot == null || endSlot == null)
+    return {
+      [ColorState.Skipped]: 0,
+      [ColorState.NotSkipped]: 0,
+    };
+
+  const totalSlots = endSlot - startSlot + 1;
+  const skipped = skippedCount ?? 0;
+  return {
+    [ColorState.Skipped]: skipped,
+    [ColorState.NotSkipped]: totalSlots - skipped,
+  };
+}
+
+/**
+ * Draw rectangles. Appends data if granularity is the same as in the last draw.
+ * Create new meshes as needed.
+ */
+export function drawMiniMap(
+  rendererObj: RendererObj,
+  newData: AggSlots,
+  getRelativeMs: (absoluteNs: bigint) => number,
+) {
+  const { scene, meshes } = rendererObj;
+  const { granularity, reference_ts_ns, start_slot, end_slot, skipped } =
+    newData;
+  const referenceMs = getRelativeMs(reference_ts_ns);
+
+  if (newData.granularity !== rendererObj.meshReferences?.granularity) {
+    // reset meshes on granularity change
+    for (const mesh of rendererObj.meshes) {
+      updateRectMeshCounts(mesh, 0);
+    }
+
+    // initialize mesh range
+    rendererObj.meshReferences = {
+      granularity: newData.granularity,
+      referenceMs,
+    };
+  }
+
+  // track ranges that were updated within each mesh
+  const meshUpdates: { minIdx: number; maxIdx: number }[] = [];
+  const bucketSizeMs = msBucketSizes[granularity];
+
+  let maxY = 0;
+  for (let i = 0; i < start_slot.length; i++) {
+    const startMs = referenceMs + i * bucketSizeMs;
+    const width = bucketSizeMs;
+
+    const bucketColorCounts = getBucketColorCounts(
+      start_slot[i],
+      end_slot[i],
+      skipped[i],
+    );
+
+    let y = 0;
+    for (let colorIdx = 0; colorIdx < colorStates.length; colorIdx++) {
+      const colorState = colorStates[colorIdx];
+      const startY = y;
+      const height = bucketColorCounts[colorState];
+      const color = colors[colorState];
+
+      const { meshIdx, rectangleIdx } = getPositionInMesh(
+        rendererObj.meshReferences,
+        startMs,
+        bucketSizeMs,
+        colorIdx,
+      );
+
+      if (!rendererObj.meshes[meshIdx]) {
+        const newMesh = createRectMesh(
+          rendererObj.resources,
+          MAX_RECTANGLES_PER_MESH,
+        );
+        rendererObj.meshes[meshIdx] = newMesh;
+        scene.add(newMesh.mesh);
+      }
+
+      const mesh = meshes[meshIdx];
+      addRectangleToMesh(
+        mesh,
+        rectangleIdx,
+        startMs,
+        startY,
+        width,
+        height,
+        color,
+      );
+
+      // keep track of update range for each mesh
+      if (meshUpdates[meshIdx]) {
+        meshUpdates[meshIdx] = {
+          minIdx: Math.min(rectangleIdx, meshUpdates[meshIdx].minIdx),
+          maxIdx: Math.max(rectangleIdx, meshUpdates[meshIdx].maxIdx),
+        };
+      } else {
+        meshUpdates[meshIdx] = {
+          minIdx: rectangleIdx,
+          maxIdx: rectangleIdx,
+        };
+      }
+
+      y = startY + height;
+    }
+    maxY = Math.max(y, maxY);
+  }
+  updateCameraToMaxY(maxY, rendererObj.camera);
+
+  // update mesh counts / ranges
+  for (let i = 0; i < meshUpdates.length; i++) {
+    const mesh = meshes[i];
+    if (!mesh || !meshUpdates[i]) continue;
+
+    const newCount = meshUpdates[i].maxIdx + 1;
+    if (mesh.count !== newCount) {
+      updateRectMeshCounts(mesh, newCount);
+    }
+
+    updateMeshRange(mesh, [meshUpdates[i].minIdx, meshUpdates[i].maxIdx]);
+  }
+}
+
+/**
+ * Get mesh idx and rectangle idx within mesh. Each bucket reserves colorState.length
+ * consecutive rectangles. Each mesh holds MAX_RECTANGLES_PER_MESH rectangles.
+ */
+function getPositionInMesh(
+  lastDraw: MeshReferences,
+  tsMs: number,
+  bucketSizeMs: number,
+  colorIdx: number,
+) {
+  const bucketIdx = Math.trunc((tsMs - lastDraw.referenceMs) / bucketSizeMs);
+  const overallRectangleIdx = bucketIdx * colorStates.length + colorIdx;
+  const meshIdx = Math.trunc(overallRectangleIdx / MAX_RECTANGLES_PER_MESH);
+  const meshRectangleIdx = overallRectangleIdx % MAX_RECTANGLES_PER_MESH;
+
+  return { meshIdx, rectangleIdx: meshRectangleIdx };
+}
+
+export function moveCamera(rendererObj: RendererObj, worldRangeMs: TsRange) {
+  const { camera } = rendererObj;
+
+  camera.left = worldRangeMs[0];
+  camera.right = worldRangeMs[1];
+  camera.updateProjectionMatrix();
+}
+
+function updateCameraToMaxY(y: number, camera: THREE.OrthographicCamera) {
+  if (y <= camera.top) {
+    return;
+  }
+  camera.top = y;
+  camera.updateProjectionMatrix();
+}

--- a/src/features/Replay/MiniMap/utils.ts
+++ b/src/features/Replay/MiniMap/utils.ts
@@ -18,8 +18,12 @@ import type { ContextHelpers } from "../../WebGl/useWebGlEventHandlers.ts";
 import { msBucketSizes } from "../const.ts";
 import type { AggGranularity, AggSlots } from "../../../api/types.ts";
 import { epochSliderProgressColor } from "../../../colors.ts";
+import { clamp } from "lodash";
 
+export const trackHeight = 25;
 const opacity = 1;
+const minY = 0;
+const maxY = 1;
 const MAX_RECTANGLES_PER_MESH = 8000;
 
 interface MeshReferences {
@@ -56,7 +60,7 @@ export function setUpRenderer(
   const { renderer, cleanUpRenderer } = rendererObj;
 
   const scene = new THREE.Scene();
-  const camera = new THREE.OrthographicCamera(0, 0, 0, 0, 0.5, 10);
+  const camera = new THREE.OrthographicCamera(0, 0, maxY, minY, 0.5, 10);
   camera.position.z = 1;
 
   const resources = createWebglResources(opacity);
@@ -107,22 +111,33 @@ const colors: Record<ColorState, RgbColor> = {
   [ColorState.NotSkipped]: convertToWebGlColor(epochSliderProgressColor),
 };
 
-function getBucketColorCounts(
+function getBucketColorRatios(
   startSlot: number | null,
   endSlot: number | null,
   skippedCount: number | null,
+  minHeightRatio: number,
 ): Record<ColorState, number> {
-  if (startSlot == null || endSlot == null)
+  if (startSlot == null || endSlot == null) {
     return {
       [ColorState.Skipped]: 0,
       [ColorState.NotSkipped]: 0,
     };
+  }
 
   const totalSlots = endSlot - startSlot + 1;
-  const skipped = skippedCount ?? 0;
+  if (totalSlots === 0) {
+    return {
+      [ColorState.Skipped]: 0,
+      [ColorState.NotSkipped]: 0,
+    };
+  }
+
+  const skippedRatio = skippedCount
+    ? clamp(skippedCount / totalSlots, minHeightRatio, maxY)
+    : 0;
   return {
-    [ColorState.Skipped]: skipped,
-    [ColorState.NotSkipped]: totalSlots - skipped,
+    [ColorState.Skipped]: skippedRatio,
+    [ColorState.NotSkipped]: maxY - skippedRatio,
   };
 }
 
@@ -157,22 +172,27 @@ export function drawMiniMap(
   const meshUpdates: { minIdx: number; maxIdx: number }[] = [];
   const bucketSizeMs = msBucketSizes[granularity];
 
-  let maxY = 0;
+  // min 1px
+  const minHeightRatio = (maxY - minY) / trackHeight;
+
   for (let i = 0; i < start_slot.length; i++) {
     const startMs = referenceMs + i * bucketSizeMs;
     const width = bucketSizeMs;
 
-    const bucketColorCounts = getBucketColorCounts(
+    const bucketColorRatios = getBucketColorRatios(
       start_slot[i],
       end_slot[i],
       skipped[i],
+      minHeightRatio,
     );
 
-    let y = 0;
+    let y = minY;
     for (let colorIdx = 0; colorIdx < colorStates.length; colorIdx++) {
       const colorState = colorStates[colorIdx];
       const startY = y;
-      const height = bucketColorCounts[colorState];
+      const ratio = bucketColorRatios[colorState];
+      // keep a non-zero band visible (at least 1px)
+      const height = ratio * (maxY - minY);
       const color = colors[colorState];
 
       const { meshIdx, rectangleIdx } = getPositionInMesh(
@@ -217,9 +237,7 @@ export function drawMiniMap(
 
       y = startY + height;
     }
-    maxY = Math.max(y, maxY);
   }
-  updateCameraToMaxY(maxY, rendererObj.camera);
 
   // update mesh counts / ranges
   for (let i = 0; i < meshUpdates.length; i++) {
@@ -258,13 +276,5 @@ export function moveCamera(rendererObj: RendererObj, worldRangeMs: TsRange) {
 
   camera.left = worldRangeMs[0];
   camera.right = worldRangeMs[1];
-  camera.updateProjectionMatrix();
-}
-
-function updateCameraToMaxY(y: number, camera: THREE.OrthographicCamera) {
-  if (y <= camera.top) {
-    return;
-  }
-  camera.top = y;
   camera.updateProjectionMatrix();
 }

--- a/src/features/Replay/RevenueTrack/RevenueTrack.tsx
+++ b/src/features/Replay/RevenueTrack/RevenueTrack.tsx
@@ -10,7 +10,7 @@ import type { WebGlRemountProps } from "../../WebGl/withWebGlRemount.tsx";
 import { useWebGlEventHandlers } from "../../WebGl/useWebGlEventHandlers.ts";
 import withWebGlRemount from "../../WebGl/withWebGlRemount.tsx";
 import {
-  drawAggRevenue as drawAggRevenue,
+  drawAggRevenue,
   isAggregate,
   moveAggCamera,
   setUpRenderers,
@@ -37,7 +37,6 @@ interface RevenueTrackProps
 function RevenueTrack({
   remount,
   subscribeRangeChange,
-  unsubscribeRangeChange,
   getAbsoluteNs,
   getRelativeMs,
   setUpExploreListeners,
@@ -129,13 +128,13 @@ function RevenueTrack({
     rendererRef.current = rendererObj;
     containerRef.current.replaceChildren(rendererObj.renderer.domElement);
 
-    subscribeRangeChange(subscriptionId, onRangeChange);
+    const unsubscribe = subscribeRangeChange(subscriptionId, onRangeChange);
     const cleanUpExploreListeners = setUpExploreListeners(containerRef.current);
     const cleanUpRenderer = rendererRef.current.cleanUp;
 
     // cleanup
     return () => {
-      unsubscribeRangeChange(subscriptionId);
+      unsubscribe?.();
       cleanUpRenderer();
       rendererRef.current = undefined;
       cleanUpExploreListeners();
@@ -144,7 +143,6 @@ function RevenueTrack({
     onRangeChange,
     setUpExploreListeners,
     subscribeRangeChange,
-    unsubscribeRangeChange,
     setUpContextListeners,
     getWasContextLost,
     hasWidth,

--- a/src/features/Replay/RevenueTrack/RevenueTrack.tsx
+++ b/src/features/Replay/RevenueTrack/RevenueTrack.tsx
@@ -1,0 +1,194 @@
+import { useAtomValue } from "jotai";
+import { useRef, useCallback, useLayoutEffect, useState } from "react";
+import {
+  type ExplorableChartProps,
+  type MarkerLinesProps,
+  type RangeChangeSubscriberProps,
+} from "../const.ts";
+import { useThrottledCallback } from "use-debounce";
+import type { WebGlRemountProps } from "../../WebGl/withWebGlRemount.tsx";
+import { useWebGlEventHandlers } from "../../WebGl/useWebGlEventHandlers.ts";
+import withWebGlRemount from "../../WebGl/withWebGlRemount.tsx";
+import {
+  drawAggRevenue as drawAggRevenue,
+  isAggregate,
+  moveAggCamera,
+  setUpRenderers,
+  type RendererObj,
+} from "./utils.ts";
+import useAggRevenueQuery, { getGranularity } from "./useAggRevenueQuery.ts";
+import type { RevenueType } from "../../../api/entities.ts";
+import { aggRevenueAtom } from "../../../api/atoms.ts";
+import type { AggGranularity } from "../../../api/types.ts";
+import type { NsTsRange, TsRange } from "../../WebGl/webglUtils.ts";
+
+const height = 150;
+const baseSubscriptionId = "revenue-track";
+
+interface RevenueTrackProps
+  extends WebGlRemountProps,
+    RangeChangeSubscriberProps,
+    ExplorableChartProps,
+    MarkerLinesProps {
+  width: number;
+  type: RevenueType;
+}
+
+function RevenueTrack({
+  remount,
+  subscribeRangeChange,
+  unsubscribeRangeChange,
+  getAbsoluteNs,
+  getRelativeMs,
+  setUpExploreListeners,
+  markerLinesClassName,
+  width,
+  type,
+}: RevenueTrackProps) {
+  const subscriptionId = `${type}-${baseSubscriptionId}`;
+  const [granularity, setGranularity] = useState<AggGranularity | undefined>(
+    undefined,
+  );
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const rendererRef = useRef<RendererObj | undefined>();
+
+  const widthRef = useRef(width);
+  widthRef.current = width;
+  const hasWidth = width > 0;
+
+  const { setUpContextListeners, getWasContextLost } = useWebGlEventHandlers({
+    remount,
+  });
+
+  const aggQuery = useAggRevenueQuery();
+  const aggRevenue = useAtomValue(aggRevenueAtom);
+
+  const throttledRelativeTsQuery = useThrottledCallback(
+    (relativeVisibleRange: TsRange, relativeWorldRange: TsRange) => {
+      if (!aggQuery) return;
+      const visibleRangeNs: NsTsRange = [
+        getAbsoluteNs(relativeVisibleRange[0]),
+        getAbsoluteNs(relativeVisibleRange[1]),
+      ];
+
+      if (isAggregate(relativeVisibleRange)) {
+        const queryGranularity = getGranularity(
+          relativeVisibleRange[1] - relativeVisibleRange[0],
+        );
+        aggQuery(visibleRangeNs, queryGranularity);
+        setGranularity(queryGranularity);
+      } else {
+        // TODO: non-aggregate query
+        setGranularity(undefined);
+      }
+    },
+    100,
+    { leading: true, trailing: true },
+  );
+
+  const renderActive = useCallback(() => {
+    if (!rendererRef.current) return;
+    const { renderer, aggResources } = rendererRef.current;
+    // TODO: add non-aggregate resources
+    const { camera, scene } = aggResources;
+    renderer.render(scene, camera);
+  }, []);
+
+  /**
+   * Update camera and query data for new range
+   */
+  const onRangeChange = useCallback(
+    (visibleRangeMs: TsRange, worldRangeMs: TsRange) => {
+      if (!rendererRef.current) return;
+
+      throttledRelativeTsQuery(visibleRangeMs, worldRangeMs);
+
+      if (isAggregate(visibleRangeMs)) {
+        moveAggCamera(rendererRef.current, visibleRangeMs);
+      } else {
+        // TODO: move non-agg camera
+      }
+      renderActive();
+    },
+    [renderActive, throttledRelativeTsQuery],
+  );
+
+  // set up renderer and subscribe to range change, to trigger queries
+  useLayoutEffect(() => {
+    if (rendererRef.current || !hasWidth || !containerRef.current) return;
+
+    const rendererObj = setUpRenderers(
+      widthRef.current,
+      height,
+      setUpContextListeners,
+      getWasContextLost,
+    );
+    if (!rendererObj) return;
+
+    rendererRef.current = rendererObj;
+    containerRef.current.replaceChildren(rendererObj.renderer.domElement);
+
+    subscribeRangeChange(subscriptionId, onRangeChange);
+    const cleanUpExploreListeners = setUpExploreListeners(containerRef.current);
+    const cleanUpRenderer = rendererRef.current.cleanUp;
+
+    // cleanup
+    return () => {
+      unsubscribeRangeChange(subscriptionId);
+      cleanUpRenderer();
+      rendererRef.current = undefined;
+      cleanUpExploreListeners();
+    };
+  }, [
+    onRangeChange,
+    setUpExploreListeners,
+    subscribeRangeChange,
+    unsubscribeRangeChange,
+    setUpContextListeners,
+    getWasContextLost,
+    hasWidth,
+    subscriptionId,
+  ]);
+
+  // handle chart resize
+  useLayoutEffect(() => {
+    if (!rendererRef.current) return;
+    rendererRef.current.renderer.setSize(width, height);
+    renderActive();
+  }, [renderActive, width]);
+
+  // trigger draw
+  useLayoutEffect(() => {
+    if (!rendererRef.current || !aggRevenue) return;
+    // TODO: draw non-agg
+    drawAggRevenue(rendererRef.current, type, aggRevenue, getRelativeMs);
+    renderActive();
+  }, [aggRevenue, getRelativeMs, renderActive, type]);
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        height: `${height}px`,
+      }}
+    >
+      <div
+        ref={containerRef}
+        className={markerLinesClassName}
+        style={{
+          position: "relative",
+          width: "100%",
+          height: "100%",
+        }}
+      />
+      <div style={{ position: "absolute", top: 0, left: "5px" }}>
+        Bucket size: {granularity ?? "-"}
+      </div>
+    </div>
+  );
+}
+
+const RevenueTrackWithRemount = withWebGlRemount(RevenueTrack);
+export default RevenueTrackWithRemount;

--- a/src/features/Replay/RevenueTrack/useAggRevenueQuery.ts
+++ b/src/features/Replay/RevenueTrack/useAggRevenueQuery.ts
@@ -1,0 +1,39 @@
+import { useCallback } from "react";
+import { ascBucketGranularities, msBucketSizes } from "../const";
+import type { AggGranularity } from "../../../api/types";
+import { useWebSocketSend } from "../../../api/ws/utils";
+import type { NsTsRange } from "../../WebGl/webglUtils";
+
+// TODO: throttle across revenue types
+export default function useAggRevenueQuery() {
+  const wsSend = useWebSocketSend();
+
+  return useCallback(
+    (visibleRangeNs: NsTsRange, granularity: AggGranularity) => {
+      const [visibleStart, visibleEnd] = visibleRangeNs;
+      wsSend({
+        topic: "timeline",
+        key: "query_agg_revenue",
+        id: 32,
+        params: {
+          start_ns: visibleStart.toString(),
+          end_ns: visibleEnd.toString(),
+          granularity,
+        },
+      });
+    },
+    [wsSend],
+  );
+}
+
+/**
+ * At most, how many buckets should be visible
+ */
+const BUCKET_COUNT_THRESHOLD = 400;
+export function getGranularity(windowSizeMs: number) {
+  return (
+    ascBucketGranularities.find((g) => {
+      return windowSizeMs < BUCKET_COUNT_THRESHOLD * msBucketSizes[g];
+    }) ?? ascBucketGranularities[ascBucketGranularities.length - 1]
+  );
+}

--- a/src/features/Replay/RevenueTrack/utils.ts
+++ b/src/features/Replay/RevenueTrack/utils.ts
@@ -2,7 +2,7 @@ import { MAX_WEBGL_PX_RATIO } from "../../../consts.ts";
 import * as THREE from "three";
 import {
   createWebglResources,
-  createSlotMesh,
+  createRectMesh,
   disposeWebglResources,
   type SlotMesh,
   type WebglResources,
@@ -42,8 +42,7 @@ export interface AggResources {
   camera: THREE.OrthographicCamera;
   scene: THREE.Scene;
   resources: WebglResources;
-  prevMesh: SlotMesh;
-  currentMesh: SlotMesh;
+  mesh: SlotMesh;
   /**
    * origin ms subtracted from both the camera bounds and
    * the rectangle geometry so the GPU works with small, float32-precise coordinates
@@ -93,8 +92,9 @@ export function setUpAggResources(
   camera.position.z = 1;
 
   const resources = createWebglResources(REVENUE_OPACITY);
-  const prevMesh = createSlotMesh(resources);
-  const currentMesh = createSlotMesh(resources);
+  const mesh = createRectMesh(resources);
+
+  scene.add(mesh.mesh);
 
   const cleanUpResources = () => {
     // If context was lost at some point, its GPU objects are already gone so skip objects disposal,
@@ -102,9 +102,7 @@ export function setUpAggResources(
     // Three doesn't restore GPU objects for restored contexts unless there's a render.
     // Remount on restore to reset the context listeners state
     if (!getWasContextLost()) {
-      for (const slotMesh of [prevMesh, currentMesh]) {
-        slotMesh.mesh.geometry.dispose();
-      }
+      mesh.mesh.geometry.dispose();
       // dispose this chart's own unitQuad / sharedMaterial
       disposeWebglResources(resources);
     }
@@ -114,8 +112,7 @@ export function setUpAggResources(
     camera,
     scene,
     resources,
-    prevMesh,
-    currentMesh,
+    mesh,
     cameraReferenceMs: 0,
     cleanUpResources,
   };
@@ -131,7 +128,7 @@ export function drawAggRevenue(
   rendererObj: RendererObj,
   type: RevenueType,
   aggRevenue: AggRevenue,
-  getRelativeMs: (absoluteMs: bigint) => number,
+  getRelativeMs: (absoluteNs: bigint) => number,
 ) {
   const { granularity, reference_ts_ns } = aggRevenue;
   const referenceMs = getRelativeMs(reference_ts_ns);
@@ -153,11 +150,9 @@ export function drawAggRevenue(
     [],
   );
 
-  const { cameraReferenceMs, scene, currentMesh, prevMesh } =
-    rendererObj.aggResources;
-  const mesh = prevMesh;
+  const { cameraReferenceMs, mesh } = rendererObj.aggResources;
 
-  /** store mesh positions relative to referenceX. This allows CPU to see small coordinates */
+  /** store mesh positions relative to referenceX. This allows GPU to see small coordinates */
   if (mesh.referenceX == null) {
     mesh.referenceX = cameraReferenceMs;
   }
@@ -181,25 +176,16 @@ export function drawAggRevenue(
       REVENUE_COLOR,
     );
   }
-
-  // switch out the prev mesh content
-  const newPrevMesh = currentMesh;
-  newPrevMesh.referenceX = undefined;
-  scene.remove(newPrevMesh.mesh);
-  rendererObj.aggResources.prevMesh = newPrevMesh;
-
-  scene.add(mesh.mesh);
-  rendererObj.aggResources.currentMesh = mesh;
 }
 
 /**
- * Move camera and and update camera and current mesh reference x
+ * Move camera and and update camera and mesh reference x
  */
 export function moveAggCamera(
   rendererObj: RendererObj,
   visibleRangeMs: TsRange,
 ) {
-  const { camera, currentMesh } = rendererObj.aggResources;
+  const { camera, mesh } = rendererObj.aggResources;
 
   // Store a camera reference to make mesh coordinates smaller for GPU
   const cameraReferenceMs = visibleRangeMs[0];
@@ -210,8 +196,8 @@ export function moveAggCamera(
 
   // Mesh point coordinates are already set. Move them to match camera reference
   // by manipulating mesh position.x
-  if (currentMesh.referenceX != null) {
-    currentMesh.mesh.position.x = currentMesh.referenceX - cameraReferenceMs;
+  if (mesh.referenceX != null) {
+    mesh.mesh.position.x = mesh.referenceX - cameraReferenceMs;
   }
 }
 

--- a/src/features/Replay/RevenueTrack/utils.ts
+++ b/src/features/Replay/RevenueTrack/utils.ts
@@ -1,0 +1,220 @@
+import { MAX_WEBGL_PX_RATIO } from "../../../consts.ts";
+import * as THREE from "three";
+import {
+  createWebglResources,
+  createSlotMesh,
+  disposeWebglResources,
+  type SlotMesh,
+  type WebglResources,
+  ensureCapacity,
+  addRectangleToMesh,
+  updateSlotMeshCounts,
+  type RgbColor,
+  type TsRange,
+  createRenderer,
+} from "../../WebGl/webglUtils.ts";
+import type { ContextHelpers } from "../../WebGl/useWebGlEventHandlers.ts";
+import { msBucketSizes } from "../const.ts";
+import type { RevenueType } from "../../../api/entities.ts";
+import type { AggRevenue } from "../../../api/types.ts";
+import { omit } from "lodash";
+import { clampNonZeroValue, logRatio } from "../../../mathUtils.ts";
+import { revenueLogBase } from "../../Overview/SlotPerformance/TransactionBarsCard/consts.ts";
+
+// TODO: set reasonable threshold with non-agg data
+const AGGREGATE_THRESHOLD_MS = 0;
+
+const REVENUE_COLOR: RgbColor = [116 / 255, 178 / 255, 238 / 255];
+const REVENUE_OPACITY = 1;
+
+const minY = 0;
+const minNonZeroY = 0.1;
+const maxY = 5;
+
+export interface RendererObj {
+  renderer: THREE.WebGLRenderer;
+  aggResources: AggResources;
+  // TODO: add nonAggResources
+  cleanUp: () => void;
+}
+
+export interface AggResources {
+  camera: THREE.OrthographicCamera;
+  scene: THREE.Scene;
+  resources: WebglResources;
+  prevMesh: SlotMesh;
+  currentMesh: SlotMesh;
+  /**
+   * origin ms subtracted from both the camera bounds and
+   * the rectangle geometry so the GPU works with small, float32-precise coordinates
+   * instead of ~3.4e8.
+   * Mesh position x values must be updated when this changes
+   */
+  cameraReferenceMs: number;
+}
+
+export function setUpRenderers(
+  canvasWidth: number,
+  canvasHeight: number,
+  setUpContextListeners: ContextHelpers["setUpContextListeners"],
+  getWasContextLost: ContextHelpers["getWasContextLost"],
+): RendererObj | undefined {
+  const rendererObj = createRenderer(
+    canvasWidth,
+    canvasHeight,
+    MAX_WEBGL_PX_RATIO,
+    setUpContextListeners,
+    getWasContextLost,
+  );
+  if (!rendererObj) return;
+
+  const { renderer, cleanUpRenderer } = rendererObj;
+  const aggResources = setUpAggResources(getWasContextLost);
+  // TODO: set up non-agg resources
+
+  const cleanUp = () => {
+    aggResources.cleanUpResources();
+    // TODO: add non-agg clean up
+    cleanUpRenderer();
+  };
+
+  return {
+    renderer,
+    aggResources: omit(aggResources, "cleanUpResources"),
+    cleanUp,
+  };
+}
+
+export function setUpAggResources(
+  getWasContextLost: ContextHelpers["getWasContextLost"],
+): AggResources & { cleanUpResources: () => void } {
+  const scene = new THREE.Scene();
+  const camera = new THREE.OrthographicCamera(0, 0, maxY, minY, 0.5, 10);
+  camera.position.z = 1;
+
+  const resources = createWebglResources(REVENUE_OPACITY);
+  const prevMesh = createSlotMesh(resources);
+  const currentMesh = createSlotMesh(resources);
+
+  const cleanUpResources = () => {
+    // If context was lost at some point, its GPU objects are already gone so skip objects disposal,
+    // to prevent warnings e.g. WebGL: INVALID_OPERATION: delete: object does not belong to this context
+    // Three doesn't restore GPU objects for restored contexts unless there's a render.
+    // Remount on restore to reset the context listeners state
+    if (!getWasContextLost()) {
+      for (const slotMesh of [prevMesh, currentMesh]) {
+        slotMesh.mesh.geometry.dispose();
+      }
+      // dispose this chart's own unitQuad / sharedMaterial
+      disposeWebglResources(resources);
+    }
+  };
+
+  return {
+    camera,
+    scene,
+    resources,
+    prevMesh,
+    currentMesh,
+    cameraReferenceMs: 0,
+    cleanUpResources,
+  };
+}
+
+function getRevenueRatio(maxValue: bigint, value: bigint) {
+  if (maxValue === 0n) return 0;
+  const ratio = 1 / logRatio(Number(maxValue), Number(value), revenueLogBase);
+  return clampNonZeroValue(ratio, minNonZeroY, maxY);
+}
+
+export function drawAggRevenue(
+  rendererObj: RendererObj,
+  type: RevenueType,
+  aggRevenue: AggRevenue,
+  getRelativeMs: (absoluteMs: bigint) => number,
+) {
+  const { granularity, reference_ts_ns } = aggRevenue;
+  const referenceMs = getRelativeMs(reference_ts_ns);
+  const bucketMs = msBucketSizes[granularity];
+
+  let maxValue = 0n;
+  const data = aggRevenue[type].reduce<[value: bigint, startMs: number][]>(
+    (acc, value, i) => {
+      if (value != null) {
+        const startMs = referenceMs + i * bucketMs;
+        acc.push([value, startMs]);
+
+        if (value > maxValue) {
+          maxValue = value;
+        }
+      }
+      return acc;
+    },
+    [],
+  );
+
+  const { cameraReferenceMs, scene, currentMesh, prevMesh } =
+    rendererObj.aggResources;
+  const mesh = prevMesh;
+
+  /** store mesh positions relative to referenceX. This allows CPU to see small coordinates */
+  if (mesh.referenceX == null) {
+    mesh.referenceX = cameraReferenceMs;
+  }
+  mesh.mesh.position.x = mesh.referenceX - cameraReferenceMs;
+
+  // draw nothing if max value is 0
+  const dataCount = maxValue === 0n ? 0 : data.length;
+  ensureCapacity(mesh, dataCount);
+  updateSlotMeshCounts(mesh, dataCount);
+
+  for (let rectangleIdx = 0; rectangleIdx < dataCount; rectangleIdx++) {
+    const [value, startMs] = data[rectangleIdx];
+    const endMs = startMs + bucketMs;
+    addRectangleToMesh(
+      mesh,
+      rectangleIdx,
+      startMs - mesh.referenceX,
+      minY,
+      endMs - startMs,
+      getRevenueRatio(maxValue, value),
+      REVENUE_COLOR,
+    );
+  }
+
+  // switch out the prev mesh content
+  const newPrevMesh = currentMesh;
+  newPrevMesh.referenceX = undefined;
+  scene.remove(newPrevMesh.mesh);
+  rendererObj.aggResources.prevMesh = newPrevMesh;
+
+  scene.add(mesh.mesh);
+  rendererObj.aggResources.currentMesh = mesh;
+}
+
+/**
+ * Move camera and and update camera and current mesh reference x
+ */
+export function moveAggCamera(
+  rendererObj: RendererObj,
+  visibleRangeMs: TsRange,
+) {
+  const { camera, currentMesh } = rendererObj.aggResources;
+
+  // Store a camera reference to make mesh coordinates smaller for GPU
+  const cameraReferenceMs = visibleRangeMs[0];
+  rendererObj.aggResources.cameraReferenceMs = cameraReferenceMs;
+  camera.left = visibleRangeMs[0] - cameraReferenceMs;
+  camera.right = visibleRangeMs[1] - cameraReferenceMs;
+  camera.updateProjectionMatrix();
+
+  // Mesh point coordinates are already set. Move them to match camera reference
+  // by manipulating mesh position.x
+  if (currentMesh.referenceX != null) {
+    currentMesh.mesh.position.x = currentMesh.referenceX - cameraReferenceMs;
+  }
+}
+
+export function isAggregate(rangeMs: TsRange) {
+  return rangeMs[1] - rangeMs[0] > AGGREGATE_THRESHOLD_MS;
+}

--- a/src/features/Replay/RevenueTrack/utils.ts
+++ b/src/features/Replay/RevenueTrack/utils.ts
@@ -4,11 +4,11 @@ import {
   createWebglResources,
   createRectMesh,
   disposeWebglResources,
-  type SlotMesh,
+  type RectMesh,
   type WebglResources,
   ensureCapacity,
   addRectangleToMesh,
-  updateSlotMeshCounts,
+  updateRectMeshCounts,
   type RgbColor,
   type TsRange,
   createRenderer,
@@ -42,7 +42,7 @@ export interface AggResources {
   camera: THREE.OrthographicCamera;
   scene: THREE.Scene;
   resources: WebglResources;
-  mesh: SlotMesh;
+  mesh: RectMesh;
   /**
    * origin ms subtracted from both the camera bounds and
    * the rectangle geometry so the GPU works with small, float32-precise coordinates
@@ -153,15 +153,13 @@ export function drawAggRevenue(
   const { cameraReferenceMs, mesh } = rendererObj.aggResources;
 
   /** store mesh positions relative to referenceX. This allows GPU to see small coordinates */
-  if (mesh.referenceX == null) {
-    mesh.referenceX = cameraReferenceMs;
-  }
-  mesh.mesh.position.x = mesh.referenceX - cameraReferenceMs;
+  mesh.referenceX = cameraReferenceMs;
+  mesh.mesh.position.x = 0;
 
   // draw nothing if max value is 0
   const dataCount = maxValue === 0n ? 0 : data.length;
   ensureCapacity(mesh, dataCount);
-  updateSlotMeshCounts(mesh, dataCount);
+  updateRectMeshCounts(mesh, dataCount);
 
   for (let rectangleIdx = 0; rectangleIdx < dataCount; rectangleIdx++) {
     const [value, startMs] = data[rectangleIdx];

--- a/src/features/Replay/VisibleRangeInfo.tsx
+++ b/src/features/Replay/VisibleRangeInfo.tsx
@@ -1,0 +1,59 @@
+import { Flex } from "@radix-ui/themes";
+import { Duration, DateTime } from "luxon";
+import { memo, useLayoutEffect, useState } from "react";
+import type { RangeChangeSubscriberProps } from "./const";
+import type { NsTsRange } from "../WebGl/webglUtils";
+import { nsPerMs } from "../../consts";
+
+const formatAbsoluteTs = (absoluteNs: bigint) => {
+  return DateTime.fromMillis(
+    Number(absoluteNs / BigInt(nsPerMs)),
+  ).toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
+};
+
+const subscriberId = "visible-range";
+export default memo(function VisibleRangeInfo({
+  subscribeRangeChange,
+  unsubscribeRangeChange,
+  getAbsoluteNs,
+}: RangeChangeSubscriberProps) {
+  const [absoluteVisibleRangeNs, setAbsoluteVisibleRangeNs] =
+    useState<NsTsRange>();
+
+  useLayoutEffect(() => {
+    subscribeRangeChange(subscriberId, (visibleRangeMs) => {
+      setAbsoluteVisibleRangeNs([
+        getAbsoluteNs(visibleRangeMs[0]),
+        getAbsoluteNs(visibleRangeMs[1]),
+      ]);
+    });
+    return () => unsubscribeRangeChange(subscriberId);
+  }, [subscribeRangeChange, unsubscribeRangeChange, getAbsoluteNs]);
+
+  if (!absoluteVisibleRangeNs) return null;
+
+  const durationNs = absoluteVisibleRangeNs[1] - absoluteVisibleRangeNs[0];
+  const durationMs = Number(durationNs / BigInt(nsPerMs));
+
+  const durationText = Duration.fromMillis(durationMs)
+    .shiftTo("days", "hours", "minutes", "seconds", "milliseconds")
+    .normalize()
+    .toHuman({ unitDisplay: "short", maximumFractionDigits: 0 })
+    .split(", ")
+    .filter((part) => !part.startsWith("0 "))
+    .join(", ");
+
+  return (
+    <Flex justify="between" my="2">
+      <Value>{formatAbsoluteTs(absoluteVisibleRangeNs[0])}</Value>
+      <div>
+        Window duration: <Value>{durationText}</Value>
+      </div>
+      <Value>{formatAbsoluteTs(absoluteVisibleRangeNs[1])}</Value>
+    </Flex>
+  );
+});
+
+function Value({ children }: { children: React.ReactNode }) {
+  return <span style={{ color: "#b0b0b0" }}>{children}</span>;
+}

--- a/src/features/Replay/VisibleRangeInfo.tsx
+++ b/src/features/Replay/VisibleRangeInfo.tsx
@@ -14,21 +14,20 @@ const formatAbsoluteTs = (absoluteNs: bigint) => {
 const subscriberId = "visible-range";
 export default memo(function VisibleRangeInfo({
   subscribeRangeChange,
-  unsubscribeRangeChange,
   getAbsoluteNs,
 }: RangeChangeSubscriberProps) {
   const [absoluteVisibleRangeNs, setAbsoluteVisibleRangeNs] =
     useState<NsTsRange>();
 
   useLayoutEffect(() => {
-    subscribeRangeChange(subscriberId, (visibleRangeMs) => {
+    const unsubscribe = subscribeRangeChange(subscriberId, (visibleRangeMs) => {
       setAbsoluteVisibleRangeNs([
         getAbsoluteNs(visibleRangeMs[0]),
         getAbsoluteNs(visibleRangeMs[1]),
       ]);
     });
-    return () => unsubscribeRangeChange(subscriberId);
-  }, [subscribeRangeChange, unsubscribeRangeChange, getAbsoluteNs]);
+    return () => unsubscribe?.();
+  }, [subscribeRangeChange, getAbsoluteNs]);
 
   if (!absoluteVisibleRangeNs) return null;
 

--- a/src/features/Replay/chart.module.css
+++ b/src/features/Replay/chart.module.css
@@ -1,0 +1,18 @@
+.container {
+  padding: 32px;
+  border-radius: 8px;
+  border: 4px solid rgb(42, 53, 72);
+  background: rgb(34, 44, 61);
+  flex-shrink: 0;
+}
+
+.with-marker-lines::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-left: 3px solid yellow;
+  transform: translateX(var(--marker-lines-pct)) translateX(-1.5px);
+}

--- a/src/features/Replay/chart.module.css
+++ b/src/features/Replay/chart.module.css
@@ -4,13 +4,23 @@
   flex-shrink: 0;
 }
 
+.with-marker-lines,
+.with-world-marker-lines {
+  &::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-left: 3px solid yellow;
+  }
+}
+
 .with-marker-lines::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border-left: 3px solid yellow;
   transform: translateX(var(--marker-lines-pct)) translateX(-1.5px);
+}
+
+.with-world-marker-lines::after {
+  transform: translateX(var(--world-marker-lines-pct)) translateX(-1.5px);
 }

--- a/src/features/Replay/chart.module.css
+++ b/src/features/Replay/chart.module.css
@@ -1,8 +1,6 @@
 .container {
   padding: 32px;
   border-radius: 8px;
-  border: 4px solid rgb(42, 53, 72);
-  background: rgb(34, 44, 61);
   flex-shrink: 0;
 }
 

--- a/src/features/Replay/const.ts
+++ b/src/features/Replay/const.ts
@@ -41,9 +41,9 @@ export type RangeChangeHandler = (
 export interface RangeChangeSubscriberProps {
   subscribeRangeChange: (
     subscriberId: string,
-    onRangeChange: RangeChangeHandler,
-  ) => void;
-  unsubscribeRangeChange: (subscriberId: string) => void;
+    onVisibleRangeChange: RangeChangeHandler,
+    onSelectedMsChange?: RangeChangeHandler,
+  ) => (() => void) | undefined;
   getAbsoluteNs: (relativeMs: number) => bigint;
   getRelativeMs: (absoluteNs: bigint) => number;
 }

--- a/src/features/Replay/const.ts
+++ b/src/features/Replay/const.ts
@@ -1,0 +1,57 @@
+import type { AggGranularity } from "../../api/types";
+import type { TsRange } from "../WebGl/webglUtils";
+
+export const DEFAULT_WINDOW_MS = 12_000;
+export const MIN_VISIBLE_MS = 600;
+
+export const msBucketSizes: Record<AggGranularity, number> = {
+  "250ms": 250,
+  "500ms": 500,
+  "1s": 1_000,
+  "2s": 2_000,
+  "4s": 4_000,
+  "8s": 8_000,
+  "15s": 15_000,
+  "30s": 30_000,
+  "1m": 60_000,
+  "2m": 120_000,
+  "4m": 240_000,
+  "8m": 480_000,
+  "15m": 900_000,
+  "30m": 1_800_000,
+  "1h": 3_600_000,
+  "2h": 7_200_000,
+  "4h": 14_400_000,
+  "8h": 28_800_000,
+  "12h": 43_200_000,
+  "1d": 86_400_000,
+};
+
+export const ascBucketGranularities = Object.keys(msBucketSizes).sort(
+  (a, b) =>
+    msBucketSizes[a as AggGranularity] - msBucketSizes[b as AggGranularity],
+) as AggGranularity[];
+
+export type RangeChangeHandler = (
+  visibleRangeMs: TsRange,
+  worldRangeMs: TsRange,
+  selectedMs: number | undefined,
+) => void;
+
+export interface RangeChangeSubscriberProps {
+  subscribeRangeChange: (
+    subscriberId: string,
+    onRangeChange: RangeChangeHandler,
+  ) => void;
+  unsubscribeRangeChange: (subscriberId: string) => void;
+  getAbsoluteNs: (relativeMs: number) => bigint;
+  getRelativeMs: (absoluteNs: bigint) => number;
+}
+
+export interface ExplorableChartProps {
+  setUpExploreListeners: (trackEl: HTMLDivElement) => () => void;
+}
+
+export interface MarkerLinesProps {
+  markerLinesClassName: string;
+}

--- a/src/features/Replay/const.ts
+++ b/src/features/Replay/const.ts
@@ -43,6 +43,7 @@ export interface RangeChangeSubscriberProps {
     subscriberId: string,
     onVisibleRangeChange: RangeChangeHandler,
     onSelectedMsChange?: RangeChangeHandler,
+    onWorldRangeChange?: RangeChangeHandler,
   ) => (() => void) | undefined;
   getAbsoluteNs: (relativeMs: number) => bigint;
   getRelativeMs: (absoluteNs: bigint) => number;
@@ -52,6 +53,16 @@ export interface ExplorableChartProps {
   setUpExploreListeners: (trackEl: HTMLDivElement) => () => void;
 }
 
+export interface MiniMapSetupProps {
+  setUpMiniMap: (
+    trackEl: HTMLDivElement,
+    visibleRangeEl: HTMLDivElement,
+    leftHandleEl: HTMLDivElement,
+    rightHandleEl: HTMLDivElement,
+  ) => () => void;
+}
+
 export interface MarkerLinesProps {
   markerLinesClassName: string;
+  miniMapMarkerLinesClassName: string;
 }

--- a/src/features/Replay/index.tsx
+++ b/src/features/Replay/index.tsx
@@ -1,19 +1,29 @@
-import { Card, Flex } from "@radix-ui/themes";
+import { Card, Flex, Spinner } from "@radix-ui/themes";
 import CardHeader from "../../components/CardHeader";
+import Chart from "./Chart";
 import { useAtomValue } from "jotai";
+import { startupTimeAtom } from "../../api/atoms";
 import { isWebgl2SupportedAtom } from "../WebGl/atoms";
 
 export default function Replay() {
   const isWebGl2Supported = useAtomValue(isWebgl2SupportedAtom);
+  const startupTimeNs = useAtomValue(startupTimeAtom)?.startupTimeNanos;
   return (
     <Flex direction="column" gap="4" height="100%">
       {isWebGl2Supported ? (
-        <Card>
-          <CardHeader text="Replay" />
-          <Flex direction="column" gap="4" mt="2">
-            Replay Chart
-          </Flex>
-        </Card>
+        startupTimeNs != null ? (
+          <Card>
+            <CardHeader text="Replay" />
+            <Flex direction="column" gap="4" mt="2">
+              <Chart
+                key={String(startupTimeNs)}
+                startupTimeNs={startupTimeNs}
+              />
+            </Flex>
+          </Card>
+        ) : (
+          <Spinner />
+        )
       ) : (
         <div>WebGL2 support required</div>
       )}

--- a/src/features/Replay/index.tsx
+++ b/src/features/Replay/index.tsx
@@ -1,0 +1,22 @@
+import { Card, Flex } from "@radix-ui/themes";
+import CardHeader from "../../components/CardHeader";
+import { useAtomValue } from "jotai";
+import { isWebgl2SupportedAtom } from "../WebGl/atoms";
+
+export default function Replay() {
+  const isWebGl2Supported = useAtomValue(isWebgl2SupportedAtom);
+  return (
+    <Flex direction="column" gap="4" height="100%">
+      {isWebGl2Supported ? (
+        <Card>
+          <CardHeader text="Replay" />
+          <Flex direction="column" gap="4" mt="2">
+            Replay Chart
+          </Flex>
+        </Card>
+      ) : (
+        <div>WebGL2 support required</div>
+      )}
+    </Flex>
+  );
+}

--- a/src/features/Replay/useAggSlotsQuery.ts
+++ b/src/features/Replay/useAggSlotsQuery.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+import { useWebSocketSend } from "../../api/ws/utils";
+import type { AggGranularity } from "../../api/types";
+import type { NsTsRange } from "../WebGl/webglUtils";
+
+export enum RequesterId {
+  MiniMap = 0,
+}
+
+export default function useAggSlotsQuery(requesterId: RequesterId) {
+  const wsSend = useWebSocketSend();
+
+  return useCallback(
+    (rangeNs: NsTsRange, granularity: AggGranularity) => {
+      const [start, end] = rangeNs;
+      wsSend({
+        topic: "timeline",
+        key: "query_agg_slots",
+        id: requesterId,
+        params: {
+          start_ns: start.toString(),
+          end_ns: end.toString(),
+          granularity,
+        },
+      });
+    },
+    [requesterId, wsSend],
+  );
+}

--- a/src/features/Replay/useExplorableChart.ts
+++ b/src/features/Replay/useExplorableChart.ts
@@ -1,9 +1,29 @@
-import { useMemo, useRef, type RefObject } from "react";
+import { useCallback, useMemo, useRef, type RefObject } from "react";
 import type { TsRange } from "../WebGl/webglUtils";
 import { MIN_VISIBLE_MS, type ExplorableChartProps } from "./const";
 
 const PAN_THRESHOLD_PX = 0;
 const ZOOM_INTENSITY = 0.002;
+
+function clientXToTs(
+  trackEl: HTMLDivElement,
+  clientX: number,
+  tsWindow: TsRange,
+) {
+  const trackRect = trackEl.getBoundingClientRect();
+  const fraction = (clientX - trackRect.left) / trackRect.width;
+  return tsWindow[0] + fraction * (tsWindow[1] - tsWindow[0]);
+}
+
+function addListener<K extends keyof HTMLElementEventMap>(
+  el: HTMLElement,
+  type: K,
+  listener: (event: HTMLElementEventMap[K]) => void,
+  options?: AddEventListenerOptions,
+): () => void {
+  el.addEventListener(type, listener, options);
+  return () => el.removeEventListener(type, listener, options);
+}
 
 interface UseExplorableChartProps {
   rangeRef: RefObject<
@@ -31,147 +51,140 @@ export function useExplorableChart({
   }>();
   const isPanningRef = useRef(false);
 
+  const createCallbacks = useCallback(
+    (
+      trackEl: HTMLDivElement,
+      refreshCursor: () => void,
+      isWorldTrack: boolean,
+    ) => {
+      const startDrag = (clientX: number) => {
+        if (!rangeRef.current) return;
+
+        const window = isWorldTrack
+          ? ([0, rangeRef.current.worldEndMs] satisfies TsRange)
+          : rangeRef.current.visibleRangeMs;
+        const ts = clientXToTs(trackEl, clientX, window);
+
+        dragStartRef.current = {
+          clientX,
+          ts,
+          draggableWindow: [...window],
+          startVisibleRange: [...rangeRef.current.visibleRangeMs],
+        };
+
+        isPanningRef.current = false;
+        refreshCursor();
+        setSelectedMs(dragStartRef.current.ts);
+      };
+
+      const moveDrag = (clientX: number) => {
+        if (
+          !dragStartRef.current ||
+          Math.abs(clientX - dragStartRef.current.clientX) < PAN_THRESHOLD_PX
+        ) {
+          return;
+        }
+        isPanningRef.current = true;
+        refreshCursor();
+        const xTs = clientXToTs(
+          trackEl,
+          clientX,
+          dragStartRef.current.draggableWindow,
+        );
+        const diff = (isWorldTrack ? -1 : 1) * (xTs - dragStartRef.current.ts);
+        setVisibleRange([
+          dragStartRef.current.startVisibleRange[0] - diff,
+          dragStartRef.current.startVisibleRange[1] - diff,
+        ]);
+      };
+
+      const zoom = (clientX: number, deltaY: number) => {
+        const prevWindow = rangeRef.current?.visibleRangeMs;
+        if (!prevWindow) return;
+
+        const [startTs, endTs] = prevWindow;
+        const span = endTs - startTs;
+        const isZoomingOut = deltaY > 0;
+
+        const cursorTs = clientXToTs(trackEl, clientX, prevWindow);
+        // larger deltaY = faster zoom
+        let scale = Math.exp(deltaY * ZOOM_INTENSITY);
+        // don't zoom in past the minimum span (clamp to it instead of overshooting)
+        if (!isZoomingOut && span * scale < MIN_VISIBLE_MS) {
+          scale = MIN_VISIBLE_MS / span;
+        }
+        setVisibleRange([
+          cursorTs - (cursorTs - startTs) * scale,
+          cursorTs + (endTs - cursorTs) * scale,
+        ]);
+      };
+
+      return {
+        endDrag: () => {
+          dragStartRef.current = undefined;
+          isPanningRef.current = false;
+          refreshCursor();
+        },
+        onMouseDown: (e: MouseEvent) => {
+          if (e.button !== 0) return;
+          startDrag(e.clientX);
+          e.preventDefault();
+        },
+        onMouseMove: (e: MouseEvent) => {
+          if (!(e.buttons & 1)) return;
+          moveDrag(e.clientX);
+        },
+        onTouchStart: (e: TouchEvent) => {
+          if (e.touches.length !== 1) return;
+          startDrag(e.touches[0].clientX);
+          e.preventDefault();
+        },
+        onTouchMove: (e: TouchEvent) => {
+          if (e.touches.length !== 1) return;
+          moveDrag(e.touches[0].clientX);
+          e.preventDefault();
+        },
+        onWheel: (e: WheelEvent) => {
+          e.preventDefault();
+          zoom(e.clientX, e.deltaY);
+        },
+      };
+    },
+    [rangeRef, setSelectedMs, setVisibleRange],
+  );
+
   return useMemo(() => {
-    const setIsPanning = (trackEl: HTMLDivElement, isPanning: boolean) => {
-      isPanningRef.current = isPanning;
-      trackEl.style.cursor = isPanning ? "grabbing" : "grab";
-    };
-
-    const clientXToTs = (
-      trackEl: HTMLDivElement,
-      clientX: number,
-      tsWindow: TsRange,
-    ) => {
-      const rect = trackEl.getBoundingClientRect();
-      const fraction = (clientX - rect.left) / rect.width;
-      return tsWindow[0] + fraction * (tsWindow[1] - tsWindow[0]);
-    };
-
-    const startDrag = (
-      trackEl: HTMLDivElement,
-      draggingEl: HTMLDivElement,
-      clientX: number,
-      isWorld: boolean,
-    ) => {
-      if (!rangeRef.current) return;
-
-      const window = isWorld
-        ? ([0, rangeRef.current.worldEndMs] satisfies TsRange)
-        : rangeRef.current.visibleRangeMs;
-      const ts = clientXToTs(trackEl, clientX, window);
-
-      dragStartRef.current = {
-        clientX,
-        ts,
-        draggableWindow: [...window],
-        startVisibleRange: [...rangeRef.current.visibleRangeMs],
-      };
-
-      setIsPanning(draggingEl, false);
-      setSelectedMs(dragStartRef.current.ts);
-    };
-
-    const moveDrag = (
-      trackEl: HTMLDivElement,
-      draggingEl: HTMLDivElement,
-      clientX: number,
-      isWorld: boolean,
-    ) => {
-      if (
-        !dragStartRef.current ||
-        Math.abs(clientX - dragStartRef.current.clientX) < PAN_THRESHOLD_PX
-      ) {
-        return;
-      }
-      setIsPanning(draggingEl, true);
-      const xTs = clientXToTs(
-        trackEl,
-        clientX,
-        dragStartRef.current.draggableWindow,
-      );
-      const diff = (isWorld ? -1 : 1) * (xTs - dragStartRef.current.ts);
-      setVisibleRange([
-        dragStartRef.current.startVisibleRange[0] - diff,
-        dragStartRef.current.startVisibleRange[1] - diff,
-      ]);
-    };
-
-    const zoom = (trackEl: HTMLDivElement, clientX: number, deltaY: number) => {
-      const prevWindow = rangeRef.current?.visibleRangeMs;
-      if (!prevWindow) return;
-
-      const [startTs, endTs] = prevWindow;
-      const span = endTs - startTs;
-      const isZoomingOut = deltaY > 0;
-
-      const cursorTs = clientXToTs(trackEl, clientX, prevWindow);
-      // exp keeps in/out symmetric and reversible; larger deltaY = faster zoom
-      let scale = Math.exp(deltaY * ZOOM_INTENSITY);
-      // don't zoom in past the minimum span (clamp to it instead of overshooting)
-      if (!isZoomingOut && span * scale < MIN_VISIBLE_MS) {
-        scale = MIN_VISIBLE_MS / span;
-      }
-      setVisibleRange([
-        cursorTs - (cursorTs - startTs) * scale,
-        cursorTs + (endTs - cursorTs) * scale,
-      ]);
-    };
-
     const setUpExploreListeners = (trackEl: HTMLDivElement) => {
-      trackEl.style.cursor = "grab";
-
-      const endDrag = () => {
-        dragStartRef.current = undefined;
-        setIsPanning(trackEl, false);
+      const refreshCursor = () => {
+        const cursor = isPanningRef.current ? "grabbing" : "grab";
+        trackEl.style.cursor = cursor;
       };
 
-      const onMouseDown = (e: MouseEvent) => {
-        if (e.button !== 0) return;
-        startDrag(trackEl, trackEl, e.clientX, false);
-        e.preventDefault();
-      };
-      const onMouseMove = (e: MouseEvent) => {
-        if (!(e.buttons & 1)) return;
-        moveDrag(trackEl, trackEl, e.clientX, false);
-      };
-      const onTouchStart = (e: TouchEvent) => {
-        if (e.touches.length !== 1) return;
-        startDrag(trackEl, trackEl, e.touches[0].clientX, false);
-        e.preventDefault();
-      };
-      const onTouchMove = (e: TouchEvent) => {
-        if (e.touches.length !== 1) return;
-        moveDrag(trackEl, trackEl, e.touches[0].clientX, false);
-        e.preventDefault();
-      };
-      const onWheel = (e: WheelEvent) => {
-        e.preventDefault();
-        zoom(trackEl, e.clientX, e.deltaY);
-      };
+      refreshCursor();
 
-      trackEl.addEventListener("mousedown", onMouseDown);
-      trackEl.addEventListener("mousemove", onMouseMove);
-      trackEl.addEventListener("mouseup", endDrag);
-      trackEl.addEventListener("mouseleave", endDrag);
-      trackEl.addEventListener("touchstart", onTouchStart, { passive: false });
-      trackEl.addEventListener("touchmove", onTouchMove, { passive: false });
-      trackEl.addEventListener("touchend", endDrag);
-      trackEl.addEventListener("touchcancel", endDrag);
-      trackEl.addEventListener("wheel", onWheel, { passive: false });
+      const {
+        endDrag,
+        onMouseDown,
+        onMouseMove,
+        onTouchStart,
+        onTouchMove,
+        onWheel,
+      } = createCallbacks(trackEl, refreshCursor, false);
 
-      return () => {
-        trackEl.removeEventListener("mousedown", onMouseDown);
-        trackEl.removeEventListener("mousemove", onMouseMove);
-        trackEl.removeEventListener("mouseup", endDrag);
-        trackEl.removeEventListener("mouseleave", endDrag);
-        trackEl.removeEventListener("touchstart", onTouchStart);
-        trackEl.removeEventListener("touchmove", onTouchMove);
-        trackEl.removeEventListener("touchend", endDrag);
-        trackEl.removeEventListener("touchcancel", endDrag);
-        trackEl.removeEventListener("wheel", onWheel);
-      };
+      const cleanups = [
+        addListener(trackEl, "mousedown", onMouseDown),
+        addListener(trackEl, "mousemove", onMouseMove),
+        addListener(trackEl, "mouseup", endDrag),
+        addListener(trackEl, "mouseleave", endDrag),
+        addListener(trackEl, "touchstart", onTouchStart, { passive: false }),
+        addListener(trackEl, "touchmove", onTouchMove, { passive: false }),
+        addListener(trackEl, "touchend", endDrag),
+        addListener(trackEl, "touchcancel", endDrag),
+        addListener(trackEl, "wheel", onWheel, { passive: false }),
+      ];
+
+      return () => cleanups.forEach((off) => off());
     };
-
     return { setUpExploreListeners };
-  }, [rangeRef, setSelectedMs, setVisibleRange]);
+  }, [createCallbacks]);
 }

--- a/src/features/Replay/useExplorableChart.ts
+++ b/src/features/Replay/useExplorableChart.ts
@@ -1,0 +1,177 @@
+import { useMemo, useRef, type RefObject } from "react";
+import type { TsRange } from "../WebGl/webglUtils";
+import { MIN_VISIBLE_MS, type ExplorableChartProps } from "./const";
+
+const PAN_THRESHOLD_PX = 0;
+const ZOOM_INTENSITY = 0.002;
+
+interface UseExplorableChartProps {
+  rangeRef: RefObject<
+    | {
+        referenceNs: bigint;
+        worldEndMs: number;
+        visibleRangeMs: TsRange;
+      }
+    | undefined
+  >;
+  setSelectedMs: (ts: number | undefined) => void;
+  setVisibleRange: (unclampedNewRange: TsRange) => void;
+}
+
+export function useExplorableChart({
+  rangeRef,
+  setSelectedMs,
+  setVisibleRange,
+}: UseExplorableChartProps): ExplorableChartProps {
+  const dragStartRef = useRef<{
+    clientX: number;
+    ts: number;
+    draggableWindow: TsRange;
+    startVisibleRange: TsRange;
+  }>();
+  const isPanningRef = useRef(false);
+
+  return useMemo(() => {
+    const setIsPanning = (trackEl: HTMLDivElement, isPanning: boolean) => {
+      isPanningRef.current = isPanning;
+      trackEl.style.cursor = isPanning ? "grabbing" : "grab";
+    };
+
+    const clientXToTs = (
+      trackEl: HTMLDivElement,
+      clientX: number,
+      tsWindow: TsRange,
+    ) => {
+      const rect = trackEl.getBoundingClientRect();
+      const fraction = (clientX - rect.left) / rect.width;
+      return tsWindow[0] + fraction * (tsWindow[1] - tsWindow[0]);
+    };
+
+    const startDrag = (
+      trackEl: HTMLDivElement,
+      draggingEl: HTMLDivElement,
+      clientX: number,
+      isWorld: boolean,
+    ) => {
+      if (!rangeRef.current) return;
+
+      const window = isWorld
+        ? ([0, rangeRef.current.worldEndMs] satisfies TsRange)
+        : rangeRef.current.visibleRangeMs;
+      const ts = clientXToTs(trackEl, clientX, window);
+
+      dragStartRef.current = {
+        clientX,
+        ts,
+        draggableWindow: [...window],
+        startVisibleRange: [...rangeRef.current.visibleRangeMs],
+      };
+
+      setIsPanning(draggingEl, false);
+      setSelectedMs(dragStartRef.current.ts);
+    };
+
+    const moveDrag = (
+      trackEl: HTMLDivElement,
+      draggingEl: HTMLDivElement,
+      clientX: number,
+      isWorld: boolean,
+    ) => {
+      if (
+        !dragStartRef.current ||
+        Math.abs(clientX - dragStartRef.current.clientX) < PAN_THRESHOLD_PX
+      ) {
+        return;
+      }
+      setIsPanning(draggingEl, true);
+      const xTs = clientXToTs(
+        trackEl,
+        clientX,
+        dragStartRef.current.draggableWindow,
+      );
+      const diff = (isWorld ? -1 : 1) * (xTs - dragStartRef.current.ts);
+      setVisibleRange([
+        dragStartRef.current.startVisibleRange[0] - diff,
+        dragStartRef.current.startVisibleRange[1] - diff,
+      ]);
+    };
+
+    const zoom = (trackEl: HTMLDivElement, clientX: number, deltaY: number) => {
+      const prevWindow = rangeRef.current?.visibleRangeMs;
+      if (!prevWindow) return;
+
+      const [startTs, endTs] = prevWindow;
+      const span = endTs - startTs;
+      const isZoomingOut = deltaY > 0;
+
+      const cursorTs = clientXToTs(trackEl, clientX, prevWindow);
+      // exp keeps in/out symmetric and reversible; larger deltaY = faster zoom
+      let scale = Math.exp(deltaY * ZOOM_INTENSITY);
+      // don't zoom in past the minimum span (clamp to it instead of overshooting)
+      if (!isZoomingOut && span * scale < MIN_VISIBLE_MS) {
+        scale = MIN_VISIBLE_MS / span;
+      }
+      setVisibleRange([
+        cursorTs - (cursorTs - startTs) * scale,
+        cursorTs + (endTs - cursorTs) * scale,
+      ]);
+    };
+
+    const setUpExploreListeners = (trackEl: HTMLDivElement) => {
+      trackEl.style.cursor = "grab";
+
+      const endDrag = () => {
+        dragStartRef.current = undefined;
+        setIsPanning(trackEl, false);
+      };
+
+      const onMouseDown = (e: MouseEvent) => {
+        if (e.button !== 0) return;
+        startDrag(trackEl, trackEl, e.clientX, false);
+        e.preventDefault();
+      };
+      const onMouseMove = (e: MouseEvent) => {
+        if (!(e.buttons & 1)) return;
+        moveDrag(trackEl, trackEl, e.clientX, false);
+      };
+      const onTouchStart = (e: TouchEvent) => {
+        if (e.touches.length !== 1) return;
+        startDrag(trackEl, trackEl, e.touches[0].clientX, false);
+        e.preventDefault();
+      };
+      const onTouchMove = (e: TouchEvent) => {
+        if (e.touches.length !== 1) return;
+        moveDrag(trackEl, trackEl, e.touches[0].clientX, false);
+        e.preventDefault();
+      };
+      const onWheel = (e: WheelEvent) => {
+        e.preventDefault();
+        zoom(trackEl, e.clientX, e.deltaY);
+      };
+
+      trackEl.addEventListener("mousedown", onMouseDown);
+      trackEl.addEventListener("mousemove", onMouseMove);
+      trackEl.addEventListener("mouseup", endDrag);
+      trackEl.addEventListener("mouseleave", endDrag);
+      trackEl.addEventListener("touchstart", onTouchStart, { passive: false });
+      trackEl.addEventListener("touchmove", onTouchMove, { passive: false });
+      trackEl.addEventListener("touchend", endDrag);
+      trackEl.addEventListener("touchcancel", endDrag);
+      trackEl.addEventListener("wheel", onWheel, { passive: false });
+
+      return () => {
+        trackEl.removeEventListener("mousedown", onMouseDown);
+        trackEl.removeEventListener("mousemove", onMouseMove);
+        trackEl.removeEventListener("mouseup", endDrag);
+        trackEl.removeEventListener("mouseleave", endDrag);
+        trackEl.removeEventListener("touchstart", onTouchStart);
+        trackEl.removeEventListener("touchmove", onTouchMove);
+        trackEl.removeEventListener("touchend", endDrag);
+        trackEl.removeEventListener("touchcancel", endDrag);
+        trackEl.removeEventListener("wheel", onWheel);
+      };
+    };
+
+    return { setUpExploreListeners };
+  }, [rangeRef, setSelectedMs, setVisibleRange]);
+}

--- a/src/features/Replay/useExplorableChart.ts
+++ b/src/features/Replay/useExplorableChart.ts
@@ -1,6 +1,11 @@
 import { useCallback, useMemo, useRef, type RefObject } from "react";
+import { clamp } from "lodash";
 import type { TsRange } from "../WebGl/webglUtils";
-import { MIN_VISIBLE_MS, type ExplorableChartProps } from "./const";
+import {
+  MIN_VISIBLE_MS,
+  type ExplorableChartProps,
+  type MiniMapSetupProps,
+} from "./const";
 
 const PAN_THRESHOLD_PX = 0;
 const ZOOM_INTENSITY = 0.002;
@@ -42,7 +47,10 @@ export function useExplorableChart({
   rangeRef,
   setSelectedMs,
   setVisibleRange,
-}: UseExplorableChartProps): ExplorableChartProps {
+}: UseExplorableChartProps): {
+  explorableChartProps: ExplorableChartProps;
+  miniMapProps: MiniMapSetupProps;
+} {
   const dragStartRef = useRef<{
     clientX: number;
     ts: number;
@@ -50,6 +58,7 @@ export function useExplorableChart({
     startVisibleRange: TsRange;
   }>();
   const isPanningRef = useRef(false);
+  const resizeEdgeRef = useRef<"start" | "end">();
 
   const createCallbacks = useCallback(
     (
@@ -74,7 +83,9 @@ export function useExplorableChart({
 
         isPanningRef.current = false;
         refreshCursor();
-        setSelectedMs(dragStartRef.current.ts);
+        if (!isWorldTrack) {
+          setSelectedMs(dragStartRef.current.ts);
+        }
       };
 
       const moveDrag = (clientX: number) => {
@@ -185,6 +196,151 @@ export function useExplorableChart({
 
       return () => cleanups.forEach((off) => off());
     };
-    return { setUpExploreListeners };
-  }, [createCallbacks]);
+
+    const setUpMiniMap = (
+      trackEl: HTMLDivElement,
+      visibleRangeEl: HTMLDivElement,
+      leftHandleEl: HTMLDivElement,
+      rightHandleEl: HTMLDivElement,
+    ) => {
+      const refreshCursor = () => {
+        const allEls = [trackEl, visibleRangeEl, leftHandleEl, rightHandleEl];
+        const cursor = resizeEdgeRef.current
+          ? "ew-resize"
+          : isPanningRef.current
+            ? "grabbing"
+            : // fallback to default
+              "";
+        allEls.forEach((el) => (el.style.cursor = cursor));
+      };
+      refreshCursor();
+
+      const {
+        endDrag,
+        onMouseDown,
+        onMouseMove,
+        onTouchStart,
+        onTouchMove,
+        onWheel,
+      } = createCallbacks(trackEl, refreshCursor, true);
+
+      const startResize = (edge: "start" | "end") => {
+        resizeEdgeRef.current = edge;
+        refreshCursor();
+      };
+
+      const moveResize = (clientX: number) => {
+        const edge = resizeEdgeRef.current;
+        if (!edge || !rangeRef.current) return;
+
+        const { worldEndMs } = rangeRef.current;
+        const cursorTs = clamp(
+          clientXToTs(trackEl, clientX, [0, worldEndMs]),
+          0,
+          worldEndMs,
+        );
+        const [start, end] = rangeRef.current.visibleRangeMs;
+
+        if (edge === "start") {
+          setVisibleRange([Math.min(cursorTs, end - MIN_VISIBLE_MS), end]);
+        } else {
+          setVisibleRange([start, Math.max(cursorTs, start + MIN_VISIBLE_MS)]);
+        }
+      };
+
+      const endResize = () => {
+        if (!resizeEdgeRef.current) return;
+        resizeEdgeRef.current = undefined;
+        refreshCursor();
+      };
+
+      const panToPoint = (clientX: number) => {
+        if (!rangeRef.current) return;
+        const { worldEndMs, visibleRangeMs } = rangeRef.current;
+        const cursorTs = clientXToTs(trackEl, clientX, [0, worldEndMs]);
+        const span = visibleRangeMs[1] - visibleRangeMs[0];
+        setVisibleRange([cursorTs - span / 2, cursorTs + span / 2]);
+      };
+
+      const onHandleMouseDown = (edge: "start" | "end") => (e: MouseEvent) => {
+        if (e.button !== 0) return;
+        startResize(edge);
+        e.stopPropagation();
+        e.preventDefault();
+      };
+      const onHandleTouchStart = (edge: "start" | "end") => (e: TouchEvent) => {
+        if (e.touches.length !== 1) return;
+        startResize(edge);
+        e.stopPropagation();
+        e.preventDefault();
+      };
+
+      const cleanups = [
+        addListener(leftHandleEl, "mousedown", onHandleMouseDown("start")),
+        addListener(rightHandleEl, "mousedown", onHandleMouseDown("end")),
+        addListener(leftHandleEl, "touchstart", onHandleTouchStart("start"), {
+          passive: false,
+        }),
+        addListener(rightHandleEl, "touchstart", onHandleTouchStart("end"), {
+          passive: false,
+        }),
+
+        addListener(visibleRangeEl, "mousedown", onMouseDown),
+        addListener(visibleRangeEl, "touchstart", onTouchStart, {
+          passive: false,
+        }),
+        addListener(visibleRangeEl, "click", (e) =>
+          // prevent track click
+          e.stopPropagation(),
+        ),
+        addListener(trackEl, "click", (e) => panToPoint(e.clientX)),
+        addListener(trackEl, "mousemove", (e) => {
+          if (resizeEdgeRef.current) {
+            moveResize(e.clientX);
+          } else {
+            onMouseMove(e);
+          }
+        }),
+        addListener(trackEl, "mouseup", () => {
+          endResize();
+          endDrag();
+        }),
+        addListener(trackEl, "mouseleave", () => {
+          endResize();
+          endDrag();
+        }),
+        addListener(
+          trackEl,
+          "touchmove",
+          (e) => {
+            if (resizeEdgeRef.current) {
+              if (e.touches.length === 1) {
+                moveResize(e.touches[0].clientX);
+                e.preventDefault();
+              }
+            } else {
+              onTouchMove(e);
+            }
+          },
+          { passive: false },
+        ),
+        addListener(trackEl, "touchend", () => {
+          endResize();
+          endDrag();
+        }),
+        addListener(trackEl, "touchcancel", () => {
+          endResize();
+          endDrag();
+        }),
+        addListener(trackEl, "wheel", onWheel, { passive: false }),
+      ];
+
+      return () => cleanups.forEach((off) => off());
+    };
+
+    return {
+      explorableChartProps: { setUpExploreListeners },
+      miniMapProps: { setUpMiniMap },
+    };
+  }, [createCallbacks, rangeRef, setVisibleRange]);
 }

--- a/src/features/Replay/useVisibleRangeSubscribers.ts
+++ b/src/features/Replay/useVisibleRangeSubscribers.ts
@@ -22,14 +22,22 @@ export function useVisibleRangeSubscribers({
   rangeRef,
   selectedMsRef,
 }: UseVisibleRangeSubscribersProps) {
-  const visibleRangeSubscribersRef = useRef<Map<string, RangeChangeHandler>>(
-    new Map(),
-  );
+  const visibleRangeSubscribersRef = useRef<
+    Map<
+      string,
+      {
+        onRangeChange: RangeChangeHandler;
+        onSelectedMsChange?: RangeChangeHandler;
+      }
+    >
+  >(new Map());
 
   return useMemo(() => {
     const broadcastVisibleRangeChange = () => {
       if (!rangeRef.current) return;
-      for (const onRangeChange of visibleRangeSubscribersRef.current.values()) {
+      for (const {
+        onRangeChange,
+      } of visibleRangeSubscribersRef.current.values()) {
         onRangeChange(
           rangeRef.current.visibleRangeMs,
           [0, rangeRef.current.worldEndMs],
@@ -38,20 +46,33 @@ export function useVisibleRangeSubscribers({
       }
     };
 
+    const broadcastSelectedMsChange = () => {
+      if (!rangeRef.current) return;
+      for (const {
+        onSelectedMsChange,
+      } of visibleRangeSubscribersRef.current.values()) {
+        onSelectedMsChange?.(
+          rangeRef.current.visibleRangeMs,
+          [0, rangeRef.current.worldEndMs],
+          selectedMsRef.current,
+        );
+      }
+    };
+
     const subscribeRangeChange: RangeChangeSubscriberProps["subscribeRangeChange"] =
-      (chartId, onRangeChange) => {
-        visibleRangeSubscribersRef.current.set(chartId, onRangeChange);
+      (chartId, onRangeChange, onSelectedMsChange) => {
+        visibleRangeSubscribersRef.current.set(chartId, {
+          onRangeChange,
+          onSelectedMsChange,
+        });
         if (!rangeRef.current) return;
         onRangeChange(
           rangeRef.current.visibleRangeMs,
           [0, rangeRef.current.worldEndMs],
           selectedMsRef.current,
         );
-      };
 
-    const unsubscribeRangeChange: RangeChangeSubscriberProps["unsubscribeRangeChange"] =
-      (chartId) => {
-        visibleRangeSubscribersRef.current.delete(chartId);
+        return () => visibleRangeSubscribersRef.current.delete(chartId);
       };
 
     const getAbsoluteNs = (relativeMs: number) => {
@@ -66,13 +87,13 @@ export function useVisibleRangeSubscribers({
 
     const visibleRangeSubscriberProps: RangeChangeSubscriberProps = {
       subscribeRangeChange,
-      unsubscribeRangeChange,
       getAbsoluteNs,
       getRelativeMs,
     };
 
     return {
       broadcastVisibleRangeChange,
+      broadcastSelectedMsChange,
       visibleRangeSubscriberProps,
     };
   }, [rangeRef, selectedMsRef]);

--- a/src/features/Replay/useVisibleRangeSubscribers.ts
+++ b/src/features/Replay/useVisibleRangeSubscribers.ts
@@ -1,0 +1,79 @@
+import { useMemo, useRef, type MutableRefObject, type RefObject } from "react";
+import type { TsRange } from "../WebGl/webglUtils";
+import {
+  type RangeChangeHandler,
+  type RangeChangeSubscriberProps,
+} from "./const";
+import { calcAbsoluteNs, calcRelativeMs } from "./utils";
+
+interface UseVisibleRangeSubscribersProps {
+  rangeRef: RefObject<
+    | {
+        referenceNs: bigint;
+        worldEndMs: number;
+        visibleRangeMs: TsRange;
+      }
+    | undefined
+  >;
+  selectedMsRef: MutableRefObject<number | undefined>;
+}
+
+export function useVisibleRangeSubscribers({
+  rangeRef,
+  selectedMsRef,
+}: UseVisibleRangeSubscribersProps) {
+  const visibleRangeSubscribersRef = useRef<Map<string, RangeChangeHandler>>(
+    new Map(),
+  );
+
+  return useMemo(() => {
+    const broadcastVisibleRangeChange = () => {
+      if (!rangeRef.current) return;
+      for (const onRangeChange of visibleRangeSubscribersRef.current.values()) {
+        onRangeChange(
+          rangeRef.current.visibleRangeMs,
+          [0, rangeRef.current.worldEndMs],
+          selectedMsRef.current,
+        );
+      }
+    };
+
+    const subscribeRangeChange: RangeChangeSubscriberProps["subscribeRangeChange"] =
+      (chartId, onRangeChange) => {
+        visibleRangeSubscribersRef.current.set(chartId, onRangeChange);
+        if (!rangeRef.current) return;
+        onRangeChange(
+          rangeRef.current.visibleRangeMs,
+          [0, rangeRef.current.worldEndMs],
+          selectedMsRef.current,
+        );
+      };
+
+    const unsubscribeRangeChange: RangeChangeSubscriberProps["unsubscribeRangeChange"] =
+      (chartId) => {
+        visibleRangeSubscribersRef.current.delete(chartId);
+      };
+
+    const getAbsoluteNs = (relativeMs: number) => {
+      if (!rangeRef.current) return 0n;
+      return calcAbsoluteNs(rangeRef.current.referenceNs, relativeMs);
+    };
+
+    const getRelativeMs = (absoluteNs: bigint) => {
+      if (!rangeRef.current) return 0;
+      return calcRelativeMs(rangeRef.current.referenceNs, absoluteNs);
+    };
+
+    const visibleRangeSubscriberProps: RangeChangeSubscriberProps = {
+      subscribeRangeChange,
+      unsubscribeRangeChange,
+      getAbsoluteNs,
+      getRelativeMs,
+    };
+
+    return {
+      broadcastVisibleRangeChange,
+      visibleRangeSubscriberProps,
+    };
+  }, [rangeRef, selectedMsRef]);
+}

--- a/src/features/Replay/useVisibleRangeSubscribers.ts
+++ b/src/features/Replay/useVisibleRangeSubscribers.ts
@@ -26,8 +26,9 @@ export function useVisibleRangeSubscribers({
     Map<
       string,
       {
-        onRangeChange: RangeChangeHandler;
+        onVisibleRangeChange: RangeChangeHandler;
         onSelectedMsChange?: RangeChangeHandler;
+        onWorldRangeChange?: RangeChangeHandler;
       }
     >
   >(new Map());
@@ -36,9 +37,9 @@ export function useVisibleRangeSubscribers({
     const broadcastVisibleRangeChange = () => {
       if (!rangeRef.current) return;
       for (const {
-        onRangeChange,
+        onVisibleRangeChange,
       } of visibleRangeSubscribersRef.current.values()) {
-        onRangeChange(
+        onVisibleRangeChange(
           rangeRef.current.visibleRangeMs,
           [0, rangeRef.current.worldEndMs],
           selectedMsRef.current,
@@ -59,14 +60,33 @@ export function useVisibleRangeSubscribers({
       }
     };
 
+    const broadcastWorldRangeChange = () => {
+      if (!rangeRef.current) return;
+      for (const {
+        onWorldRangeChange,
+      } of visibleRangeSubscribersRef.current.values()) {
+        onWorldRangeChange?.(
+          rangeRef.current.visibleRangeMs,
+          [0, rangeRef.current.worldEndMs],
+          selectedMsRef.current,
+        );
+      }
+    };
+
     const subscribeRangeChange: RangeChangeSubscriberProps["subscribeRangeChange"] =
-      (chartId, onRangeChange, onSelectedMsChange) => {
+      (
+        chartId,
+        onVisibleRangeChange,
+        onSelectedMsChange,
+        onWorldRangeChange,
+      ) => {
         visibleRangeSubscribersRef.current.set(chartId, {
-          onRangeChange,
+          onVisibleRangeChange,
           onSelectedMsChange,
+          onWorldRangeChange,
         });
         if (!rangeRef.current) return;
-        onRangeChange(
+        onVisibleRangeChange(
           rangeRef.current.visibleRangeMs,
           [0, rangeRef.current.worldEndMs],
           selectedMsRef.current,
@@ -94,6 +114,7 @@ export function useVisibleRangeSubscribers({
     return {
       broadcastVisibleRangeChange,
       broadcastSelectedMsChange,
+      broadcastWorldRangeChange,
       visibleRangeSubscriberProps,
     };
   }, [rangeRef, selectedMsRef]);

--- a/src/features/Replay/utils.ts
+++ b/src/features/Replay/utils.ts
@@ -1,0 +1,33 @@
+import { nsPerMs } from "../../consts.ts";
+import { DEFAULT_WINDOW_MS } from "./const.ts";
+import { clamp } from "../../uplotReact/utils.ts";
+import type { TsRange } from "../WebGl/webglUtils.ts";
+import { convertToNsTimestamp } from "../../mathUtils.ts";
+
+export function getInitVisibleRange(
+  selectedMs: number | undefined,
+  worldEndMs: number,
+): TsRange {
+  if (selectedMs == null) {
+    // show right most data
+    return [Math.max(0, worldEndMs - DEFAULT_WINDOW_MS), worldEndMs];
+  }
+
+  // try to center around selected ts
+  return clamp(
+    DEFAULT_WINDOW_MS,
+    selectedMs - DEFAULT_WINDOW_MS / 2,
+    selectedMs + DEFAULT_WINDOW_MS / 2,
+    worldEndMs,
+    0,
+    worldEndMs,
+  );
+}
+
+export function calcRelativeMs(referenceNs: bigint, valueNs: bigint) {
+  return Number(valueNs - referenceNs) / nsPerMs;
+}
+
+export function calcAbsoluteNs(referenceNs: bigint, relativeMs: number) {
+  return referenceNs + convertToNsTimestamp(relativeMs);
+}

--- a/src/features/Replay/utils.ts
+++ b/src/features/Replay/utils.ts
@@ -3,6 +3,8 @@ import { DEFAULT_WINDOW_MS } from "./const.ts";
 import { clamp } from "../../uplotReact/utils.ts";
 import type { TsRange } from "../WebGl/webglUtils.ts";
 import { convertToNsTimestamp } from "../../mathUtils.ts";
+import { useServerMessages } from "../../api/ws/utils.ts";
+import type { WsEntity } from "../../api/worker/types.ts";
 
 export function getInitVisibleRange(
   selectedMs: number | undefined,
@@ -30,4 +32,33 @@ export function calcRelativeMs(referenceNs: bigint, valueNs: bigint) {
 
 export function calcAbsoluteNs(referenceNs: bigint, relativeMs: number) {
   return referenceNs + convertToNsTimestamp(relativeMs);
+}
+
+type TimelineEntityForKey<TKey extends string> = Extract<
+  WsEntity,
+  { topic: "timeline"; key: TKey }
+>;
+
+function isTimelineKey<TKey extends string>(
+  message: WsEntity,
+  key: TKey,
+): message is TimelineEntityForKey<TKey> {
+  return message.topic === "timeline" && message.key === key;
+}
+
+export function useTimelineServerMessage<TKey extends string>(
+  key: TKey,
+  onMessage: (message: TimelineEntityForKey<TKey>) => void,
+) {
+  useServerMessages((message) => {
+    if (message.type === "kv" && isTimelineKey(message, key)) {
+      onMessage(message);
+    } else if (message.type === "kvb") {
+      for (const item of message.items) {
+        if (isTimelineKey(item, key)) {
+          onMessage(item);
+        }
+      }
+    }
+  });
 }

--- a/src/features/WebGl/webglUtils.ts
+++ b/src/features/WebGl/webglUtils.ts
@@ -8,7 +8,7 @@ export type TsRange = [startTs: number, endTs: number];
 export type NsTsRange = [startTs: bigint, endTs: bigint];
 export type RgbColor = [r: number, g: number, b: number];
 
-export type SlotMesh = {
+export type RectMesh = {
   mesh: THREE.Mesh;
   rectArray: Float32Array;
   colorArray: Float32Array;
@@ -148,7 +148,7 @@ const INITIAL_CAPACITY = 700 * (SHRED_EVENT_TYPES_COUNT - 1);
 /**
  * Create a mesh to draw 2D rectangles
  */
-export function createRectMesh(resources: WebglResources): SlotMesh {
+export function createRectMesh(resources: WebglResources): RectMesh {
   const rectArray = new Float32Array(INITIAL_CAPACITY * 4);
   const colorArray = new Float32Array(INITIAL_CAPACITY * 3);
 
@@ -187,28 +187,28 @@ export function createRectMesh(resources: WebglResources): SlotMesh {
 /**
  * Bump up capacity for slot as needed
  */
-export function ensureCapacity(slotMesh: SlotMesh, needed: number) {
-  if (needed <= slotMesh.capacity) return;
+export function ensureCapacity(rectMesh: RectMesh, needed: number) {
+  if (needed <= rectMesh.capacity) return;
 
-  let newCapacity = slotMesh.capacity || INITIAL_CAPACITY;
+  let newCapacity = rectMesh.capacity || INITIAL_CAPACITY;
   while (newCapacity < needed) newCapacity *= 2;
 
   const rectArray = new Float32Array(newCapacity * 4);
   const colorArray = new Float32Array(newCapacity * 3);
-  rectArray.set(slotMesh.rectArray);
-  colorArray.set(slotMesh.colorArray);
+  rectArray.set(rectMesh.rectArray);
+  colorArray.set(rectMesh.colorArray);
 
-  slotMesh.rectArray = rectArray;
-  slotMesh.colorArray = colorArray;
-  slotMesh.rectAttr = new THREE.InstancedBufferAttribute(rectArray, 4);
-  slotMesh.colorAttr = new THREE.InstancedBufferAttribute(colorArray, 3);
-  slotMesh.rectAttr.setUsage(THREE.DynamicDrawUsage);
-  slotMesh.colorAttr.setUsage(THREE.DynamicDrawUsage);
-  slotMesh.capacity = newCapacity;
+  rectMesh.rectArray = rectArray;
+  rectMesh.colorArray = colorArray;
+  rectMesh.rectAttr = new THREE.InstancedBufferAttribute(rectArray, 4);
+  rectMesh.colorAttr = new THREE.InstancedBufferAttribute(colorArray, 3);
+  rectMesh.rectAttr.setUsage(THREE.DynamicDrawUsage);
+  rectMesh.colorAttr.setUsage(THREE.DynamicDrawUsage);
+  rectMesh.capacity = newCapacity;
 
-  const geometry = slotMesh.mesh.geometry as THREE.InstancedBufferGeometry;
-  geometry.setAttribute("instanceRect", slotMesh.rectAttr);
-  geometry.setAttribute("instanceColor", slotMesh.colorAttr);
+  const geometry = rectMesh.mesh.geometry as THREE.InstancedBufferGeometry;
+  geometry.setAttribute("instanceRect", rectMesh.rectAttr);
+  geometry.setAttribute("instanceColor", rectMesh.colorAttr);
   // clear private field _maxInstanceCount for recomputation,
   // instead of allocating a new geometry
   // @ts-expect-error
@@ -216,7 +216,7 @@ export function ensureCapacity(slotMesh: SlotMesh, needed: number) {
 }
 
 export function addRectangleToMesh(
-  slotMesh: SlotMesh,
+  rectMesh: RectMesh,
   rectangleIdx: number,
   x: number,
   y: number,
@@ -225,23 +225,23 @@ export function addRectangleToMesh(
   color: RgbColor,
 ) {
   const ri = rectangleIdx * 4;
-  slotMesh.rectArray[ri] = x;
-  slotMesh.rectArray[ri + 1] = y;
-  slotMesh.rectArray[ri + 2] = w;
-  slotMesh.rectArray[ri + 3] = h;
+  rectMesh.rectArray[ri] = x;
+  rectMesh.rectArray[ri + 1] = y;
+  rectMesh.rectArray[ri + 2] = w;
+  rectMesh.rectArray[ri + 3] = h;
 
   const ci = rectangleIdx * 3;
-  slotMesh.colorArray[ci] = color[0];
-  slotMesh.colorArray[ci + 1] = color[1];
-  slotMesh.colorArray[ci + 2] = color[2];
+  rectMesh.colorArray[ci] = color[0];
+  rectMesh.colorArray[ci + 1] = color[1];
+  rectMesh.colorArray[ci + 2] = color[2];
 }
 
-export function updateSlotMeshCounts(slotMesh: SlotMesh, count: number) {
-  slotMesh.count = count;
-  (slotMesh.mesh.geometry as THREE.InstancedBufferGeometry).instanceCount =
+export function updateRectMeshCounts(rectMesh: RectMesh, count: number) {
+  rectMesh.count = count;
+  (rectMesh.mesh.geometry as THREE.InstancedBufferGeometry).instanceCount =
     count;
-  slotMesh.rectAttr.needsUpdate = true;
-  slotMesh.colorAttr.needsUpdate = true;
+  rectMesh.rectAttr.needsUpdate = true;
+  rectMesh.colorAttr.needsUpdate = true;
 }
 
 const tmpColor = new THREE.Color();

--- a/src/features/WebGl/webglUtils.ts
+++ b/src/features/WebGl/webglUtils.ts
@@ -1,7 +1,12 @@
 import * as THREE from "three";
 import { SHRED_EVENT_TYPES_COUNT } from "../../api/entities";
+import type { ContextHelpers } from "./useWebGlEventHandlers";
+import { isWebgl2SupportedAtom } from "./atoms";
+import { getDefaultStore } from "jotai";
 
-const SHREDS_OPACITY = 0.8;
+export type TsRange = [startTs: number, endTs: number];
+export type NsTsRange = [startTs: bigint, endTs: bigint];
+export type RgbColor = [r: number, g: number, b: number];
 
 export type SlotMesh = {
   mesh: THREE.Mesh;
@@ -11,6 +16,8 @@ export type SlotMesh = {
   colorAttr: THREE.InstancedBufferAttribute;
   capacity: number;
   count: number;
+  /** optionally store mesh positions relative to referenceX. This allows GPU to see small coordinates */
+  referenceX: number | undefined;
 };
 
 const vertexShader = /* glsl */ `
@@ -41,6 +48,52 @@ void main() {
 }
 `;
 
+const store = getDefaultStore();
+
+export function createRenderer(
+  canvasWidth: number,
+  canvasHeight: number,
+  maxWebGlPixelRatio: number,
+  setUpContextListeners: ContextHelpers["setUpContextListeners"],
+  getWasContextLost: ContextHelpers["getWasContextLost"],
+) {
+  try {
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(
+      Math.min(window.devicePixelRatio, maxWebGlPixelRatio),
+    );
+    renderer.setSize(canvasWidth, canvasHeight);
+    renderer.setClearColor(0x000000, 0);
+
+    const clearContextListeners = setUpContextListeners(renderer.domElement);
+    const cleanUpRenderer = () => {
+      // If context was lost at some point, its GPU objects are already gone so skip objects disposal,
+      // to prevent warnings e.g. WebGL: INVALID_OPERATION: delete: object does not belong to this context
+      // Three doesn't restore GPU objects for restored contexts unless there's a render.
+      // Remount on restore to reset the context listeners state
+      if (!getWasContextLost()) {
+        renderer.dispose();
+      }
+
+      // release currently live context (may be the restored one)
+      // make sure context listeners are removed beforehand
+      clearContextListeners();
+      if (!renderer.getContext().isContextLost()) {
+        renderer.forceContextLoss();
+      }
+    };
+
+    return {
+      renderer,
+      cleanUpRenderer,
+    };
+  } catch {
+    // context creation can still fail despite the probe (e.g. too many live
+    // contexts, driver crash). Mark as unsupported to trigger fallback to canvas chart
+    store.set(isWebgl2SupportedAtom, false);
+  }
+}
+
 /**
  * Resources shared by all slot meshes of a single chart / renderer.
  * Compiled shaders / uploaded buffers are bound to a specific GL
@@ -65,22 +118,22 @@ function createUnitQuad() {
   return geometry;
 }
 
-function createSharedMaterial() {
+function createSharedMaterial(opacity: number) {
   return new THREE.RawShaderMaterial({
     vertexShader,
     fragmentShader,
     side: THREE.FrontSide,
     transparent: true,
     uniforms: {
-      uOpacity: { value: SHREDS_OPACITY },
+      uOpacity: { value: opacity },
     },
   });
 }
 
-export function createWebglResources(): WebglResources {
+export function createWebglResources(opacity: number): WebglResources {
   return {
     unitQuad: createUnitQuad(),
-    sharedMaterial: createSharedMaterial(),
+    sharedMaterial: createSharedMaterial(opacity),
   };
 }
 
@@ -128,6 +181,7 @@ export function createSlotMesh(resources: WebglResources): SlotMesh {
     colorAttr,
     capacity: INITIAL_CAPACITY,
     count: 0,
+    referenceX: undefined,
   };
 }
 
@@ -169,7 +223,7 @@ export function addRectangleToMesh(
   y: number,
   w: number,
   h: number,
-  color: [r: number, g: number, b: number],
+  color: RgbColor,
 ) {
   const ri = rectangleIdx * 4;
   slotMesh.rectArray[ri] = x;
@@ -198,9 +252,7 @@ const tmpRgb = { r: 0, g: 0, b: 0 };
  * Convert hex color to sRGB values for the shader, instead of
  * Three.js's default linear working color space
  */
-export function convertToWebGlColor(
-  hex: string,
-): [r: number, g: number, b: number] {
+export function convertToWebGlColor(hex: string): RgbColor {
   tmpColor.setHex(parseInt(hex.replace("#", ""), 16), THREE.SRGBColorSpace);
   tmpColor.getRGB(tmpRgb, THREE.SRGBColorSpace);
   return [tmpRgb.r, tmpRgb.g, tmpRgb.b];

--- a/src/features/WebGl/webglUtils.ts
+++ b/src/features/WebGl/webglUtils.ts
@@ -95,7 +95,7 @@ export function createRenderer(
 }
 
 /**
- * Resources shared by all slot meshes of a single chart / renderer.
+ * Resources shared by all rect meshes of a single chart / renderer.
  * Compiled shaders / uploaded buffers are bound to a specific GL
  * context, so a fresh renderer (e.g. after a context loss) needs its own copy.
  */
@@ -148,9 +148,12 @@ const INITIAL_CAPACITY = 700 * (SHRED_EVENT_TYPES_COUNT - 1);
 /**
  * Create a mesh to draw 2D rectangles
  */
-export function createRectMesh(resources: WebglResources): RectMesh {
-  const rectArray = new Float32Array(INITIAL_CAPACITY * 4);
-  const colorArray = new Float32Array(INITIAL_CAPACITY * 3);
+export function createRectMesh(
+  resources: WebglResources,
+  initialCapacity = INITIAL_CAPACITY,
+): RectMesh {
+  const rectArray = new Float32Array(initialCapacity * 4);
+  const colorArray = new Float32Array(initialCapacity * 3);
 
   const rectAttr = new THREE.InstancedBufferAttribute(rectArray, 4);
   const colorAttr = new THREE.InstancedBufferAttribute(colorArray, 3);
@@ -185,7 +188,7 @@ export function createRectMesh(resources: WebglResources): RectMesh {
 }
 
 /**
- * Bump up capacity for slot as needed
+ * Bump up capacity for rectangles as needed
  */
 export function ensureCapacity(rectMesh: RectMesh, needed: number) {
   if (needed <= rectMesh.capacity) return;
@@ -241,6 +244,27 @@ export function updateRectMeshCounts(rectMesh: RectMesh, count: number) {
   (rectMesh.mesh.geometry as THREE.InstancedBufferGeometry).instanceCount =
     count;
   rectMesh.rectAttr.needsUpdate = true;
+  rectMesh.colorAttr.needsUpdate = true;
+}
+
+/**
+ * Mark a specific range as updated
+ */
+export function updateMeshRange(
+  rectMesh: RectMesh,
+  idxRange: [number, number],
+) {
+  const startIdx = idxRange[0];
+  const endIdx = Math.min(rectMesh.count - 1, idxRange[1]);
+  const instanceCount = endIdx - startIdx + 1;
+  if (instanceCount <= 0) return;
+
+  rectMesh.rectAttr.clearUpdateRanges();
+  rectMesh.rectAttr.addUpdateRange(startIdx * 4, instanceCount * 4);
+  rectMesh.rectAttr.needsUpdate = true;
+
+  rectMesh.colorAttr.clearUpdateRanges();
+  rectMesh.colorAttr.addUpdateRange(startIdx * 3, instanceCount * 3);
   rectMesh.colorAttr.needsUpdate = true;
 }
 

--- a/src/features/WebGl/webglUtils.ts
+++ b/src/features/WebGl/webglUtils.ts
@@ -146,10 +146,9 @@ export function disposeWebglResources(resources: WebglResources) {
 const INITIAL_CAPACITY = 700 * (SHRED_EVENT_TYPES_COUNT - 1);
 
 /**
- * Create one mesh per slot. That way, we can easily add / delete slots without updating
- * unchanged slots.
+ * Create a mesh to draw 2D rectangles
  */
-export function createSlotMesh(resources: WebglResources): SlotMesh {
+export function createRectMesh(resources: WebglResources): SlotMesh {
   const rectArray = new Float32Array(INITIAL_CAPACITY * 4);
   const colorArray = new Float32Array(INITIAL_CAPACITY * 3);
 

--- a/src/hooks/useCurrentRoute.ts
+++ b/src/hooks/useCurrentRoute.ts
@@ -6,13 +6,15 @@ export type RouteLabel =
   | "Schedule"
   | "Gossip"
   | "Slot Details"
-  | "Accounts";
+  | "Accounts"
+  | "Replay";
 export const RouteLabelToPath: Record<RouteLabel, string> = {
   Overview: "/",
   "Slot Details": "/slotDetails",
   Schedule: "/leaderSchedule",
   Gossip: "/gossip",
   Accounts: "/accounts",
+  Replay: "/replay",
 };
 
 export function useCurrentRoute() {

--- a/src/hooks/useSlotsNavigation.ts
+++ b/src/hooks/useSlotsNavigation.ts
@@ -7,17 +7,22 @@ import { useMedia } from "react-use";
 export function useSlotsNavigation() {
   const isNarrowScreen = useMedia(narrowNavMedia);
   const [isNavCollapsed, setIsNavCollapsed] = useAtom(_isNavCollapsedAtom);
-  const isLeaderSchedule = useCurrentRoute() === "Schedule";
+  const currentRoute = useCurrentRoute();
 
-  const showNav = isLeaderSchedule || !isNavCollapsed;
-  const showOnlyEpochBar = isLeaderSchedule;
+  const noNav = currentRoute === "Replay";
+  const showOnlyEpochBar = currentRoute === "Schedule";
+
+  const showNav = !noNav && (showOnlyEpochBar || !isNavCollapsed);
 
   return {
+    noNav,
     isNarrowScreen,
     showNav,
     setIsNavCollapsed,
     showOnlyEpochBar,
-    blurBackground: isNarrowScreen && !isNavCollapsed && !showOnlyEpochBar,
-    occupyRowWidth: showOnlyEpochBar || (!isNarrowScreen && !isNavCollapsed),
+    blurBackground:
+      !noNav && isNarrowScreen && !isNavCollapsed && !showOnlyEpochBar,
+    occupyRowWidth:
+      !noNav && (showOnlyEpochBar || (!isNarrowScreen && !isNavCollapsed)),
   };
 }

--- a/src/mathUtils.ts
+++ b/src/mathUtils.ts
@@ -1,8 +1,10 @@
 import { clamp } from "lodash";
+import { nsPerMs } from "./consts";
 
 export function logRatio(a: number, b: number, base = Math.E) {
   if (b === 0) return Infinity;
   if (a === 0) return 0;
+
   if (a <= 0 || b <= 0) {
     console.error(a, b);
     console.error("Logarithms are only defined for positive numbers.");
@@ -48,4 +50,14 @@ export function safeDivide(a: number, b: number) {
 export function clampNonZeroValue(value: number, lower: number, upper: number) {
   if (value === 0) return 0;
   return clamp(value, lower, upper);
+}
+
+/**
+ * Convert ms timestamp to ns timestamp while keeping as much
+ * precision as possible
+ */
+export function convertToNsTimestamp(msTimestamp: number): bigint {
+  const wholeMs = Math.trunc(msTimestamp);
+  const fracNs = Math.round((msTimestamp - wholeMs) * nsPerMs);
+  return BigInt(wholeMs) * BigInt(nsPerMs) + BigInt(fracNs);
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SlotDetailsRouteImport } from './routes/slotDetails'
+import { Route as ReplayRouteImport } from './routes/replay'
 import { Route as LeaderScheduleRouteImport } from './routes/leaderSchedule'
 import { Route as GossipRouteImport } from './routes/gossip'
 import { Route as AccountsRouteImport } from './routes/accounts'
@@ -19,6 +20,11 @@ import { Route as IndexRouteImport } from './routes/index'
 const SlotDetailsRoute = SlotDetailsRouteImport.update({
   id: '/slotDetails',
   path: '/slotDetails',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ReplayRoute = ReplayRouteImport.update({
+  id: '/replay',
+  path: '/replay',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LeaderScheduleRoute = LeaderScheduleRouteImport.update({
@@ -53,6 +59,7 @@ export interface FileRoutesByFullPath {
   '/accounts': typeof AccountsRoute
   '/gossip': typeof GossipRoute
   '/leaderSchedule': typeof LeaderScheduleRoute
+  '/replay': typeof ReplayRoute
   '/slotDetails': typeof SlotDetailsRoute
 }
 export interface FileRoutesByTo {
@@ -61,6 +68,7 @@ export interface FileRoutesByTo {
   '/accounts': typeof AccountsRoute
   '/gossip': typeof GossipRoute
   '/leaderSchedule': typeof LeaderScheduleRoute
+  '/replay': typeof ReplayRoute
   '/slotDetails': typeof SlotDetailsRoute
 }
 export interface FileRoutesById {
@@ -70,6 +78,7 @@ export interface FileRoutesById {
   '/accounts': typeof AccountsRoute
   '/gossip': typeof GossipRoute
   '/leaderSchedule': typeof LeaderScheduleRoute
+  '/replay': typeof ReplayRoute
   '/slotDetails': typeof SlotDetailsRoute
 }
 export interface FileRouteTypes {
@@ -80,6 +89,7 @@ export interface FileRouteTypes {
     | '/accounts'
     | '/gossip'
     | '/leaderSchedule'
+    | '/replay'
     | '/slotDetails'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -88,6 +98,7 @@ export interface FileRouteTypes {
     | '/accounts'
     | '/gossip'
     | '/leaderSchedule'
+    | '/replay'
     | '/slotDetails'
   id:
     | '__root__'
@@ -96,6 +107,7 @@ export interface FileRouteTypes {
     | '/accounts'
     | '/gossip'
     | '/leaderSchedule'
+    | '/replay'
     | '/slotDetails'
   fileRoutesById: FileRoutesById
 }
@@ -105,6 +117,7 @@ export interface RootRouteChildren {
   AccountsRoute: typeof AccountsRoute
   GossipRoute: typeof GossipRoute
   LeaderScheduleRoute: typeof LeaderScheduleRoute
+  ReplayRoute: typeof ReplayRoute
   SlotDetailsRoute: typeof SlotDetailsRoute
 }
 
@@ -115,6 +128,13 @@ declare module '@tanstack/react-router' {
       path: '/slotDetails'
       fullPath: '/slotDetails'
       preLoaderRoute: typeof SlotDetailsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/replay': {
+      id: '/replay'
+      path: '/replay'
+      fullPath: '/replay'
+      preLoaderRoute: typeof ReplayRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/leaderSchedule': {
@@ -161,6 +181,7 @@ const rootRouteChildren: RootRouteChildren = {
   AccountsRoute: AccountsRoute,
   GossipRoute: GossipRoute,
   LeaderScheduleRoute: LeaderScheduleRoute,
+  ReplayRoute: ReplayRoute,
   SlotDetailsRoute: SlotDetailsRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -69,7 +69,7 @@ function Root() {
 
 function OutletContainer() {
   const isSchedule = useCurrentRoute() === "Schedule";
-  const { setIsNavCollapsed, isNarrowScreen, occupyRowWidth, blurBackground } =
+  const { setIsNavCollapsed, isNarrowScreen, occupyRowWidth } =
     useSlotsNavigation();
 
   useEffect(() => {
@@ -90,7 +90,7 @@ function OutletContainer() {
       }
     >
       <Outlet />
-      {blurBackground && <NavBlur />}
+      <NavBlur />
     </Box>
   );
 }

--- a/src/routes/replay.tsx
+++ b/src/routes/replay.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import Replay from "../features/Replay";
+
+export const Route = createFileRoute("/replay")({
+  component: Replay,
+});


### PR DESCRIPTION
- add a hook that queries data as tiles (fixed size time windows) and keeps track of fetched / pending tiles to reduce re-fetching
- convert agg fees to store bucketed data for each granularity